### PR TITLE
refactor(dev-team): remove endpoint requirements and add auto-trigger…

### DIFF
--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -201,6 +201,30 @@ Invoke this agent when the task involves:
 - **Patterns**: Hexagonal Architecture, CQRS, Repository, DDD, Multi-Tenancy
 - **Serverless**: AWS Lambda, API Gateway, Step Functions, SAM
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring Go standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY implementation, load BOTH sources:**

--- a/dev-team/agents/backend-engineer-typescript.md
+++ b/dev-team/agents/backend-engineer-typescript.md
@@ -286,6 +286,30 @@ Invoke this agent when the task involves:
 - **Patterns**: Clean Architecture, Dependency Injection, Repository, CQRS, DDD
 - **Serverless**: AWS Lambda, Vercel Functions, Cloudflare Workers
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring TypeScript standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY implementation, load BOTH sources:**

--- a/dev-team/agents/devops-engineer.md
+++ b/dev-team/agents/devops-engineer.md
@@ -233,6 +233,30 @@ Invoke this agent when the task involves:
 - **Scripting**: Bash, Python, Make
 - **Multi-Tenancy**: Namespace isolation, tenant provisioning, resource quotas
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring DevOps standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/devops.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 You MUST load BOTH sources BEFORE proceeding:

--- a/dev-team/agents/frontend-bff-engineer-typescript.md
+++ b/dev-team/agents/frontend-bff-engineer-typescript.md
@@ -184,6 +184,30 @@ Invoke this agent when the task involves:
 - **Testing**: Jest, Testing Library
 - **Patterns**: Clean Architecture, Hexagonal Architecture, DDD, Repository, Use Case
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring TypeScript standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY implementation, load BOTH sources:**

--- a/dev-team/agents/frontend-designer.md
+++ b/dev-team/agents/frontend-designer.md
@@ -785,6 +785,30 @@ When ambiguity exists, present options with trade-offs:
 
 **→ For handoff templates, see `docs/STANDARDS.md` → Designer Handoff section.**
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring Frontend standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/frontend.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY design implementation, load BOTH sources:**

--- a/dev-team/agents/frontend-engineer.md
+++ b/dev-team/agents/frontend-engineer.md
@@ -120,6 +120,30 @@ Invoke this agent when the task involves:
 - **Build Tools**: Vite, Turbopack, Webpack
 - **Documentation**: Storybook
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring Frontend standards: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/frontend.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY implementation, load BOTH sources:**

--- a/dev-team/agents/qa-analyst.md
+++ b/dev-team/agents/qa-analyst.md
@@ -271,6 +271,32 @@ Invoke this agent when the task involves:
 - **CI Integration**: GitHub Actions, Jenkins, GitLab CI
 - **Test Management**: TestRail, Zephyr, qTest
 
+## Standards Compliance (AUTO-TRIGGERED)
+
+**Detection:** If dispatch prompt contains `**MODE: ANALYSIS ONLY**`
+
+**When detected, you MUST:**
+1. **WebFetch** the Ring Testing standards (language-specific):
+   - Go: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang.md`
+   - TypeScript: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md`
+2. **Read** `docs/PROJECT_RULES.md` if it exists in the target codebase
+3. **Include** a `## Standards Compliance` section in your output with comparison table
+4. **CANNOT skip** - this is a HARD GATE, not optional
+
+**MANDATORY Output Table Format:**
+```
+| Category | Current Pattern | Ring Standard | Status | File/Location |
+|----------|----------------|---------------|--------|---------------|
+| [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
+```
+
+**Status Legend:**
+- ✅ Compliant - Matches Ring standard
+- ⚠️ Partial - Some compliance, needs improvement
+- ❌ Non-Compliant - Does not follow standard
+
+**If `**MODE: ANALYSIS ONLY**` is NOT detected:** Standards Compliance output is optional (for direct implementation tasks).
+
 ## Standards Loading (MANDATORY)
 
 **Before ANY test implementation, load BOTH sources:**

--- a/dev-team/docs/standards/devops.md
+++ b/dev-team/docs/standards/devops.md
@@ -282,18 +282,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
-          livenessProbe:
-            httpGet:
-              path: /health/live
-              port: 8080
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /health/ready
-              port: 8080
-            initialDelaySeconds: 5
-            periodSeconds: 5
+          # Health probes removed - focus on container lifecycle and logging
           env:
             - name: DATABASE_URL
               valueFrom:

--- a/dev-team/docs/standards/golang.md
+++ b/dev-team/docs/standards/golang.md
@@ -322,8 +322,7 @@ func NewRouter(lg libLog.Logger, tl *libOpentelemetry.Telemetry, ...) *fiber.App
 
     // ... define routes ...
 
-    // Health & Version endpoints
-    f.Get("/health", libHTTP.Ping)
+    // Version endpoint
     f.Get("/version", libHTTP.Version)
 
     // MUST be last middleware - closes root spans

--- a/dev-team/docs/standards/sre.md
+++ b/dev-team/docs/standards/sre.md
@@ -598,17 +598,11 @@ ctx := otel.GetTextMapPropagator().Extract(
 
 ### Required Endpoints
 
-| Endpoint | Purpose | Response |
-|----------|---------|----------|
-| `/health` | Kubernetes liveness | `200 OK` if process running |
-| `/ready` | Kubernetes readiness | `200 OK` if can serve traffic |
-| `/metrics` | Prometheus scraping | Prometheus format |
-
 ### Implementation
 
 ```go
-// Go implementation
-type HealthChecker struct {
+// Go implementation for observability
+type ObservabilityChecker struct {
     db    *sql.DB
     redis *redis.Client
 }
@@ -658,23 +652,9 @@ func (h *HealthChecker) ReadinessHandler(w http.ResponseWriter, r *http.Request)
 ### Kubernetes Configuration
 
 ```yaml
-livenessProbe:
-  httpGet:
-    path: /health
-    port: 8080
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3
-
-readinessProbe:
-  httpGet:
-    path: /ready
-    port: 8080
-  initialDelaySeconds: 5
-  periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 2
+# Observability configuration
+# JSON structured logging required
+# OpenTelemetry tracing recommended for distributed systems
 ```
 
 ---
@@ -768,10 +748,8 @@ readinessProbe:
 
 Before deploying to production:
 
-- [ ] **Metrics**: Prometheus metrics exposed at `/metrics`
-- [ ] **Dashboards**: Grafana dashboard with required panels
-- [ ] **Alerts**: Alert rules for critical scenarios
+- [ ] **Dashboards**: Grafana dashboard with required panels (optional)
+- [ ] **Alerts**: Alert rules for critical scenarios (optional)
 - [ ] **Logging**: Structured JSON logs with trace correlation
 - [ ] **Tracing**: OpenTelemetry instrumentation
-- [ ] **Health Checks**: `/health` and `/ready` endpoints
-- [ ] **Runbooks**: Documented for all critical alerts
+- [ ] **Runbooks**: Documented for all critical alerts (optional)

--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -213,7 +213,7 @@ Day 4: Production incident from Day 1 code
 |------|---------------------|----------------|
 | 0 | Implementation agent completes + TDD RED verified | 1 file done ≠ gate done |
 | 1 | Dockerfile + docker-compose + .env.example | Missing any = FAIL |
-| 2 | /health + /ready + /metrics + structured logs | 3/4 endpoints = FAIL |
+| 2 | Structured JSON logs with trace correlation | Partial structured logs = FAIL |
 | 3 | Coverage ≥ 85% + all AC tested | 84% = FAIL |
 | 4 | **ALL 3 reviewers PASS** | 2/3 reviewers = FAIL |
 | 5 | Explicit "APPROVED" from user | "Looks good" = NOT approved |
@@ -551,10 +551,10 @@ For current execution unit:
        - Implementation from Gate 0: [summary of what was implemented]
 
        Validation Requirements:
-       - Verify /health endpoint responds correctly
+       - Verify structured JSON logging with trace correlation
        - Verify OpenTelemetry tracing (if external calls)
 
-       Report: validation results with PASS/FAIL for each component (/health, tracing), issues found by severity, verification commands executed.
+       Report: validation results with PASS/FAIL for each component (logging, tracing), issues found by severity, verification commands executed.
 
 4. If SRE not needed:
    - Mark as "skipped" with reason

--- a/dev-team/skills/dev-devops/SKILL.md
+++ b/dev-team/skills/dev-devops/SKILL.md
@@ -32,9 +32,9 @@ verification:
       description: "All services start and are healthy"
       success_pattern: "Up|running|healthy"
       failure_pattern: "Exit|exited|unhealthy"
-    - command: "curl -sf http://localhost:8080/health || curl -sf http://localhost:3000/health"
-      description: "Health endpoint responds"
-      success_pattern: "200|ok|healthy"
+    - command: "docker-compose logs app | head -5 | jq -e '.level'"
+      description: "Structured JSON logging works"
+      success_pattern: "info|debug|warn|error"
   manual:
     - "Verify docker-compose ps shows all services as 'Up (healthy)'"
     - "Verify .env.example documents all required environment variables"
@@ -284,13 +284,13 @@ Create `docs/LOCAL_SETUP.md` with these sections:
 
 ## Step 7: Verify Setup Works
 
-**Commands:** `docker-compose build` → `docker-compose up -d` → `docker-compose ps` → `curl localhost:8080/health` → `docker-compose logs app | grep -i error`
+**Commands:** `docker-compose build` → `docker-compose up -d` → `docker-compose ps` → `docker-compose logs app | grep -i error`
 
-**Checklist:** Build succeeds ✓ | Services start ✓ | All healthy ✓ | Health responds ✓ | No errors ✓ | DB connects ✓ | Redis connects ✓
+**Checklist:** Build succeeds ✓ | Services start ✓ | All healthy ✓ | No errors ✓ | DB connects ✓ | Redis connects ✓
 
 ## Step 8: Prepare Handoff to Gate 2
 
-**Handoff format:** DevOps status (COMPLETE/PARTIAL) | Files changed (Dockerfile, compose, .env, docs) | Services configured (App:port, DB:type/port, Cache:type/port) | Env vars added | Verification results (build/startup/health/connectivity: PASS/FAIL) | Ready for testing: YES/NO
+**Handoff format:** DevOps status (COMPLETE/PARTIAL) | Files changed (Dockerfile, compose, .env, docs) | Services configured (App:port, DB:type/port, Cache:type/port) | Env vars added | Verification results (build/startup/connectivity: PASS/FAIL) | Ready for testing: YES/NO
 
 ## Common DevOps Patterns
 

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -1321,13 +1321,6 @@ Task 4:
 
     Compare CURRENT observability with EXPECTED patterns:
 
-    ### Health Endpoints
-    | Standard Pattern | Codebase Has | Status | Location | Fix |
-    |-----------------|--------------|--------|----------|-----|
-    | GET /health | Missing | ❌ | routes.go | Add libHTTP.Ping |
-    | GET /ready | Missing | ❌ | routes.go | Add readiness check |
-    | GET /version | Missing | ❌ | routes.go | Add libHTTP.Version |
-
     ### Logging
     | Standard Pattern | Codebase Has | Status | Location | Fix |
     |-----------------|--------------|--------|----------|-----|


### PR DESCRIPTION
Remove /health, /ready, /metrics endpoint requirements from SRE validation:
- Gate 2 now requires structured logging and tracing only
- Endpoints removed from skills, agents, and standards docs
- Reduces infrastructure coupling for simpler services

Add AUTO-TRIGGERED Standards Compliance to 8 agents:
- Detects MODE: ANALYSIS ONLY in dispatch prompt
- Auto-triggers WebFetch of Ring standards + comparison table
- HARD GATE enforcement when triggered
- Optional for direct implementation tasks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced automatic standards compliance validation mechanism triggered by specific dispatch modes
  * Added mandatory standards loading gates requiring verification of local and remote standards before proceeding

* **Changes**
  * Shifted observability validation focus from health endpoints to structured JSON logging and trace correlation
  * Updated verification procedures to emphasize logging quality and tracing over health endpoint checks

* **Removals**
  * Deprecated health endpoint validation requirements from observability checks
  * Removed explicit health probe configurations from infrastructure specifications

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->