### PR TITLE
fix(dev-team): add missing template sections to frontend agents

### DIFF
--- a/dev-team/agents/frontend-designer.md
+++ b/dev-team/agents/frontend-designer.md
@@ -162,6 +162,27 @@ Before coding, this agent analyzes context and commits to a BOLD aesthetic direc
 - **Typography**: Google Fonts, Adobe Fonts, variable fonts, custom font loading
 - **Design Tools Integration**: Figma-to-code, design tokens, style guides
 
+## Standards Loading (MANDATORY)
+
+**Before ANY design implementation, load BOTH sources:**
+
+### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
+```
+Read docs/PROJECT_RULES.md
+```
+**MANDATORY:** Project-specific design guidelines (brand colors, typography, spacing). Cannot proceed without reading this file.
+
+### Step 2: Fetch Ring Frontend Standards (HARD GATE)
+```
+WebFetch: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/frontend.md
+```
+**MANDATORY:** Base design standards that must always be applied.
+
+### Apply Both
+- Ring Standards = Base design patterns (typography, color systems, animation)
+- PROJECT_RULES.md = Project brand identity and specific guidelines
+- **Both are complementary. Neither excludes the other. Both must be followed.**
+
 ## Anti-Patterns (NEVER Do These)
 
 - Generic font families (Inter, Roboto, Arial, system fonts)

--- a/dev-team/agents/frontend-engineer-typescript.md
+++ b/dev-team/agents/frontend-engineer-typescript.md
@@ -782,6 +782,19 @@ If code is ALREADY compliant with all standards:
 
 **You CANNOT introduce new UI libraries without explicit approval.**
 
+## Severity Calibration
+
+When reporting issues in frontend code:
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **CRITICAL** | Security risk, type unsafety | XSS vulnerability, `any` in props, missing input sanitization |
+| **HIGH** | Runtime errors likely | Unhandled promises, missing null checks, no error boundaries |
+| **MEDIUM** | Type quality, maintainability | Missing Zod validation, no branded types for IDs |
+| **LOW** | Best practices | Could use discriminated union, minor refactor |
+
+**Report ALL severities. Let user prioritize.**
+
 ## Security Best Practices
 
 ### XSS Prevention


### PR DESCRIPTION
Standardizes agent structure across dev-team:

- frontend-engineer-typescript: Add Severity Calibration section
- frontend-designer: Add Standards Loading (MANDATORY) section

Both agents now follow the same template as other dev-team agents.

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Standards Loading section to frontend design guidelines with local and remote standards requirements
  * Added Severity Calibration section with four-level severity framework to TypeScript engineering guidelines
  * Enhanced Security Best Practices documentation with XSS handling guidance and code examples demonstrating safe vs. unsafe patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->