### PR TITLE
style(dev-team): add language identifiers to fenced code blocks

### DIFF
--- a/dev-team/agents/frontend-bff-engineer-typescript.md
+++ b/dev-team/agents/frontend-bff-engineer-typescript.md
@@ -195,7 +195,7 @@ Invoke this agent when the task involves:
 4. **CANNOT skip** - this is a HARD GATE, not optional
 
 **MANDATORY Output Table Format:**
-```
+```markdown
 | Category | Current Pattern | Ring Standard | Status | File/Location |
 |----------|----------------|---------------|--------|---------------|
 | [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |
@@ -213,7 +213,7 @@ Invoke this agent when the task involves:
 **Before ANY implementation, load BOTH sources:**
 
 ### Step 1: Read Local PROJECT_RULES.md (HARD GATE)
-```
+```text
 Read docs/PROJECT_RULES.md
 ```
 **MANDATORY:** Project-specific technical information that must always be considered. Cannot proceed without reading this file.

--- a/dev-team/agents/frontend-engineer.md
+++ b/dev-team/agents/frontend-engineer.md
@@ -131,7 +131,7 @@ Invoke this agent when the task involves:
 4. **CANNOT skip** - this is a HARD GATE, not optional
 
 **MANDATORY Output Table Format:**
-```
+```markdown
 | Category | Current Pattern | Ring Standard | Status | File/Location |
 |----------|----------------|---------------|--------|---------------|
 | [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |

--- a/dev-team/agents/sre.md
+++ b/dev-team/agents/sre.md
@@ -192,7 +192,7 @@ When validation fails, report issues to developers:
 4. **CANNOT skip** - this is a HARD GATE, not optional
 
 **MANDATORY Output Table Format:**
-```
+```markdown
 | Category | Current Pattern | Ring Standard | Status | File/Location |
 |----------|----------------|---------------|--------|---------------|
 | [category] | [what codebase does] | [what standard requires] | ✅/⚠️/❌ | [file:line] |


### PR DESCRIPTION
Fix MD040 linter violations by adding language identifiers to code blocks:
- frontend-bff-engineer-typescript.md: markdown, text
- frontend-engineer.md: markdown
- sre.md: markdown

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code block formatting in developer documentation to improve syntax highlighting and readability of examples across multiple guide files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->