### PR TITLE
fix(dev-refactor): clarify ring-default:codebase-explorer in OVERRIDE…

### DIFF
--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -37,7 +37,11 @@ This skill has its own specialized agents that MUST be used instead.
 - ❌ DO NOT use `Explore` agent (even though using-ring recommends it for codebase work)
 - ❌ DO NOT use `general-purpose` agent
 - ❌ DO NOT use `Plan` agent
-- ✅ ONLY use `ring-dev-team:*` agents (see list below)
+- ✅ Step 3: Use `ring-default:codebase-explorer` (ONLY agent allowed for codebase exploration)
+- ✅ Step 4+: Use `ring-dev-team:*` agents (specialists)
+
+**⛔ CRITICAL: For codebase exploration, use `ring-default:codebase-explorer`, NOT `Explore`.**
+The built-in `Explore` agent is FORBIDDEN. It does NOT load Ring standards.
 
 **Why?** The ring-dev-team:* agents have domain expertise and load Ring standards via WebFetch.
 Generic agents like Explore do NOT have this capability.
@@ -562,7 +566,7 @@ All specialist agent prompts MUST:
 | `ring-default:code-reviewer` | Wrong plugin, for review not analysis | SKILL FAILURE |
 
 **✅ EXCEPTION for Step 3 ONLY:**
-| `ring-default:codebase-explorer` | Explores codebase structure | **ALLOWED IN STEP 2.5 ONLY** - generates codebase-report.md for specialists |
+| `ring-default:codebase-explorer` | Explores codebase structure | **ALLOWED IN STEP 3 ONLY** - generates codebase-report.md for specialists |
 
 **After Step 3, ring-default:codebase-explorer is FORBIDDEN. Specialists compare the report with Ring standards.**
 


### PR DESCRIPTION
The orchestrator was using built-in Explore agent instead of ring-default:codebase-explorer because the OVERRIDE NOTICE only mentioned "ring-dev-team:*" agents without the codebase-explorer exception.

Changes:
- Added explicit "Step 3: Use ring-default:codebase-explorer" to OVERRIDE NOTICE
- Added critical warning: "NOT Explore" in bold
- Fixed remaining "Step 2.5 ONLY" reference to "Step 3 ONLY"

The OVERRIDE NOTICE now clearly states:
- Step 3: ring-default:codebase-explorer (for codebase exploration)
- Step 4+: ring-dev-team:* agents (for specialist analysis)
- Explore agent is FORBIDDEN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guidance to clarify agent responsibilities and enforce proper codebase exploration practices.
  * Added explicit instructions to ensure correct tools are used at each step of the development process.
  * Implemented stronger controls to maintain consistency with established standards throughout the workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->