### PR TITLE
feat(dev-refactor): add Code Transformation Context output format

### DIFF
--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -1187,111 +1187,34 @@ Task 1:
 
     ## Code Transformation Context (MANDATORY FOR EACH ISSUE)
 
-    **⛔ HARD GATE: For EACH non-compliant issue, you MUST provide a complete Code Transformation Context block.**
+    **⛔ HARD GATE:** For EACH non-compliant issue, you MUST provide a Code Transformation Context (CTC) block.
 
-    **This is NOT optional. This is a NON-NEGOTIABLE requirement.**
+    **If CTC is missing → Output is INCOMPLETE → SKILL FAILURE**
 
-    **If Code Transformation Context is missing → Output is INCOMPLETE → SKILL FAILURE**
+    See [docs/PROMPT_ENGINEERING.md#code-transformation-context-ctc-format](../../../docs/PROMPT_ENGINEERING.md#code-transformation-context-ctc-format) for the canonical CTC template.
 
-    ```text
-    ╔══════════════════════════════════════════════════════════════════════════════════╗
-    ║  ⛔ NON-NEGOTIABLE: DYNAMIC CONTENT vs FIXED STANDARDS                            ║
-    ║                                                                                  ║
-    ║  • BEFORE (Current Code) = DYNAMIC - Extracted from the ACTUAL project          ║
-    ║    being analyzed. This code comes from reading the codebase.                    ║
-    ║                                                                                  ║
-    ║  • AFTER (Ring Standards) = FIXED PATTERNS - Always follows Ring/Lerian         ║
-    ║    standards (golang.md, typescript.md). The patterns are fixed, but            ║
-    ║    applied to the specific code from the project.                               ║
-    ║                                                                                  ║
-    ║  • Standard References = FIXED - Always reference the Ring standards            ║
-    ║    documents with exact section and line numbers.                               ║
-    ║                                                                                  ║
-    ║  The examples below are TEMPLATES showing the structure.                         ║
-    ║  Replace placeholders with ACTUAL code from the project being analyzed.          ║
-    ╚══════════════════════════════════════════════════════════════════════════════════╝
+    ### Required Elements Checklist
+
+    For EACH issue, your output MUST include:
+
+    - [ ] **Before (Current Code)** - Actual code from project with `file:line` reference
+    - [ ] **After (Ring Standards)** - Transformed code using lib-commons patterns
+    - [ ] **Standard References table** - Pattern, Source, Section, Line Range
+    - [ ] **Why This Transformation Matters** - Problem, Standard, Impact
+
+    ### Line Range Derivation (MANDATORY)
+
+    **⛔ DO NOT hardcode line numbers.** Standards files change.
+
+    **REQUIRED:** Derive `:{line_range}` at runtime:
+    1. Read the current standards file (`golang.md`, `typescript.md`, etc.)
+    2. Search for the relevant section header
+    3. Cite actual line numbers from the live file
+
     ```
-
-    ### Purpose
-
-    This block gives AI agents executing refactoring tasks EXACT context about:
-    1. What the current code looks like (from analysis)
-    2. What the transformed code should look like (following Ring standards)
-    3. Which specific Ring standards apply (with line references)
-
-    ### Template Structure
-
-    ```markdown
-    ## Code Transformation Context: ISSUE-XXX
-
-    ### Before (Current Code)
-    ```{language}
-    // file: {actual_path_from_codebase}:{start_line}-{end_line}
-    // ↓↓↓ ACTUAL code extracted from the project being analyzed ↓↓↓
-    {paste the actual code from the codebase that needs transformation}
+    Example: Agent reads golang.md → Finds "## Configuration Loading" at line 99
+             Agent cites: "Configuration Loading (golang.md:99-230)"
     ```
-
-    ### After (Ring Standards)
-    ```{language}
-    // file: {actual_path_from_codebase}:{start_line}-{new_end_line}
-    // ↓↓↓ Transformed code following Ring/Lerian standards ↓↓↓
-    // ✅ Ring Standard: {Pattern Name} ({standards_file}:{line_range})
-    {transformed code using lib-commons patterns}
-    ```
-
-    ### Standard References
-    | Pattern Applied | Ring Standard Source | Section | Line Reference |
-    |-----------------|---------------------|---------|----------------|
-    | {pattern_name} | `{golang.md|typescript.md|devops.md}` | {Section Title} | :{line_range} |
-
-    ### Why This Transformation Matters
-    - **Problem:** {What is wrong with the current code}
-    - **Ring Standard:** {Which standard this violates}
-    - **Impact:** {Business/technical impact of the fix}
-    ```
-
-    ### How to Fill the Template
-
-    | Field | Source | Example |
-    |-------|--------|---------|
-    | `{actual_path_from_codebase}` | From codebase-report.md or file analysis | `internal/service/user.go` |
-    | `{start_line}-{end_line}` | From code analysis | `:45-52` |
-    | `{paste the actual code}` | Read from actual project files | The real code, not examples |
-    | `{standards_file}` | Ring standards doc | `golang.md`, `typescript.md` |
-    | `{Section Title}` | Section in standards doc | `Telemetry & Observability` |
-    | `{line_range}` | Line numbers in standards doc | `:337-352` |
-
-    ### Reference: Ring Standards Sections (golang.md)
-
-    Use these ACTUAL section references when filling the template:
-
-    | Category | Section in golang.md | Line Range |
-    |----------|---------------------|------------|
-    | Configuration | Configuration Loading (MANDATORY) | :99-230 |
-    | Telemetry | Telemetry & Observability (MANDATORY) | :234-401 |
-    | Bootstrap | Bootstrap Pattern (MANDATORY) | :405-479 |
-    | Data Transformation | ToEntity/FromEntity (MANDATORY) | :483-542 |
-    | Error Codes | Error Codes Convention (MANDATORY) | :545-608 |
-    | Error Handling | Error Handling | :613-648 |
-    | Testing | Testing Patterns | :932-970 |
-    | Logging | Logging Standards | :995-1017 |
-    | Architecture | Architecture Patterns | :1056-1093 |
-    | DDD | DDD Patterns (Go Implementation) | :1174-1240 |
-
-    ### Anti-Rationalization: Code Transformation Context
-
-    **If you catch yourself thinking ANY of these, STOP. You are about to produce INCOMPLETE output:**
-
-    | Rationalization | Why It's WRONG | Required Action |
-    |-----------------|----------------|-----------------|
-    | "The comparison table is enough" | Table shows WHAT to change. Context shows HOW. Both are REQUIRED. | **Add Code Transformation Context** |
-    | "Code examples take too long" | Incomplete output is worse than slow output. Context is NON-NEGOTIABLE. | **Add Code Transformation Context** |
-    | "I'll just describe the change" | Description ≠ executable context. AI needs exact before/after code. | **Add Code Transformation Context** |
-    | "The engineer will figure it out" | Figuring out = guessing = inconsistent results. Provide exact code. | **Add Code Transformation Context** |
-    | "Ring standards are obvious" | Obvious to YOU ≠ obvious to execution agent. Reference exact lines. | **Include Standard References table** |
-    | "One example is enough" | Each issue needs its OWN context. Issues are different. | **Add context for EACH issue** |
-    | "Before code is self-evident" | Nothing is self-evident. Extract and show ACTUAL code from project. | **Include actual Before code** |
-    | "After code follows patterns" | Patterns without code = abstract. Show concrete transformed code. | **Include actual After code** |
 
     ## Standards Compliance (MANDATORY)
 

--- a/docs/PROMPT_ENGINEERING.md
+++ b/docs/PROMPT_ENGINEERING.md
@@ -125,6 +125,74 @@ Action: STOP immediately. Report blocker. AWAIT user decision.
 
 ---
 
+## Code Transformation Context (CTC) Format
+
+When documenting refactoring issues, agents MUST provide a Code Transformation Context block for EACH non-compliant issue. This gives execution agents exact before/after code context.
+
+### Required Elements Checklist
+
+For EACH issue, output MUST include:
+
+- [ ] **Before (Current Code)** - Actual code extracted from the project with `file:line` reference
+- [ ] **After (Ring Standards)** - Transformed code following Ring/Lerian standards
+- [ ] **Standard References table** - Pattern, Source file, Section name, Line range
+- [ ] **Why This Transformation Matters** - Problem, Standard violated, Impact
+
+### Template Structure
+
+```markdown
+## Code Transformation Context: ISSUE-XXX
+
+### Before (Current Code)
+```{language}
+// file: {path}:{start_line}-{end_line}
+{actual code from project}
+```
+
+### After (Ring Standards)
+```{language}
+// file: {path}:{start_line}-{new_end_line}
+// ✅ Ring Standard: {Pattern Name} ({standards_file}:{section})
+{transformed code using lib-commons patterns}
+```
+
+### Standard References
+| Pattern Applied | Source | Section | Line Range |
+|-----------------|--------|---------|------------|
+| {pattern} | `{file}.md` | {Section Title} | :{derive_at_runtime} |
+
+### Why This Transformation Matters
+- **Problem:** {current issue}
+- **Ring Standard:** {which standard violated}
+- **Impact:** {business/technical impact}
+```
+
+### Line Range Derivation (MANDATORY)
+
+**⛔ DO NOT hardcode line numbers.** Standards files change over time.
+
+**REQUIRED:** Derive exact `:{line_range}` values at runtime by:
+1. Reading the current standards file (e.g., `golang.md`, `typescript.md`)
+2. Searching for the relevant section header
+3. Citing the actual line numbers from the live file
+
+**Example derivation:**
+```
+Agent reads golang.md → Finds "## Configuration Loading" at line 99
+Agent cites: "Configuration Loading (golang.md:99-230)"
+```
+
+### Anti-Rationalization
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "Comparison table is enough" | Table = WHAT. Context = HOW. Both REQUIRED. | **Add CTC block** |
+| "I'll describe the change" | Description ≠ executable context | **Show actual code** |
+| "Standards are obvious" | Obvious to you ≠ obvious to executor | **Include Standard References** |
+| "One example is enough" | Each issue needs its OWN context | **Add CTC for EACH issue** |
+
+---
+
 ## Key Principle
 
 The more assertive and explicit the language, the less room for AI to rationalize, assume, or make autonomous decisions. Strong language creates clear boundaries.


### PR DESCRIPTION
Adds mandatory before/after code transformation section for refactoring issues. This gives AI agents exact context about what to change by showing:

- BEFORE: Dynamic code extracted from the actual project being analyzed

- AFTER: Transformed code following Ring/Lerian standards (lib-commons patterns)

- Standard References: Exact section and line numbers from golang.md/typescript.md

Includes anti-rationalization table and PROMPT_ENGINEERING.md compliance (HARD GATE, NON-NEGOTIABLE, consequence phrases).

Generated-by: Claude
AI-Model: claude-opus-4-5-20251101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Introduced a mandatory Code Transformation Context (CTC) block for relevant task prompts, with structured BEFORE/AFTER sections, required-elements checklist, line-range derivation guidance, and anti-rationalization notes to standardize transformation documentation.
  * CTC template added in multiple locations for consistent coverage across tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->