### PR TITLE
refactor(dev-team): rename dev-analysis skill to dev-refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ ring/                                  # Monorepo root
 ├── dev-team/                      # Developer Agents plugin (ring-dev-team)
 │   ├── skills/                    # 10 developer skills
 │   │   ├── using-dev-team/        # Plugin introduction
-│   │   ├── dev-analysis/          # Codebase analysis against standards
+│   │   ├── dev-refactor/          # Codebase analysis against standards
 │   │   ├── dev-cycle/             # 6-gate development workflow orchestrator
 │   │   ├── dev-devops/            # Gate 1: DevOps setup (Docker, compose)
 │   │   ├── dev-feedback-loop/     # Assertiveness scoring and metrics
@@ -410,7 +410,7 @@ output_schema:
       required: true
 ```
 
-**Used by:** All backend engineers (`ring-dev-team:backend-engineer-golang`, `ring-dev-team:backend-engineer-typescript`), all frontend engineers except designer (`ring-dev-team:frontend-engineer-typescript`), `ring-dev-team:devops-engineer`, `ring-dev-team:qa-analyst`, `ring-dev-team:sre`, `ring-finops-team:finops-automation`
+**Used by:** `ring-dev-team:backend-engineer-golang`, `ring-dev-team:backend-engineer-typescript`, `ring-dev-team:frontend-engineer-typescript`, `ring-dev-team:devops-engineer`, `ring-dev-team:qa-analyst`, `ring-dev-team:sre`, `ring-finops-team:finops-automation`
 
 **Analysis Schema** (for agents that analyze and recommend):
 ```yaml

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ No "should work" → Only "does work" with proof
 
 **Code Development:**
 - `ring-dev-team:using-dev-team` - Introduction to developer specialist agents
-- `ring-dev-team:dev-analysis` - Codebase analysis against standards
+- `ring-dev-team:dev-refactor` - Codebase analysis against standards
 - `ring-dev-team:dev-cycle` - 6-gate development workflow orchestrator
 
 **6-Gate Workflow Skills:**

--- a/dev-team/commands/dev-refactor.md
+++ b/dev-team/commands/dev-refactor.md
@@ -140,6 +140,6 @@ Analyze existing codebase against standards and execute refactoring through dev-
 
 ---
 
-Now loading the `ring-dev-team:dev-analysis` skill to analyze your codebase...
+Now loading the `ring-dev-team:dev-refactor` skill to analyze your codebase...
 
-Use skill: `ring-dev-team:dev-analysis`
+Use skill: `ring-dev-team:dev-refactor`

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dev-analysis
+name: dev-refactor
 description: |
   Analyzes existing codebase against standards to identify gaps in architecture, code quality,
   testing, and DevOps. Auto-detects project language and uses appropriate agent standards
@@ -24,7 +24,7 @@ related:
   complementary: [ring-dev-team:dev-cycle, ring-dev-team:dev-implementation]
 ---
 
-# Dev Analysis Skill
+# Dev Refactor Skill
 
 This skill analyzes an existing codebase to identify gaps between current implementation and project standards, then generates a structured refactoring plan compatible with the dev-cycle workflow.
 

--- a/dev-team/skills/using-dev-team/SKILL.md
+++ b/dev-team/skills/using-dev-team/SKILL.md
@@ -349,7 +349,7 @@ Remember:
 **Skills:**
 - ring-dev-team:using-dev-team: Plugin introduction and agent selection guide
 - ring-dev-team:dev-cycle: 6-gate development workflow (Implementation → DevOps → SRE → Testing → Review → Validation)
-- ring-dev-team:dev-analysis: Analyze codebase against PROJECT_RULES.md, generate refactoring tasks
+- ring-dev-team:dev-refactor: Analyze codebase against PROJECT_RULES.md, generate refactoring tasks
 
 **Commands:**
 - `/ring-dev-team:dev-cycle` – Execute development cycle for tasks
@@ -394,7 +394,7 @@ The dev-team plugin provides three unified workflows that all use the same 6-gat
         │
         ▼
 ┌─────────────────────────────┐
-│      dev-analysis           │
+│      dev-refactor           │
 │                             │
 │  • Scan codebase            │
 │  • Compare vs PROJECT_RULES.md  │


### PR DESCRIPTION
Aligns skill name with command name for consistency. The /ring-dev-team:dev-refactor command now uses the ring-dev-team:dev-refactor skill instead of dev-analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed the Developer Skill from "Dev Analysis" to "Dev Refactor" across all skill identifiers, commands, and documentation. Updated usage examples and workflow descriptions to reflect the new naming convention while maintaining existing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->