### PR TITLE
fix(dev-team): add pressure resistance rationalizations to skills

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -89,6 +89,10 @@ The development cycle orchestrator loads tasks/subtasks from PM team output (or 
 | "Tests pass, skip review" | Tests verify code works. Review verifies code is correct, secure, maintainable. |
 | "Automatic mode means faster" | Automatic mode skips CHECKPOINTS, not GATES. Same quality, less interruption. |
 | "We'll fix issues post-merge" | Post-merge fixes are 10x more expensive. Gates exist to prevent this. |
+| "Defense in depth exists (frontend validates)" | Frontend can be bypassed. Backend is the last line. Fix at source. |
+| "Backlog the Medium issue, it's documented" | Documented risk ≠ mitigated risk. Medium in Gate 4 = fix NOW, not later. |
+| "Risk-based prioritization allows deferral" | Gates ARE the risk-based system. Reviewers define severity, not you. |
+| "Business context justifies exception" | Business context informed gate design. Gates already account for it. |
 
 ## Red Flags - STOP
 
@@ -101,6 +105,11 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "We can fix issues later"
 - "Automatic mode will handle it"
 - "Just this once won't hurt"
+- "Frontend already validates this"
+- "I'll document it in backlog/TODO"
+- "Medium severity can wait"
+- "Business context is different here"
+- "Risk-based approach says defer"
 
 **All of these indicate you're about to violate mandatory workflow. Return to gate execution.**
 

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -76,6 +76,12 @@ When user requests refactoring or improvement:
 | "Only critical matters" | Today's medium = tomorrow's critical. Document all. |
 | "Legacy gets a pass" | Legacy sets precedent. Analysis shows what to improve. |
 | "Team has their own way" | Document "their way" as standards. Analyze against it. |
+| "ROI of refactoring is low" | ROI calculation requires analysis. You can't calculate without data. |
+| "Partial analysis is enough" | Partial analysis = partial picture. Hidden debt in skipped areas. |
+| "3 years without bugs = stable" | No bugs ≠ no debt. Time doesn't validate architecture. |
+| "Analysis is overkill" | Analysis is the MINIMUM. Refactoring without analysis is guessing. |
+| "Code smells ≠ problems" | Code smells ARE problems. They slow development and cause bugs. |
+| "No specific problem motivating" | Technical debt IS the problem. Analysis quantifies it. |
 
 ## Red Flags - STOP
 
@@ -87,6 +93,12 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "Only critical issues matter"
 - "Legacy code is exempt"
 - "That's just how we do it here"
+- "ROI doesn't justify full analysis"
+- "Partial analysis is sufficient"
+- "3+ years stable = no debt"
+- "Analysis is overkill"
+- "Code smells aren't real problems"
+- "No specific problem to solve"
 
 **All of these indicate analysis violation. Complete full 4-dimension analysis.**
 

--- a/dev-team/skills/dev-sre/SKILL.md
+++ b/dev-team/skills/dev-sre/SKILL.md
@@ -97,6 +97,12 @@ This skill validates and implements observability requirements for the implement
 | "Task says observability not needed" | AI cannot self-exempt. Tasks don't override gates. |
 | "Pure frontend, no backend calls" | If it calls ANY API, backend needs observability. Frontend-only = static HTML. |
 | "It's just MVP" | MVP without metrics = blind MVP. You won't know if it's working. |
+| "YAGNI - we don't need it yet" | YAGNI doesn't apply to observability. You need it BEFORE problems occur. |
+| "Only N users, no need for metrics" | User count is irrelevant. 1 user with silent failure = bad experience. |
+| "Basic fmt.Println logs are enough" | fmt.Println is not structured, not searchable, not alertable. JSON logs required. |
+| "Single server, no Kubernetes" | /health is for ANY environment. Load balancers, systemd, monitoring all need it. |
+| "Just /health is enough for now" | /health + /ready + /metrics is the MINIMUM. Partial observability = partial blindness. |
+| "45 min overhead not worth it" | 45 min now prevents 4+ hours debugging blind production issues. |
 
 ## Red Flags - STOP
 
@@ -111,6 +117,12 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "Task says observability not required"
 - "Pure frontend, no backend impact"
 - "It's just MVP, we'll add metrics later"
+- "YAGNI - don't need it yet"
+- "Only N users, doesn't justify"
+- "fmt.Println is fine for now"
+- "Single server doesn't need /ready"
+- "Just /health endpoint is enough"
+- "45 min not worth it"
 
 **All of these indicate Gate 2 violation. Implement observability now.**
 

--- a/dev-team/skills/dev-testing/SKILL.md
+++ b/dev-team/skills/dev-testing/SKILL.md
@@ -88,6 +88,11 @@ Ensure every acceptance criterion has at least one **unit test** proving it work
 | "We can add tests later in CI/CD" | Gate 3 exit criteria require tests NOW. Later = never. |
 | "These mocks make it a unit test" | If you hit DB/API/filesystem, it's integration. Mock the interface. |
 | "All criteria tested, coverage low" | Write edge case tests until threshold met. |
+| "Coverage % is vanity metric" | Coverage is GATE metric. Vanity or not, below threshold = FAIL. |
+| "Integration tests compensate low coverage" | Different scope. Integration tests are NOT unit test substitute. |
+| "Edge cases are obscure/unlikely" | Edge cases cause production incidents. Test them. |
+| "Time spent on edge cases not worth it" | Time spent debugging production incidents is worse. Test now. |
+| "76% with AC tested is defensible" | Defensible ≠ passing. Threshold is 80%. Period. |
 
 ## Red Flags - STOP
 
@@ -99,6 +104,11 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "We can add tests after review"
 - "All criteria covered, percentage doesn't matter"
 - "Tests slow down development"
+- "Coverage % is vanity metric"
+- "Integration tests compensate"
+- "Edge cases are unlikely"
+- "Time spent not worth it for 4%"
+- "76% is defensible"
 
 **All of these indicate Gate 3 violation. Write unit tests until threshold met.**
 

--- a/dev-team/skills/dev-validation/SKILL.md
+++ b/dev-team/skills/dev-validation/SKILL.md
@@ -83,6 +83,10 @@ Final validation gate requiring explicit user approval. Present evidence that ea
 | "User seemed happy" | Seeming ≠ approval. Require explicit response. |
 | "Implicit approval after demo" | Demo ≠ approval. Ask for explicit decision. |
 | "User approved similar before" | Past ≠ present. Each validation requires fresh approval. |
+| "Async over sync - work in parallel" | Validation is a GATE, not async task. STOP means STOP. |
+| "Continue other tasks while waiting" | Other tasks may conflict. Validation blocks ALL related work. |
+| "Cost of waiting is too high" | Cost of wrong approval is higher. Wait is investment. |
+| "Send message and continue" | Message sent ≠ waiting for response. STOP until APPROVED. |
 
 ## Red Flags - STOP
 
@@ -94,6 +98,10 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "User didn't say no, so it's approved"
 - "User seemed satisfied with the demo"
 - "Previous similar work was approved"
+- "I'll work on other tasks while waiting"
+- "Async over sync - don't block"
+- "Send message and continue"
+- "Cost of waiting is too high"
 
 **All of these indicate Gate 5 violation. Wait for explicit "APPROVED" or "REJECTED".**
 


### PR DESCRIPTION
Added new rationalizations and red flags to 5 skills based on TDD testing:

- dev-cycle: +4 rationalizations for security backlog scenarios
- dev-validation: +4 rationalizations, +4 red flags for async/sync scenarios
- dev-testing: +5 rationalizations, +5 red flags for coverage scenarios
- dev-sre: +6 rationalizations, +6 red flags for YAGNI/MVP scenarios
- dev-refactor: +6 rationalizations, +6 red flags for ROI scenarios

These additions close loopholes identified through pressure testing with the testing-skills-with-subagents methodology (RED-GREEN-REFACTOR).

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development process guidelines to strengthen quality gate requirements across testing, validation, refactoring analysis, and system observability, reducing allowable exceptions and reinforcing mandatory quality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->