### PR TITLE
fix(dev-team): remove loopholes that allowed AI to skip mandatory gates

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -11,9 +11,9 @@ trigger: |
   - Need structured, gate-based task execution with quality checkpoints
 
 skip_when: |
-  - Single simple task without quality gates -> execute directly
   - Already in a specific gate skill -> let that gate complete
   - Need to plan tasks first -> use ring-default:writing-plans or ring-pm-team:pre-dev-full
+  - Human explicitly requests manual implementation (non-AI workflow)
 
 NOT_skip_when: |
   - "Task is simple" → Simple ≠ risk-free. Execute gates.
@@ -75,7 +75,7 @@ The development cycle orchestrator loads tasks/subtasks from PM team output (or 
 | **Time** | "Production down, skip gates" | "Gates prevent production issues. Automatic mode = 20 min. Skipping gates increases risk." |
 | **Sunk Cost** | "Already did 4 gates, skip review" | "Each gate catches different issues. Prior gates don't reduce review value. Review = 10 min." |
 | **Authority** | "Director override, ship now" | "Cannot skip GATES based on authority. Can skip CHECKPOINTS (automatic mode). Gates are non-negotiable." |
-| **Simplicity** | "Simple fix, skip gates" | "Simple tasks often have complex impacts. Gates required unless: <5 lines, no deps, >90% existing coverage." |
+| **Simplicity** | "Simple fix, skip gates" | "Simple tasks have complex impacts. AI doesn't negotiate. ALL tasks require ALL gates. No exceptions." |
 
 **Non-negotiable principle:** Execution mode selection affects CHECKPOINTS (user approval pauses), not GATES (quality checks). ALL gates execute regardless of mode.
 

--- a/dev-team/skills/dev-feedback-loop/SKILL.md
+++ b/dev-team/skills/dev-feedback-loop/SKILL.md
@@ -13,7 +13,10 @@ trigger: |
 skip_when: |
   - Task still in progress -> wait for completion
   - Feedback already recorded for this task -> proceed
-  - Exploratory/spike work (no metrics tracked)
+
+NOT_skip_when: |
+  - "Exploratory/spike work" → ALL work produces learnings. Track metrics for spikes too.
+  - "Just experimenting" → Experiments need metrics to measure success. No exceptions.
 
 sequence:
   after: [ring-dev-team:dev-validation]
@@ -47,6 +50,8 @@ Continuous improvement system that tracks development cycle effectiveness throug
 
 | Excuse | Reality |
 |--------|---------|
+| "It was just a spike/experiment" | Spikes produce learnings. Track what worked and what didn't. |
+| "Exploratory work, no metrics" | Exploration needs metrics to measure success. Track ALL work. |
 | "Task was too simple" | Simple tasks still contribute to cycle patterns. Track all. |
 | "Perfect score, no insights" | Perfect scores reveal what works. Document for replication. |
 | "User is happy, skip analysis" | Happiness ≠ process quality. Collect metrics objectively. |
@@ -58,6 +63,8 @@ Continuous improvement system that tracks development cycle effectiveness throug
 
 If you catch yourself thinking ANY of these, STOP immediately:
 
+- "It was just a spike, no need to track"
+- "Exploratory work doesn't need metrics"
 - "This task was too simple to track"
 - "Perfect outcome, no need for feedback"
 - "User approved, skip the metrics"

--- a/dev-team/skills/dev-review/SKILL.md
+++ b/dev-team/skills/dev-review/SKILL.md
@@ -12,7 +12,10 @@ trigger: |
 skip_when: |
   - Tests not passing -> complete Gate 3 first
   - Already reviewed with no changes since -> proceed to validation
-  - Trivial change (<20 lines, no logic) -> document skip reason
+
+NOT_skip_when: |
+  - "Trivial change" → Security issues fit in 1 line. ALL changes require review. No exceptions.
+  - "Only N lines" → Line count is irrelevant. AI doesn't negotiate. Review ALL changes.
 
 sequence:
   after: [ring-dev-team:dev-testing]
@@ -79,6 +82,8 @@ Execute comprehensive code review using 3 specialized reviewers IN PARALLEL. Agg
 
 | Excuse | Reality |
 |--------|---------|
+| "Trivial change, skip review" | Security vulnerabilities fit in 1 line. ALL changes require ALL 3 reviewers. |
+| "Only N lines changed" | Line count is irrelevant. SQL injection is 1 line. Review ALL changes. |
 | "Code reviewer covers security" | Code reviewer checks architecture. Security reviewer checks OWASP. Different expertise. |
 | "Only found LOW issues" | LOW issues accumulate into technical debt. Document in TODO or fix. |
 | "Small fix, no re-review needed" | Small fixes can have big impacts. Re-run ALL reviewers after ANY change. |
@@ -90,6 +95,8 @@ Execute comprehensive code review using 3 specialized reviewers IN PARALLEL. Agg
 
 If you catch yourself thinking ANY of these, STOP immediately:
 
+- "This change is too trivial for review"
+- "Only N lines, skip review"
 - "One reviewer found nothing, skip the others"
 - "These are just cosmetic issues"
 - "Small fix doesn't need re-review"

--- a/dev-team/skills/dev-sre/SKILL.md
+++ b/dev-team/skills/dev-sre/SKILL.md
@@ -11,8 +11,11 @@ trigger: |
 
 skip_when: |
   - No service implementation (documentation only)
-  - Task explicitly marks observability as not required
-  - Pure frontend changes without backend calls
+
+NOT_skip_when: |
+  - "Task says observability not required" → AI cannot self-exempt. ALL services need observability.
+  - "Pure frontend" → If it calls ANY API, backend needs observability. Frontend-only = static HTML.
+  - "MVP doesn't need metrics" → MVP without metrics = blind MVP. No exceptions.
 
 sequence:
   after: [ring-dev-team:dev-devops]
@@ -91,6 +94,9 @@ This skill validates and implements observability requirements for the implement
 | "It's just an internal tool" | Internal tools fail too. Observability required. |
 | "Dashboard can come later" | Dashboard is optional. Metrics endpoint is not. |
 | "Too much overhead for MVP" | Observability is minimal overhead, maximum value. |
+| "Task says observability not needed" | AI cannot self-exempt. Tasks don't override gates. |
+| "Pure frontend, no backend calls" | If it calls ANY API, backend needs observability. Frontend-only = static HTML. |
+| "It's just MVP" | MVP without metrics = blind MVP. You won't know if it's working. |
 
 ## Red Flags - STOP
 
@@ -102,6 +108,9 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "Metrics add too much overhead"
 - "It's just an internal service"
 - "We can monitor manually"
+- "Task says observability not required"
+- "Pure frontend, no backend impact"
+- "It's just MVP, we'll add metrics later"
 
 **All of these indicate Gate 2 violation. Implement observability now.**
 


### PR DESCRIPTION
Hardens dev-cycle, dev-review, dev-feedback-loop, and dev-sre skills by:
- Removing quantitative exceptions (<5 lines, <20 lines) from skip_when
- Adding NOT_skip_when sections with explicit rationalization rejections
- Expanding Common Rationalizations tables with new anti-patterns
- Adding Red Flags to catch self-exemption attempts

All gates now enforce absolute rules: AI doesn't negotiate, no exceptions.

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development process guidelines to strengthen enforcement of code review, testing, and observability standards across all tasks, regardless of complexity or scope.

---

**Note:** These are internal process documentation updates with no direct end-user visible changes. The updates reinforce development standards that may indirectly improve code quality and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->