### PR TITLE
feat(dev-team): add Standards Loading section to agents with WebFetch…

### DIFF
--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -185,17 +185,26 @@ Invoke this agent when the task involves:
 - **Patterns**: Hexagonal Architecture, CQRS, Repository, DDD, Multi-Tenancy
 - **Serverless**: AWS Lambda, API Gateway, Step Functions, SAM
 
-## Project Standards Integration
+## Standards Loading (MANDATORY)
 
-**IMPORTANT:** Before implementing, check if `docs/PROJECT_RULES.md` exists in the project.
+**Before ANY implementation, load BOTH sources:**
 
-This file contains:
-- **Methodologies enabled**: DDD, TDD, Clean Architecture
-- **Implementation patterns**: Code examples for each pattern
-- **Naming conventions**: How to name entities, repositories, tests
-- **Directory structure**: Where to place domain, infrastructure, tests
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.
 
-**→ See `docs/PROJECT_RULES.md` for implementation patterns and code examples.**
+### Step 2: Fetch Ring Go Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang.md
+```
+**MANDATORY:** Base technical standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base technical patterns (error handling, testing, architecture)
+- PROJECT_RULES.md = Project tech stack and specific patterns
+- **Both are complementary. Neither excludes the other. Both must be followed.**
 
 ## Domain-Driven Design (DDD)
 

--- a/dev-team/agents/backend-engineer-typescript.md
+++ b/dev-team/agents/backend-engineer-typescript.md
@@ -202,17 +202,26 @@ Invoke this agent when the task involves:
 - **Patterns**: Clean Architecture, Dependency Injection, Repository, CQRS, DDD
 - **Serverless**: AWS Lambda, Vercel Functions, Cloudflare Workers
 
-## Project Standards Integration
+## Standards Loading (MANDATORY)
 
-**IMPORTANT:** Before implementing, check if `docs/PROJECT_RULES.md` exists in the project.
+**Before ANY implementation, load BOTH sources:**
 
-This file contains:
-- **Methodologies enabled**: DDD, TDD, Clean Architecture
-- **Implementation patterns**: Code examples for each pattern
-- **Naming conventions**: How to name entities, repositories, tests
-- **Directory structure**: Where to place domain, infrastructure, tests
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.
 
-**→ See `docs/PROJECT_RULES.md` for implementation patterns and code examples.**
+### Step 2: Fetch Ring TypeScript Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md
+```
+**MANDATORY:** Base technical standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base technical patterns (error handling, testing, architecture)
+- PROJECT_RULES.md = Project tech stack and specific patterns
+- **Both are complementary. Neither excludes the other. Both must be followed.**
 
 ## Domain-Driven Design (DDD)
 

--- a/dev-team/agents/devops-engineer.md
+++ b/dev-team/agents/devops-engineer.md
@@ -226,17 +226,26 @@ Invoke this agent when the task involves:
 - **Scripting**: Bash, Python, Make
 - **Multi-Tenancy**: Namespace isolation, tenant provisioning, resource quotas
 
-## Project Standards Integration
+## Standards Loading (MANDATORY)
 
-**IMPORTANT:** Before implementing, check if `docs/PROJECT_RULES.md` exists in the project.
+**Before ANY implementation, load BOTH sources:**
 
-This file contains:
-- **Methodologies enabled**: GitOps, Infrastructure as Code, CI/CD patterns
-- **Implementation patterns**: Code examples for each pattern
-- **Naming conventions**: How to name resources, environments, pipelines
-- **Directory structure**: Where to place manifests, terraform modules, charts
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.
 
-**→ See `docs/PROJECT_RULES.md` for implementation patterns and code examples.**
+### Step 2: Fetch Ring DevOps Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/devops.md
+```
+**MANDATORY:** Base technical standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base technical patterns (error handling, testing, architecture)
+- PROJECT_RULES.md = Project tech stack and specific patterns
+- **Both are complementary. Neither excludes the other. Both must be followed.**
 
 ## Handling Ambiguous Requirements
 

--- a/dev-team/agents/frontend-engineer-typescript.md
+++ b/dev-team/agents/frontend-engineer-typescript.md
@@ -666,6 +666,27 @@ const ApiErrorSchema = z.discriminatedUnion('type', [
 - **Testing**: Jest + Testing Library with type-safe mocks and fixtures
 - **Build**: TypeScript project references, path aliases, strict mode
 
+## Standards Loading (MANDATORY)
+
+**Before ANY implementation, load BOTH sources:**
+
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.
+
+### Step 2: Fetch Ring Frontend Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/frontend.md
+```
+**MANDATORY:** Base technical standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base technical patterns (error handling, testing, architecture)
+- PROJECT_RULES.md = Project tech stack and specific patterns
+- **Both are complementary. Neither excludes the other. Both must be followed.**
+
 ## Handling Ambiguous Requirements
 
 ### Step 1: Check Project Standards (ALWAYS FIRST)

--- a/dev-team/agents/qa-analyst.md
+++ b/dev-team/agents/qa-analyst.md
@@ -13,24 +13,21 @@ output_schema:
     - name: "Summary"
       pattern: "^## Summary"
       required: true
-    - name: "Test Strategy"
-      pattern: "^## Test Strategy"
+    - name: "Implementation"
+      pattern: "^## Implementation"
       required: true
-    - name: "Test Cases"
-      pattern: "^## Test Cases"
+      description: "Test strategy, cases, and methodology implemented"
+    - name: "Files Changed"
+      pattern: "^## Files Changed"
       required: true
-    - name: "Test Results"
-      pattern: "^## Test Results"
+      description: "Test files created or modified"
+    - name: "Testing"
+      pattern: "^## Testing"
       required: true
-    - name: "Coverage"
-      pattern: "^## Coverage"
-      required: true
+      description: "Test results and coverage metrics"
     - name: "Next Steps"
       pattern: "^## Next Steps"
       required: true
-    - name: "Blockers"
-      pattern: "^## Blockers"
-      required: false
   error_handling:
     on_blocker: "pause_and_report"
     escalation_path: "orchestrator"

--- a/dev-team/agents/sre.md
+++ b/dev-team/agents/sre.md
@@ -154,6 +154,27 @@ Invoke this agent when the task involves:
 - **Incident**: PagerDuty, OpsGenie, Incident.io
 - **SRE Practices**: SLIs, SLOs, Error Budgets, Toil Reduction
 
+## Standards Loading (MANDATORY)
+
+**Before ANY implementation, load BOTH sources:**
+
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.
+
+### Step 2: Fetch Ring SRE Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/sre.md
+```
+**MANDATORY:** Base technical standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base technical patterns (error handling, testing, architecture)
+- PROJECT_RULES.md = Project tech stack and specific patterns
+- **Both are complementary. Neither excludes the other. Both must be followed.**
+
 ## Handling Ambiguous Requirements
 
 ### Step 1: Check Project Standards (ALWAYS FIRST)

--- a/dev-team/skills/dev-feedback-loop/SKILL.md
+++ b/dev-team/skills/dev-feedback-loop/SKILL.md
@@ -93,6 +93,24 @@ If you catch yourself thinking ANY of these, STOP immediately:
 
 **You CANNOT proceed past threshold without documented response.**
 
+## Blocker Criteria - STOP and Report
+
+**ALWAYS pause and report blocker for:**
+
+| Decision Type | Examples | Action |
+|--------------|----------|--------|
+| **Score interpretation** | "Is 65 acceptable?" | STOP. Follow interpretation table. |
+| **Threshold override** | "Skip analysis for this task" | STOP. Analysis is MANDATORY for low scores. |
+| **Pattern judgment** | "Is this pattern significant?" | STOP. Document pattern, let user decide significance. |
+| **Improvement priority** | "Which fix first?" | STOP. Report all findings, let user prioritize. |
+
+**Before skipping ANY feedback collection:**
+1. Check if task is complete (feedback required for ALL completed tasks)
+2. Check threshold status (alerts are mandatory)
+3. If in doubt → STOP and report blocker
+
+**You CANNOT skip feedback collection. Period.**
+
 ## Assertiveness Score Calculation
 
 Base score of 100 points, with deductions for inefficiencies:

--- a/dev-team/skills/using-dev-team/SKILL.md
+++ b/dev-team/skills/using-dev-team/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: using-dev-team
 description: |
-  9 specialist developer agents for backend (Go/TypeScript), DevOps, frontend,
+  7 specialist developer agents for backend (Go/TypeScript), DevOps, frontend,
   design, QA, and SRE. Dispatch when you need deep technology expertise.
 
 trigger: |
@@ -22,7 +22,7 @@ related:
 
 # Using Ring Developer Specialists
 
-The ring-dev-team plugin provides 9 specialized developer agents. Use them via `Task tool with subagent_type:`.
+The ring-dev-team plugin provides 7 specialized developer agents. Use them via `Task tool with subagent_type:`.
 
 **Remember:** Follow the **ORCHESTRATOR principle** from `ring-default:using-ring`. Dispatch agents to handle complexity; don't operate tools directly.
 
@@ -336,11 +336,9 @@ Remember:
 ## Available in This Plugin
 
 **Agents:**
-- backend-engineer (language-agnostic)
 - backend-engineer-golang
 - backend-engineer-typescript
 - devops-engineer
-- frontend-engineer
 - frontend-engineer-typescript
 - frontend-designer
 - qa-analyst


### PR DESCRIPTION
… URL pattern

- Add mandatory Standards Loading section to 5 agents (golang, typescript, devops, frontend, sre)
- Agents now WebFetch Ring standards from GitHub raw URLs
- Both PROJECT_RULES.md (local) and Ring standards (remote) are HARD GATES
- Fix using-dev-team agent count (9→7), remove non-existent agents
- Add Blocker Criteria section to dev-feedback-loop
- Standardize qa-analyst output_schema to Implementation archetype

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development agent guidance with mandatory standards loading requirements before implementation.
  * Updated available developer specialists count to 7.
  * Restructured feedback scoring mechanism with explicit blocker criteria and penalty-based calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->