### PR TITLE
fix(dev-team): add missing rationalizations to dev-cycle and dev-revi…

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -88,6 +88,7 @@ The development cycle orchestrator loads tasks/subtasks from PM team output (or 
 | "Manager approved skipping" | Authority cannot override quality gates. Document the pressure. |
 | "Tests pass, skip review" | Tests verify code works. Review verifies code is correct, secure, maintainable. |
 | "Automatic mode means faster" | Automatic mode skips CHECKPOINTS, not GATES. Same quality, less interruption. |
+| "Automatic mode will skip review" | Automatic mode affects user approval pauses, NOT quality gates. ALL gates execute regardless. |
 | "We'll fix issues post-merge" | Post-merge fixes are 10x more expensive. Gates exist to prevent this. |
 | "Defense in depth exists (frontend validates)" | Frontend can be bypassed. Backend is the last line. Fix at source. |
 | "Backlog the Medium issue, it's documented" | Documented risk ≠ mitigated risk. Medium in Gate 4 = fix NOW, not later. |
@@ -108,6 +109,7 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "Tests pass, review is redundant"
 - "We can fix issues later"
 - "Automatic mode will handle it"
+- "Automatic mode will skip review"
 - "Just this once won't hurt"
 - "Frontend already validates this"
 - "I'll document it in backlog/TODO"

--- a/dev-team/skills/dev-review/SKILL.md
+++ b/dev-team/skills/dev-review/SKILL.md
@@ -90,6 +90,7 @@ Execute comprehensive code review using 3 specialized reviewers IN PARALLEL. Agg
 | "One reviewer said PASS" | PASS requires ALL 3 reviewers. One PASS + one FAIL = overall FAIL. |
 | "Business logic is tested" | Tests check behavior. Review checks intent, edge cases, requirements alignment. |
 | "Security scan passed" | Security scanners miss logic flaws. Human reviewer required. |
+| "CSS can't have security issues" | CSS can have XSS (user-controlled classes), clickjacking (z-index manipulation), data exfiltration (CSS injection). ALL code needs security review. |
 | "Only MEDIUM issues, can proceed" | MEDIUM issues must be fixed OR documented with FIXME. No silent ignoring. |
 | "Document MEDIUM and ship" | Documentation ≠ resolution. Fix now, or add FIXME with timeline. |
 | "Risk-accept MEDIUM issues" | Risk acceptance requires explicit user approval, not agent decision. |
@@ -106,6 +107,7 @@ If you catch yourself thinking ANY of these, STOP immediately:
 - "Sequential reviews are fine this time"
 - "Security scanner covers security review"
 - "Business tests cover business review"
+- "CSS can't have security issues"
 - "Only MEDIUM issues, not blocking"
 - "Risk-accept these findings"
 
@@ -147,6 +149,12 @@ Task tool #3: ring-default:security-reviewer
 - ❌ Skipping re-review after fixes
 
 **The ONLY acceptable pattern is 3 Task tools in 1 message.**
+
+**If you already dispatched reviewers sequentially (separate messages):**
+1. STOP immediately - this is a violation
+2. Discard sequential results (they're incomplete context)
+3. Re-dispatch ALL 3 reviewers in a SINGLE message with 3 Task tool calls
+4. Sequential dispatch wastes time AND misses cross-domain insights
 
 ## Prerequisites
 


### PR DESCRIPTION
…ew skills

Addresses test findings from testing-skills-with-subagents methodology:

- dev-cycle: add 'Automatic mode will skip review' rationalization and red flag
- dev-review: add 'CSS can't have security issues' rationalization and red flag
- dev-review: add recovery protocol for sequential reviewer dispatch violation

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified automatic mode behavior: reviews are skipped, but all quality gates execute
  * Updated security guidance: clarified that CSS requires security review and can have security-related concerns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->