### PR TITLE
fix(dev-refactor): add mandatory sequence to YAML description field

### DIFF
--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -1,9 +1,21 @@
 ---
 name: dev-refactor
 description: |
-  Analyzes existing codebase against standards to identify gaps in architecture, code quality,
-  testing, and DevOps. Auto-detects project language and uses appropriate agent standards
-  (Go, TypeScript, Frontend, DevOps, SRE). Generates refactoring tasks.md compatible with dev-cycle.
+  MANDATORY EXECUTION SEQUENCE (follow EXACTLY):
+
+  1. Validate docs/PROJECT_RULES.md exists
+  2. Detect project language (go.mod = Go, package.json = TypeScript)
+  3. DISPATCH ring-default:codebase-explorer FIRST (generates codebase-report.md)
+     - This step is MANDATORY and CANNOT be skipped
+     - Must complete BEFORE step 4
+  4. THEN dispatch ring-dev-team specialist agents (backend-engineer-golang, qa-analyst, etc.)
+  5. Generate findings.md from agent outputs
+  6. Generate tasks.md for dev-cycle
+
+  WARNING: If you skip step 3 (codebase-explorer) → SKILL FAILURE
+  WARNING: codebase-explorer and specialist agents are SEPARATE steps
+
+  Purpose: Analyzes existing codebase against standards to identify gaps.
 
 trigger: |
   - User wants to refactor existing project to follow standards


### PR DESCRIPTION
The orchestrator was ignoring markdown content and only reading the YAML frontmatter. Added mandatory execution sequence with explicit step-by-step instructions directly in the description field.

Key changes:
- Steps 1-6 listed in description with codebase-explorer as step 3
- Explicit warnings about skipping step 3 = SKILL FAILURE
- Clear separation: codebase-explorer FIRST, THEN specialist agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated dev-refactor skill documentation with mandatory execution sequence and gating rules.
  * Introduced hard gates, failure conditions, and explicit workflow steps to enforce strict operational flow and required tool usage throughout the process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->