### PR TITLE
refactor(dev-team): enforce ring-dev-team:* agents in dev-refactor

### DIFF
--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -26,7 +26,7 @@ related:
 
 # Dev Refactor Skill
 
-```
+```text
 ╔═══════════════════════════════════════════════════════════════════════════════╗
 ║  ⛔⛔⛔ CRITICAL: READ BEFORE DOING ANYTHING ⛔⛔⛔                            ║
 ║                                                                               ║
@@ -138,7 +138,7 @@ After outputting the blocker above:
 
 **⛔ You MUST NOT dispatch the agent. This is a HARD GATE.**
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────────┐
 │  ⛔ HARD GATE: AGENT PREFIX VALIDATION                              │
 │                                                                     │
@@ -300,7 +300,7 @@ Select agents based on the analysis dimensions needed for the task. Dispatch ALL
 
 ### Execution Checklist - MUST COMPLETE IN ORDER
 
-```
+```text
 Step 0:   [ ] PROJECT_RULES.md exists? → If NO, output blocker and TERMINATE
            ⚠️ See "STEP 0: PROJECT_RULES.md VALIDATION" at top of skill
 
@@ -331,7 +331,7 @@ Step 9:   [ ] Handoff to dev-cycle (if approved)?
 #### Prompt Prefix (REQUIRED)
 
 All agent prompts MUST start with:
-```
+```text
 **MODE: ANALYSIS ONLY** - Analyze codebase for refactoring.
 Return findings with: severity (Critical/High/Medium/Low), location (file:line), issue, recommendation.
 ```


### PR DESCRIPTION
Add aggressive enforcement to prevent using forbidden agents (Explore, general-purpose, codebase-explorer) in dev-refactor skill.

Changes:
- Add critical warning banner at top listing forbidden/required agents
- Add STEP 1.5: Agent Dispatch Validation with pre-dispatch self-check
- Add technical explanation of WHY ring-dev-team:* agents are required
- Add comparison table showing different outputs from forbidden vs correct agents
- Add WRONG vs RIGHT dispatch examples with code
- Remove hardcoded '4 agents' references - now uses 'ALL applicable agents'
- Add violation recovery procedure if wrong agent was already dispatched

The model was using Explore agent instead of specialized ring-dev-team:* agents, producing generic observations instead of standards-based compliance checks.

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a CRITICAL read-before-action block with two hard gates and an agent-prefix policy.
  * Introduced STEP 1.5: AGENT DISPATCH VALIDATION with pre-dispatch checks, violation table, and recovery flow.
  * Renamed/restructured dispatch guidance: send a single parallel message to ALL applicable agents (removed fixed "4-agent" exemplar).
  * Added Key Rules, Prompt Prefix, WRONG vs RIGHT guidance, updated execution checklist, completion schemas, examples, and templates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->