### PR TITLE
refactor(commit): replace AI identification with stealth tracing

### DIFF
--- a/default/commands/commit.md
+++ b/default/commands/commit.md
@@ -170,16 +170,18 @@ git commit \
 
 Trailers can be queried programmatically:
 
-```bash
-# Find all commits with internal system reference
-git log --all --grep="X-Lerian-Ref: 0x1"
+**Note:** `git log --grep` searches commit message content only, not trailers. Use `--format` with `%(trailers)` to query trailer values.
 
-# Show trailers for a commit
+```bash
+# Find all commits with specific X-Lerian-Ref trailer value
+git log --all --format="%H %s %(trailers:key=X-Lerian-Ref,valueonly)" | grep "0x1"
+
+# Show all trailers for a commit
 git log -1 --format="%(trailers)"
 
-# Filter by specific trailer
+# Filter commits by trailer existence (any value)
 git log --all --format="%H %s" | while read hash msg; do
-  git log -1 --format="%(trailers:key=X-Lerian-Ref)" $hash | grep -q "0x1" && echo "$hash $msg"
+  git log -1 --format="%(trailers:key=X-Lerian-Ref)" $hash | grep -q "." && echo "$hash $msg"
 done
 ```
 


### PR DESCRIPTION
Replace multiple AI-specific trailers (Generated-by, AI-Model) with single static internal reference (X-Lerian-Ref: 0x1). Maintains traceability while keeping commit messages completely clean and professional.

X-Lerian-Ref: 0x1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Revised commit message guidelines to replace visible AI attribution with internal tracing terminology and require the X-Lerian-Ref trailer placed after message content.
  * Updated examples, rules, step-by-step guidance, FAQs, and anti-patterns to reflect the new tracing conventions and prohibit visible markers/hashtags in commits.
  * No user-facing functionality or public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->