### PR TITLE
fix(dev-team): add Blockers section to qa-analyst output_schema

### DIFF
--- a/dev-team/agents/qa-analyst.md
+++ b/dev-team/agents/qa-analyst.md
@@ -28,6 +28,10 @@ output_schema:
     - name: "Next Steps"
       pattern: "^## Next Steps"
       required: true
+    - name: "Blockers"
+      pattern: "^## Blockers"
+      required: false
+      description: "Decisions requiring user input before proceeding"
   error_handling:
     on_blocker: "pause_and_report"
     escalation_path: "orchestrator"


### PR DESCRIPTION
Adds missing Blockers section to output_schema for consistency with other dev-team agents. The qa-analyst agent already references blockers in its blocker criteria section but lacked the corresponding output_schema definition.

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional Blockers section to capture decisions requiring user input before proceeding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->