### PR TITLE
fix(dev-refactor): add mandatory todo template to prevent Step 3 skip…

### DIFF
--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -48,6 +48,34 @@ Generic agents like Explore do NOT have this capability.
 
 ---
 
+## ⛔ FIRST ACTION (EXECUTE IMMEDIATELY)
+
+**Before reading any other section, you MUST use TodoWrite to create the task list.**
+
+```text
+╔═══════════════════════════════════════════════════════════════════════════════════════════╗
+║  ⛔ MANDATORY FIRST ACTION: USE TodoWrite TOOL NOW                                        ║
+║                                                                                           ║
+║  COPY this EXACT todo list using TodoWrite tool:                                          ║
+║                                                                                           ║
+║  1. "Validate PROJECT_RULES.md exists"                                                    ║
+║  2. "Detect project language"                                                             ║
+║  3. "Dispatch ring-default:codebase-explorer"  ← MANDATORY SEPARATE ITEM                  ║
+║  4. "Save codebase-report.md"                                                             ║
+║  5. "Dispatch ring-dev-team specialist agents"                                            ║
+║  6. "Generate findings.md"                                                                ║
+║  7. "Generate tasks.md"                                                                   ║
+║  8. "Get user approval"                                                                   ║
+║                                                                                           ║
+║  ⛔ If item 3 (codebase-explorer) is MISSING from your todo list → SKILL FAILURE          ║
+║  ⛔ If items 3 and 5 are COMBINED into one → SKILL FAILURE                                ║
+╚═══════════════════════════════════════════════════════════════════════════════════════════╝
+```
+
+**After TodoWrite completes → Continue to HARD GATES section below.**
+
+---
+
 ```text
 ╔═══════════════════════════════════════════════════════════════════════════════════════════╗
 ║  ⛔⛔⛔ CRITICAL: READ BEFORE DOING ANYTHING ⛔⛔⛔                                        ║
@@ -96,6 +124,45 @@ Generic agents like Explore do NOT have this capability.
 ```
 
 This skill analyzes an existing codebase to identify gaps between current implementation and project standards, then generates a structured refactoring plan compatible with the dev-cycle workflow.
+
+---
+
+## ⛔ MANDATORY TODO TEMPLATE (USE THIS EXACT LIST)
+
+**You MUST create a todo list with EXACTLY these items in this order:**
+
+```text
+TodoWrite:
+  todos:
+    - content: "Validate PROJECT_RULES.md exists"
+      status: "in_progress"
+      activeForm: "Validating PROJECT_RULES.md"
+    - content: "Detect project language (go.mod/package.json)"
+      status: "pending"
+      activeForm: "Detecting project language"
+    - content: "Dispatch ring-default:codebase-explorer (Step 3)"
+      status: "pending"
+      activeForm: "Dispatching codebase-explorer"
+    - content: "Save codebase-report.md artifact"
+      status: "pending"
+      activeForm: "Saving codebase-report.md"
+    - content: "Dispatch ring-dev-team specialist agents (Step 4)"
+      status: "pending"
+      activeForm: "Dispatching specialist agents"
+    - content: "Generate findings.md from agent outputs"
+      status: "pending"
+      activeForm: "Generating findings.md"
+    - content: "Generate tasks.md with finding references"
+      status: "pending"
+      activeForm: "Generating tasks.md"
+    - content: "Get user approval for refactoring"
+      status: "pending"
+      activeForm: "Getting user approval"
+```
+
+**⛔ CRITICAL: "Dispatch ring-default:codebase-explorer" MUST be a separate todo item.**
+**⛔ CRITICAL: Do NOT combine Steps 3 and 4 into one todo.**
+**⛔ CRITICAL: Step 3 MUST complete BEFORE Step 4 starts.**
 
 ---
 


### PR DESCRIPTION
…ping

Add FIRST ACTION section requiring TodoWrite with exact items before reading any other section. Include MANDATORY TODO TEMPLATE with explicit warning that codebase-explorer (Step 3) MUST be a separate todo item.

Prevents orchestrators from combining or skipping Step 3 when creating their internal task list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal developer workflow documentation to include enhanced pre-deployment validation steps and mandatory task sequencing requirements.

---

**Note:** This release contains no user-facing changes or feature updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->