### PR TITLE
fix: use fully qualified agent names (ring-{plugin}:{agent})

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,11 +133,11 @@ dev-team/agents/
 **Key Characteristics:**
 - Invoked via Claude's `Task` tool with `subagent_type`
 - Must specify model (typically "opus" for comprehensive analysis)
-- Review agents run in parallel (3 reviewers dispatch simultaneously via `/ring-default:codereview` command)
+- Review agents run in parallel (3 reviewers dispatch simultaneously via `/codereview` command)
 - Developer agents provide specialized domain expertise
 - Return structured reports with severity-based findings
 
-**Note:** Parallel review orchestration is handled by the `/ring-default:codereview` command
+**Note:** Parallel review orchestration is handled by the `/codereview` command
 
 **Standards Compliance Output (ring-dev-team agents):**
 
@@ -155,14 +155,14 @@ All ring-dev-team agents include a `## Standards Compliance` section in their ou
 | Invocation Context | Standards Compliance | Detection Mechanism |
 |--------------------|---------------------|---------------------|
 | Direct agent call | Optional | N/A |
-| Via `ring-dev-team:dev-cycle` skill | Optional | N/A |
-| Via `ring-dev-team:dev-refactor` skill | **MANDATORY** | Prompt contains `**MODE: ANALYSIS ONLY**` |
+| Via `dev-cycle` skill | Optional | N/A |
+| Via `dev-refactor` skill | **MANDATORY** | Prompt contains `**MODE: ANALYSIS ONLY**` |
 
 **How Enforcement Works:**
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│  User invokes: /ring-dev-team:dev-refactor                          │
+│  User invokes: /dev-refactor                          │
 │         ↓                                                           │
 │  dev-refactor skill dispatches agents with prompt:                  │
 │  "**MODE: ANALYSIS ONLY** - Compare codebase with Ring standards"   │
@@ -176,13 +176,13 @@ All ring-dev-team agents include a `## Standards Compliance` section in their ou
 ```
 
 **Affected Agents:**
-- `ring-dev-team:backend-engineer-golang` → loads `golang.md`
-- `ring-dev-team:backend-engineer-typescript` → loads `typescript.md`
-- `ring-dev-team:devops-engineer` → loads `devops.md`
-- `ring-dev-team:frontend-bff-engineer-typescript` → loads `frontend.md`
-- `ring-dev-team:frontend-designer` → loads `frontend.md`
-- `ring-dev-team:qa-analyst` → loads `qa.md`
-- `ring-dev-team:sre` → loads `sre.md`
+- `backend-engineer-golang` → loads `golang.md`
+- `backend-engineer-typescript` → loads `typescript.md`
+- `devops-engineer` → loads `devops.md`
+- `frontend-bff-engineer-typescript` → loads `frontend.md`
+- `frontend-designer` → loads `frontend.md`
+- `qa-analyst` → loads `qa.md`
+- `sre` → loads `sre.md`
 
 **Output Format (when non-compliant):**
 ```markdown
@@ -215,15 +215,15 @@ All ring-dev-team agents include a `## Standards Compliance` section in their ou
 **Structure:**
 ```
 default/commands/
-├── brainstorm.md       # /ring-default:brainstorm - Socratic design refinement
-├── write-plan.md       # /ring-default:write-plan - Implementation planning
-├── execute-plan.md     # /ring-default:execute-plan - Batch execution
-├── codereview.md       # /ring-default:codereview - Parallel 3-reviewer dispatch
-└── worktree.md         # /ring-default:worktree - Git worktree creation
+├── brainstorm.md       # /brainstorm - Socratic design refinement
+├── write-plan.md       # /write-plan - Implementation planning
+├── execute-plan.md     # /execute-plan - Batch execution
+├── codereview.md       # /codereview - Parallel 3-reviewer dispatch
+└── worktree.md         # /worktree - Git worktree creation
 
 pm-team/commands/
-├── pre-dev-feature.md  # /ring-pm-team:pre-dev-feature - 3-gate workflow
-└── pre-dev-full.md     # /ring-pm-team:pre-dev-full - 8-gate workflow
+├── pre-dev-feature.md  # /pre-dev-feature - 3-gate workflow
+└── pre-dev-full.md     # /pre-dev-full - 8-gate workflow
 ```
 
 **Key Characteristics:**
@@ -358,7 +358,7 @@ sequenceDiagram
     participant business-reviewer
     participant security-reviewer
 
-    User->>Claude: /ring-default:codereview
+    User->>Claude: /codereview
     Note over Claude: Command provides<br/>parallel review workflow
 
     Claude->>Task Tool: Dispatch 3 parallel tasks
@@ -386,7 +386,7 @@ sequenceDiagram
 Ring leverages four primary Claude Code tools:
 
 1. **Skill Tool**
-   - Invokes skills by name: `skill: "ring-default:test-driven-development"`
+   - Invokes skills by name: `skill: "test-driven-development"`
    - Skills expand into full instructions within conversation
    - Skill content becomes part of Claude's working context
 
@@ -401,7 +401,7 @@ Ring leverages four primary Claude Code tools:
    - Provides progress visibility to users
 
 4. **SlashCommand Tool**
-   - Executes commands: `SlashCommand(command="/ring-default:brainstorm")`
+   - Executes commands: `SlashCommand(command="/brainstorm")`
    - Commands expand to skill/agent invocations
    - Provides user-friendly shortcuts
 
@@ -432,10 +432,10 @@ User Request → using-ring check → Relevant skill?
 ### Pattern 2: Parallel Review Execution
 
 ```
-Review Request → /ring-default:codereview → Dispatch 3 Tasks (parallel)
-    ├─ ring-default:code-reviewer           ─┐
-    ├─ ring-default:business-logic-reviewer ─┼─→ Aggregate findings → Handle by severity
-    └─ ring-default:security-reviewer       ─┘
+Review Request → /codereview → Dispatch 3 Tasks (parallel)
+    ├─ code-reviewer           ─┐
+    ├─ business-logic-reviewer ─┼─→ Aggregate findings → Handle by severity
+    └─ security-reviewer       ─┘
 ```
 
 **Implementation:** Single message with 3 Task tool calls ensures parallel execution. All reviewers work independently and return simultaneously.
@@ -443,7 +443,7 @@ Review Request → /ring-default:codereview → Dispatch 3 Tasks (parallel)
 ### Pattern 3: Skill-to-Command Mapping
 
 ```
-User: /ring-default:brainstorm
+User: /brainstorm
     ↓
 SlashCommand Tool
     ↓
@@ -451,7 +451,7 @@ commands/brainstorm.md
     ↓
 "Use and follow the brainstorming skill"
     ↓
-Skill Tool: ring-default:brainstorming
+Skill Tool: brainstorming
     ↓
 skills/brainstorming/SKILL.md
 ```
@@ -489,9 +489,9 @@ Complex Skill → TodoWrite tracking
 - Some commands (like review) orchestrate multiple components
 
 **Example Mappings:**
-- `/ring-default:brainstorm` → `ring-default:brainstorming` skill
-- `/ring-default:write-plan` → `ring-default:writing-plans` skill
-- `/ring-default:codereview` → dispatches 3 parallel review agents (`ring-default:code-reviewer`, `ring-default:business-logic-reviewer`, `ring-default:security-reviewer`)
+- `/brainstorm` → `brainstorming` skill
+- `/write-plan` → `writing-plans` skill
+- `/codereview` → dispatches 3 parallel review agents (`code-reviewer`, `business-logic-reviewer`, `security-reviewer`)
 
 ### Skills ↔ Shared Patterns
 
@@ -569,7 +569,7 @@ SKILL.md frontmatter → generate-skills-ref.py → formatted overview → sessi
 1. Create `{plugin}/agents/{name}.md` with model specification
 2. Include YAML frontmatter: `name`, `description`, `model`, `version`
 3. Invoke via Task tool with `subagent_type="ring-{plugin}:{name}"`
-4. Review agents can run in parallel via `/ring-default:codereview`
+4. Review agents can run in parallel via `/codereview`
 5. Developer agents provide domain expertise via direct Task invocation
 
 ### Adding New Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When creating or modifying ANY agent in `*/agents/*.md`:
 3. **NEVER skip TDD's RED phase** - Test must fail before implementation
 4. **NEVER ignore skill when applicable** - "Simple task" is not an excuse
 5. **NEVER use panic() in Go** - Error handling required
-6. **NEVER commit manually** - Always use `/ring-default:commit` command
+6. **NEVER commit manually** - Always use `/commit` command
 7. **NEVER assume compliance** - VERIFY with evidence
 
 ### 4. Fully Qualified Names (ALWAYS)
@@ -56,10 +56,10 @@ When modifying standards files (`dev-team/docs/standards/*.md`):
 
 | Standards File | Agents That Use It |
 |----------------|-------------------|
-| `golang.md` | `ring-dev-team:backend-engineer-golang`, `ring-dev-team:qa-analyst` |
-| `typescript.md` | `ring-dev-team:backend-engineer-typescript`, `ring-dev-team:frontend-bff-engineer-typescript`, `ring-dev-team:qa-analyst` |
-| `frontend.md` | `ring-dev-team:frontend-engineer`, `ring-dev-team:frontend-designer` |
-| `devops.md` | `ring-dev-team:devops-engineer` |
+| `golang.md` | `backend-engineer-golang`, `qa-analyst` |
+| `typescript.md` | `backend-engineer-typescript`, `frontend-bff-engineer-typescript`, `qa-analyst` |
+| `frontend.md` | `frontend-engineer`, `frontend-designer` |
+| `devops.md` | `devops-engineer` |
 | `sre.md` | `sre` |
 
 **Section Index Location:** `dev-team/skills/shared-patterns/standards-coverage-table.md` → "Agent → Standards Section Index"
@@ -68,14 +68,14 @@ When modifying standards files (`dev-team/docs/standards/*.md`):
 
 | Agent | Standards File | Section Count |
 |-------|----------------|---------------|
-| `ring-dev-team:backend-engineer-golang` | golang.md | See coverage table |
-| `ring-dev-team:backend-engineer-typescript` | typescript.md | See coverage table |
-| `ring-dev-team:frontend-bff-engineer-typescript` | typescript.md | See coverage table |
-| `ring-dev-team:frontend-engineer` | frontend.md | See coverage table |
-| `ring-dev-team:frontend-designer` | frontend.md | See coverage table |
-| `ring-dev-team:devops-engineer` | devops.md | See coverage table |
+| `backend-engineer-golang` | golang.md | See coverage table |
+| `backend-engineer-typescript` | typescript.md | See coverage table |
+| `frontend-bff-engineer-typescript` | typescript.md | See coverage table |
+| `frontend-engineer` | frontend.md | See coverage table |
+| `frontend-designer` | frontend.md | See coverage table |
+| `devops-engineer` | devops.md | See coverage table |
 | `sre` | sre.md | See coverage table |
-| `ring-dev-team:qa-analyst` | golang.md OR typescript.md | See coverage table |
+| `qa-analyst` | golang.md OR typescript.md | See coverage table |
 
 **⛔ If section counts in skills don't match this table → Update the skill.**
 
@@ -363,17 +363,17 @@ git log --oneline -20              # Recent commits show hook development
 git worktree list                  # Check isolated development branches
 
 # Skill invocation (via Claude Code)
-Skill tool: "ring-default:test-driven-development"  # Enforce TDD workflow
-Skill tool: "ring-default:systematic-debugging"     # Debug with 4-phase analysis
-Skill tool: "ring-default:using-ring"               # Load mandatory workflows
+Skill tool: "test-driven-development"  # Enforce TDD workflow
+Skill tool: "systematic-debugging"     # Debug with 4-phase analysis
+Skill tool: "using-ring"               # Load mandatory workflows
 
 # Slash commands
-/ring-default:codereview          # Dispatch 3 parallel reviewers
-/ring-default:brainstorm          # Socratic design refinement
-/ring-pm-team:pre-dev-feature     # <2 day features (4 gates)
-/ring-pm-team:pre-dev-full        # ≥2 day features (9 gates)
-/ring-default:execute-plan        # Batch execution with checkpoints
-/ring-default:worktree            # Create isolated development branch
+/codereview          # Dispatch 3 parallel reviewers
+/brainstorm          # Socratic design refinement
+/pre-dev-feature     # <2 day features (4 gates)
+/pre-dev-full        # ≥2 day features (9 gates)
+/execute-plan        # Batch execution with checkpoints
+/worktree            # Create isolated development branch
 
 # Hook validation (from default plugin)
 bash default/hooks/session-start.sh      # Test skill loading
@@ -389,9 +389,9 @@ python default/hooks/generate-skills-ref.py # Generate skill overview
 | Add skill | `mkdir default/skills/name/` → create `SKILL.md` with frontmatter |
 | Add agent | Create `*/agents/name.md` → verify required sections per [Agent Design](docs/AGENT_DESIGN.md) |
 | Modify hooks | Edit `*/hooks/hooks.json` → test with `bash */hooks/session-start.sh` |
-| Code review | `/ring-default:codereview` dispatches 3 parallel reviewers |
-| Pre-dev (small) | `/ring-pm-team:pre-dev-feature` → 4-gate workflow |
-| Pre-dev (large) | `/ring-pm-team:pre-dev-full` → 9-gate workflow |
+| Code review | `/codereview` dispatches 3 parallel reviewers |
+| Pre-dev (small) | `/pre-dev-feature` → 4-gate workflow |
+| Pre-dev (large) | `/pre-dev-full` → 9-gate workflow |
 
 See [docs/WORKFLOWS.md](docs/WORKFLOWS.md) for detailed instructions.
 
@@ -410,7 +410,7 @@ See [docs/WORKFLOWS.md](docs/WORKFLOWS.md) for detailed instructions.
 ### Naming Conventions
 - Skills: `kebab-case` matching directory name
 - Agents: `{domain}-reviewer.md` format
-- Commands: `/ring-{plugin}:{action}` format (e.g., `/ring-default:brainstorm`, `/ring-pm-team:pre-dev-feature`)
+- Commands: `/ring-{plugin}:{action}` format (e.g., `/brainstorm`, `/pre-dev-feature`)
 - Hooks: `{event}-{purpose}.sh` format
 
 #### Agent/Skill/Command Invocation
@@ -457,7 +457,7 @@ See [docs/AGENT_DESIGN.md](docs/AGENT_DESIGN.md) for complete schema definitions
 - Announce non-obvious skill usage
 
 # Commit compliance (default/commands/commit.md)
-- ALWAYS use /ring-default:commit for all commits
+- ALWAYS use /commit for all commits
 - Never write git commit commands manually
 - Command enforces: conventional commits, trailers, no emoji signatures
 - MUST use --trailer parameter for AI identification (NOT in message body)
@@ -471,7 +471,7 @@ See [docs/AGENT_DESIGN.md](docs/AGENT_DESIGN.md) for complete schema definitions
 
 The system loads at SessionStart (from `default/` plugin):
 1. `default/hooks/session-start.sh` - Loads skill quick reference via `generate-skills-ref.py`
-2. `ring-default:using-ring` skill - Injected as mandatory workflow
+2. `using-ring` skill - Injected as mandatory workflow
 3. `default/hooks/claude-md-reminder.sh` - Reminds about CLAUDE.md on prompt submit
 
 **Monorepo Context:**

--- a/default/agents/business-logic-reviewer.md
+++ b/default/agents/business-logic-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-default:business-logic-reviewer
+name: business-logic-reviewer
 version: 5.2.0
 description: "Correctness Review: reviews domain correctness, business rules, edge cases, and requirements. Uses mental execution to trace code paths and analyzes full file context, not just changes. Runs in parallel with code-reviewer and security-reviewer for fast feedback."
 type: reviewer
@@ -82,7 +82,7 @@ Missing ANY required section will cause your entire review to be rejected. Alway
 
 ## Your Role
 
-**Position:** Parallel reviewer (runs simultaneously with ring-default:code-reviewer and ring-default:security-reviewer)
+**Position:** Parallel reviewer (runs simultaneously with code-reviewer and security-reviewer)
 **Purpose:** Validate business correctness, requirements, and edge cases
 **Independence:** Review independently - do not assume other reviewers will catch issues outside your domain
 
@@ -638,7 +638,7 @@ test('scenario that fails', () => {
 
 **If PASS:**
 - ✅ Business logic review complete
-- ✅ Findings will be aggregated with ring-default:code-reviewer and ring-default:security-reviewer results
+- ✅ Findings will be aggregated with code-reviewer and security-reviewer results
 
 **If FAIL:**
 - ❌ Critical/High/Medium issues must be fixed

--- a/default/agents/code-reviewer.md
+++ b/default/agents/code-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-default:code-reviewer
+name: code-reviewer
 version: 3.2.0
 description: "Foundation Review: Reviews code quality, architecture, design patterns, algorithmic flow, and maintainability. Runs in parallel with business-logic-reviewer and security-reviewer for fast feedback."
 type: reviewer

--- a/default/agents/codebase-explorer.md
+++ b/default/agents/codebase-explorer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-default:codebase-explorer
+name: codebase-explorer
 version: 1.3.0
 description: "Deep codebase exploration agent for architecture understanding, pattern discovery, and comprehensive code analysis. Uses Opus for thorough analysis vs built-in Explore's Haiku speed-focus."
 type: exploration
@@ -199,7 +199,7 @@ Use this matrix to quickly determine the appropriate exploration depth:
 | "What's the architecture of X?" | Thorough | 30-45 min | "What's the architecture of the payment system?" |
 | "What patterns does X use?" | Thorough | 30-45 min | "What patterns does this monorepo use?" |
 
-**Multi-Area Exploration:** For questions spanning multiple domains (e.g., "How do auth, payments, and notifications integrate?"), use `ring-default:dispatching-parallel-agents` skill to launch parallel exploration agents, one per domain.
+**Multi-Area Exploration:** For questions spanning multiple domains (e.g., "How do auth, payments, and notifications integrate?"), use `dispatching-parallel-agents` skill to launch parallel exploration agents, one per domain.
 
 ## Blocker Criteria - STOP and Report
 

--- a/default/agents/security-reviewer.md
+++ b/default/agents/security-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-default:security-reviewer
+name: security-reviewer
 version: 3.2.0
 description: "Safety Review: Reviews vulnerabilities, authentication, input validation, and OWASP risks. Runs in parallel with code-reviewer and business-logic-reviewer for fast feedback."
 type: reviewer

--- a/default/agents/write-plan.md
+++ b/default/agents/write-plan.md
@@ -1,5 +1,5 @@
 ---
-name: ring-default:write-plan
+name: write-plan
 version: 1.1.0
 description: "Implementation Planning: Creates comprehensive plans for engineers with zero codebase context. Plans are executable by developers unfamiliar with the codebase, with bite-sized tasks (2-5 min each) and code review checkpoints."
 type: planning
@@ -294,7 +294,7 @@ If NO to any → Add more detail
 ```markdown
 # [Feature Name] Implementation Plan
 
-> **For Agents:** REQUIRED SUB-SKILL: Use ring-default:executing-plans to implement this plan task-by-task.
+> **For Agents:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
 
 **Goal:** [One sentence describing what this builds]
 
@@ -482,20 +482,20 @@ After saving the plan to `docs/plans/<filename>.md`, return to the main conversa
 
 **1. Subagent-Driven (this session)** - I dispatch fresh subagent per task, review between tasks, fast iteration
 
-**2. Parallel Session (separate)** - Open new session with ring-default:executing-plans, batch execution with checkpoints
+**2. Parallel Session (separate)** - Open new session with executing-plans, batch execution with checkpoints
 
 **Which approach?"**
 
 Then wait for human to choose.
 
 **If Subagent-Driven chosen:**
-- Inform: **REQUIRED SUB-SKILL:** Use ring-default:subagent-driven-development
+- Inform: **REQUIRED SUB-SKILL:** Use subagent-driven-development
 - Stay in current session
 - Fresh subagent per task + code review between tasks
 
 **If Parallel Session chosen:**
 - Guide them to open new session in the worktree
-- Inform: **REQUIRED SUB-SKILL:** New session uses ring-default:executing-plans
+- Inform: **REQUIRED SUB-SKILL:** New session uses executing-plans
 - Provide exact command: `cd <worktree-path> && claude`
 
 ## Critical Reminders

--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:backend-engineer-golang
+name: backend-engineer-golang
 version: 1.2.4
 description: Senior Backend Engineer specialized in Go for high-demand financial systems. Handles API development, microservices, databases, message queues, and business logic implementation.
 type: specialist
@@ -431,7 +431,7 @@ When reporting issues in existing code:
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the codebase against Lerian/Ring Go Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the codebase against Lerian/Ring Go Standards.
 
 ### ⛔ HARD GATE: ALWAYS Compare ALL Categories
 
@@ -552,7 +552,7 @@ coverage: 87.3% of statements
 
 ## What This Agent Does NOT Handle
 
-- Frontend/UI development (use `ring-dev-team:frontend-bff-engineer-typescript`)
-- Docker/docker-compose configuration (use `ring-dev-team:devops-engineer`)
-- Observability validation (use `ring-dev-team:sre`)
-- End-to-end test scenarios and manual testing (use `ring-dev-team:qa-analyst`)
+- Frontend/UI development (use `frontend-bff-engineer-typescript`)
+- Docker/docker-compose configuration (use `devops-engineer`)
+- Observability validation (use `sre`)
+- End-to-end test scenarios and manual testing (use `qa-analyst`)

--- a/dev-team/agents/backend-engineer-typescript.md
+++ b/dev-team/agents/backend-engineer-typescript.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:backend-engineer-typescript
+name: backend-engineer-typescript
 version: 1.3.5
 description: Senior Backend Engineer specialized in TypeScript/Node.js for scalable systems. Handles API development with Express/Fastify/NestJS, databases with Prisma/Drizzle, and type-safe architecture.
 type: specialist
@@ -498,7 +498,7 @@ When reporting issues in existing code:
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the codebase against Lerian/Ring TypeScript Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the codebase against Lerian/Ring TypeScript Standards.
 
 ### Sections to Check (MANDATORY)
 
@@ -619,8 +619,8 @@ Coverage: 89.2%
 
 ## What This Agent Does NOT Handle
 
-- Frontend/UI development (use `ring-dev-team:frontend-bff-engineer-typescript`)
-- Docker/docker-compose configuration (use `ring-dev-team:devops-engineer`)
-- Observability validation (use `ring-dev-team:sre`)
-- End-to-end test scenarios and manual testing (use `ring-dev-team:qa-analyst`)
-- Visual design and component styling (use `ring-dev-team:frontend-designer`)
+- Frontend/UI development (use `frontend-bff-engineer-typescript`)
+- Docker/docker-compose configuration (use `devops-engineer`)
+- Observability validation (use `sre`)
+- End-to-end test scenarios and manual testing (use `qa-analyst`)
+- Visual design and component styling (use `frontend-designer`)

--- a/dev-team/agents/devops-engineer.md
+++ b/dev-team/agents/devops-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:devops-engineer
+name: devops-engineer
 version: 1.3.1
 description: Senior DevOps Engineer specialized in cloud infrastructure for financial services. Handles containerization, IaC, and local development environments.
 type: specialist
@@ -291,7 +291,7 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the infrastructure against Lerian/Ring DevOps Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the infrastructure against Lerian/Ring DevOps Standards.
 
 ### Sections to Check (MANDATORY)
 
@@ -506,8 +506,8 @@ Stopping app_postgres_1 ... done
 
 ## What This Agent Does NOT Handle
 
-- Application code development (use `ring-dev-team:backend-engineer-golang`, `ring-dev-team:backend-engineer-typescript`, or `ring-dev-team:frontend-bff-engineer-typescript`)
-- Production monitoring and incident response (use `ring-dev-team:sre`)
-- Test case design and execution (use `ring-dev-team:qa-analyst`)
-- Application performance optimization (use `ring-dev-team:sre`)
-- Business logic implementation (use `ring-dev-team:backend-engineer-golang`)
+- Application code development (use `backend-engineer-golang`, `backend-engineer-typescript`, or `frontend-bff-engineer-typescript`)
+- Production monitoring and incident response (use `sre`)
+- Test case design and execution (use `qa-analyst`)
+- Application performance optimization (use `sre`)
+- Business logic implementation (use `backend-engineer-golang`)

--- a/dev-team/agents/frontend-bff-engineer-typescript.md
+++ b/dev-team/agents/frontend-bff-engineer-typescript.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:frontend-bff-engineer-typescript
+name: frontend-bff-engineer-typescript
 version: 2.1.5
 description: Senior BFF (Backend for Frontend) Engineer specialized in Next.js API Routes with Clean Architecture, DDD, and Hexagonal patterns. Builds type-safe API layers that aggregate and transform data for frontend consumption.
 type: specialist
@@ -405,7 +405,7 @@ If code is ALREADY compliant with all standards:
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the BFF layer against Lerian/Ring TypeScript Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the BFF layer against Lerian/Ring TypeScript Standards.
 
 ### ⛔ HARD GATE: ALWAYS Compare ALL Categories
 
@@ -643,8 +643,8 @@ Coverage: 88.5%
 
 ## What This Agent Does NOT Handle
 
-- Visual design specifications (use `ring-dev-team:frontend-designer`)
-- Docker/CI-CD configuration (use `ring-dev-team:devops-engineer`)
-- Server infrastructure and monitoring (use `ring-dev-team:sre`)
-- Backend microservices (use `ring-dev-team:backend-engineer-typescript`)
-- Database schema design (use `ring-dev-team:backend-engineer`)
+- Visual design specifications (use `frontend-designer`)
+- Docker/CI-CD configuration (use `devops-engineer`)
+- Server infrastructure and monitoring (use `sre`)
+- Backend microservices (use `backend-engineer-typescript`)
+- Database schema design (use `backend-engineer`)

--- a/dev-team/agents/frontend-designer.md
+++ b/dev-team/agents/frontend-designer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:frontend-designer
+name: frontend-designer
 version: 1.2.2
 description: Senior UI/UX Designer with full design team capabilities - UX research, information architecture, visual design, content design, accessibility, mobile/touch, i18n, data visualization, and prototyping. Produces specifications, not code.
 type: specialist
@@ -126,7 +126,7 @@ You are a Senior UI/UX Designer with full design team capabilities. You cover al
 
 | Pressure Type | Request | Agent Response |
 |---------------|---------|----------------|
-| **Write Code** | "Just implement this quickly" | "I produce specifications only. Use `ring-dev-team:frontend-bff-engineer-typescript` for implementation." |
+| **Write Code** | "Just implement this quickly" | "I produce specifications only. Use `frontend-bff-engineer-typescript` for implementation." |
 | **Skip Standards** | "No time for PROJECT_RULES.md" | "Standards loading is MANDATORY. Cannot proceed without design context." |
 | **Generic Design** | "Use standard colors/fonts" | "Generic = AI aesthetic. DISTINCTIVE design requires intentional choices." |
 | **Skip A11y** | "Accessibility later" | "WCAG AA is REQUIRED, not optional. Accessibility is part of design." |
@@ -178,7 +178,7 @@ If you catch yourself thinking ANY of these, STOP immediately:
 **If request is "implement X":**
 1. Create SPECIFICATION for X
 2. Document in handoff format
-3. Recommend: "Hand off to `ring-dev-team:frontend-bff-engineer-typescript` for implementation"
+3. Recommend: "Hand off to `frontend-bff-engineer-typescript` for implementation"
 4. Do NOT write implementation code
 
 ## What This Agent Does
@@ -769,8 +769,8 @@ When ambiguity exists, present options with trade-offs:
 ## Handoff to Frontend Engineers (Knowledge)
 
 **After completing design specifications, hand off to:**
-- `ring-dev-team:frontend-bff-engineer-typescript` - For BFF layer and API orchestration
-- `ring-dev-team:frontend-bff-engineer-typescript` - For BFF layer
+- `frontend-bff-engineer-typescript` - For BFF layer and API orchestration
+- `frontend-bff-engineer-typescript` - For BFF layer
 
 ### Required Handoff Sections
 
@@ -1062,7 +1062,7 @@ If design is ALREADY distinctive and standards-compliant:
 
 ## Next Steps
 
-- Handoff to `ring-dev-team:frontend-bff-engineer-typescript` for implementation
+- Handoff to `frontend-bff-engineer-typescript` for implementation
 - Create Figma prototype for stakeholder review
 
 ## Standards Compliance
@@ -1086,10 +1086,10 @@ If design is ALREADY distinctive and standards-compliant:
 ## What This Agent Does NOT Handle
 
 **This agent does NOT write code.** For implementation, hand off specifications to:
-- `ring-dev-team:frontend-bff-engineer-typescript` - BFF layer for frontend
-- `ring-dev-team:frontend-bff-engineer-typescript` - BFF layer implementation (API Routes)
-- `ring-dev-team:backend-engineer-golang` - Backend API development (Go)
-- `ring-dev-team:backend-engineer-typescript` - Backend API development (TypeScript)
-- `ring-dev-team:devops-engineer` - Docker/CI-CD configuration
-- `ring-dev-team:qa-analyst` - Testing strategy and QA automation
-- `ring-dev-team:sre` - Performance optimization and monitoring
+- `frontend-bff-engineer-typescript` - BFF layer for frontend
+- `frontend-bff-engineer-typescript` - BFF layer implementation (API Routes)
+- `backend-engineer-golang` - Backend API development (Go)
+- `backend-engineer-typescript` - Backend API development (TypeScript)
+- `devops-engineer` - Docker/CI-CD configuration
+- `qa-analyst` - Testing strategy and QA automation
+- `sre` - Performance optimization and monitoring

--- a/dev-team/agents/frontend-engineer.md
+++ b/dev-team/agents/frontend-engineer.md
@@ -1,6 +1,6 @@
 
 ---
-name: ring-dev-team:frontend-engineer
+name: frontend-engineer
 version: 3.2.4
 description: Senior Frontend Engineer specialized in React/Next.js for financial dashboards and enterprise applications. Expert in App Router, Server Components, accessibility, performance optimization, and modern React patterns.
 type: specialist
@@ -532,7 +532,7 @@ You have deep expertise in accessibility. Apply WCAG 2.1 AA standards.
 
 ## Receiving Handoff from Frontend Designer
 
-**When receiving a Handoff Contract from `ring-dev-team:frontend-designer`, follow this process:**
+**When receiving a Handoff Contract from `frontend-designer`, follow this process:**
 
 ### Step 1: Validate Handoff Contract
 
@@ -766,7 +766,7 @@ See [shared-patterns/shared-anti-rationalization.md](../skills/shared-patterns/s
 
 ## Integration with BFF Engineer
 
-**This agent consumes API endpoints provided by `ring-dev-team:frontend-bff-engineer-typescript`.**
+**This agent consumes API endpoints provided by `frontend-bff-engineer-typescript`.**
 
 ### Receiving BFF API Contract
 
@@ -802,7 +802,7 @@ See [shared-patterns/shared-anti-rationalization.md](../skills/shared-patterns/s
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the frontend implementation against Lerian/Ring Frontend Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the frontend implementation against Lerian/Ring Frontend Standards.
 
 ### Sections to Check (MANDATORY)
 
@@ -871,10 +871,10 @@ No migration actions required.
 
 ## What This Agent Does NOT Handle
 
-- **BFF/API Routes development** → use `ring-dev-team:frontend-bff-engineer-typescript`
-- **Backend API development** → use `ring-dev-team:backend-engineer-*`
-- **Docker/CI-CD configuration** → use `ring-dev-team:devops-engineer`
-- **Server infrastructure and monitoring** → use `ring-dev-team:sre`
-- **API contract testing and load testing** → use `ring-dev-team:qa-analyst`
-- **Database design and migrations** → use `ring-dev-team:backend-engineer-*`
-- **Design specifications and visual design** → use `ring-dev-team:frontend-designer`
+- **BFF/API Routes development** → use `frontend-bff-engineer-typescript`
+- **Backend API development** → use `backend-engineer-*`
+- **Docker/CI-CD configuration** → use `devops-engineer`
+- **Server infrastructure and monitoring** → use `sre`
+- **API contract testing and load testing** → use `qa-analyst`
+- **Database design and migrations** → use `backend-engineer-*`
+- **Design specifications and visual design** → use `frontend-designer`

--- a/dev-team/agents/prompt-quality-reviewer.md
+++ b/dev-team/agents/prompt-quality-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:prompt-quality-reviewer
+name: prompt-quality-reviewer
 version: 2.0.1
 description: |
   Expert Agent Quality Analyst specialized in evaluating AI agent executions against best practices,

--- a/dev-team/agents/qa-analyst.md
+++ b/dev-team/agents/qa-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:qa-analyst
+name: qa-analyst
 version: 1.3.0
 description: Senior Quality Assurance Analyst specialized in testing financial systems. Handles test strategy, API testing, E2E automation, performance testing, and compliance validation.
 type: specialist
@@ -430,7 +430,7 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the test implementation against Lerian/Ring QA Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the test implementation against Lerian/Ring QA Standards.
 
 ### Sections to Check (MANDATORY)
 
@@ -1131,8 +1131,8 @@ Tests: 3 passed | Coverage: 72%
 
 ## What This Agent Does NOT Handle
 
-- Application code development (use `ring-dev-team:backend-engineer-golang`, `ring-dev-team:backend-engineer-typescript`, or `ring-dev-team:frontend-bff-engineer-typescript`)
-- Docker/docker-compose configuration (use `ring-dev-team:devops-engineer`)
-- Observability validation (use `ring-dev-team:sre`)
-- Infrastructure provisioning (use `ring-dev-team:devops-engineer`)
-- Performance optimization implementation (use `ring-dev-team:sre` or language-specific backend engineer)
+- Application code development (use `backend-engineer-golang`, `backend-engineer-typescript`, or `frontend-bff-engineer-typescript`)
+- Docker/docker-compose configuration (use `devops-engineer`)
+- Observability validation (use `sre`)
+- Infrastructure provisioning (use `devops-engineer`)
+- Performance optimization implementation (use `sre` or language-specific backend engineer)

--- a/dev-team/agents/sre.md
+++ b/dev-team/agents/sre.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:sre
+name: sre
 version: 1.4.0
 description: Senior Site Reliability Engineer specialized in VALIDATING observability implementations for high-availability financial systems. Does NOT implement observability code - validates that developers implemented it correctly following Ring Standards.
 type: specialist
@@ -287,7 +287,7 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 
 See [docs/AGENT_DESIGN.md](https://raw.githubusercontent.com/LerianStudio/ring/main/docs/AGENT_DESIGN.md) for canonical output schema requirements.
 
-When invoked from the `ring-dev-team:dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the observability implementation against Lerian/Ring SRE Standards.
+When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST produce a Standards Compliance section comparing the observability implementation against Lerian/Ring SRE Standards.
 
 ### Sections to Check (MANDATORY)
 
@@ -482,11 +482,11 @@ $ docker-compose logs app | head -5 | jq .
 
 | Task | Who Handles It |
 |------|---------------|
-| **Implementing health endpoints** | `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript` |
-| **Implementing structured logging** | `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript` |
-| **Implementing tracing** | `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript` |
-| **Application feature development** | `ring-dev-team:backend-engineer-golang`, `ring-dev-team:backend-engineer-typescript`, or `ring-dev-team:frontend-bff-engineer-typescript` |
-| **Test case writing** | `ring-dev-team:qa-analyst` |
-| **Docker/docker-compose setup** | `ring-dev-team:devops-engineer` |
+| **Implementing health endpoints** | `backend-engineer-golang` or `backend-engineer-typescript` |
+| **Implementing structured logging** | `backend-engineer-golang` or `backend-engineer-typescript` |
+| **Implementing tracing** | `backend-engineer-golang` or `backend-engineer-typescript` |
+| **Application feature development** | `backend-engineer-golang`, `backend-engineer-typescript`, or `frontend-bff-engineer-typescript` |
+| **Test case writing** | `qa-analyst` |
+| **Docker/docker-compose setup** | `devops-engineer` |
 
 **SRE validates. Developers implement.**

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: ring-dev-team:dev-refactor
+name: dev-refactor
 description: Analyzes codebase against standards and generates refactoring tasks for dev-cycle.
 trigger: |
   - User wants to refactor existing project to follow standards
@@ -151,7 +151,7 @@ Extract project-specific conventions for agent context.
 
 ```yaml
 Task tool:
-  subagent_type: "ring-default:codebase-explorer"  # ← EXACT STRING, NOT "Explore"
+  subagent_type: "codebase-explorer"  # ← EXACT STRING, NOT "Explore"
   model: "opus"
   description: "Generate codebase architecture report"
   prompt: |
@@ -173,7 +173,7 @@ Task tool:
 | Rationalization | Why It's WRONG | Required Action |
 |-----------------|----------------|-----------------|
 | "I'll use Bash find/ls to quickly explore" | Bash cannot analyze patterns, just lists files. codebase-explorer provides architectural analysis. | **Use Task with subagent_type="ring-default:codebase-explorer"** |
-| "The Explore agent is faster" | "Explore" subagent_type ≠ "codebase-explorer". Different agents. | **Use exact string: "codebase-explorer"** |
+| "The Explore agent is faster" | "Explore" subagent_type ≠ "codebase-explorer". Different agents. | **Use exact string: "ring-default:codebase-explorer"** |
 | "I already know the structure from find output" | Knowing file paths ≠ understanding architecture. Agent provides analysis. | **Use Task with subagent_type="ring-default:codebase-explorer"** |
 | "This is a small codebase, Bash is enough" | Size is irrelevant. The agent provides standardized output format required by Step 4. | **Use Task with subagent_type="ring-default:codebase-explorer"** |
 | "I'll explore manually then dispatch agents" | Manual exploration skips the codebase-report.md artifact required for Step 4 gate. | **Use Task with subagent_type="ring-default:codebase-explorer"** |
@@ -185,7 +185,7 @@ Task tool:
 ❌ Bash(command="ls -la ...")                → SKILL FAILURE
 ❌ Bash(command="tree ...")                  → SKILL FAILURE
 ❌ Task(subagent_type="Explore", ...)        → SKILL FAILURE
-❌ Task(subagent_type="general-purpose", ...)→ SKILL FAILURE
+❌ Task(subagent_type="ring-default:general-purpose", ...)→ SKILL FAILURE
 ❌ Task(subagent_type="Plan", ...)           → SKILL FAILURE
 ```
 
@@ -245,7 +245,7 @@ Check 2: Was codebase-report.md created by codebase-explorer?
 
 ```yaml
 Task tool 1:
-  subagent_type: "ring-dev-team:backend-engineer-golang"
+  subagent_type: "backend-engineer-golang"
   model: "opus"
   description: "Go standards analysis"
   prompt: |
@@ -273,7 +273,7 @@ Task tool 1:
     2. ISSUE-XXX for each ⚠️/❌ finding with: Pattern name, Severity, file:line, Current Code, Expected Code
 
 Task tool 2:
-  subagent_type: "ring-dev-team:qa-analyst"
+  subagent_type: "qa-analyst"
   model: "opus"
   description: "Test coverage analysis"
   prompt: |
@@ -283,7 +283,7 @@ Task tool 2:
     Output: Standards Coverage Table + ISSUE-XXX for gaps
 
 Task tool 3:
-  subagent_type: "ring-dev-team:devops-engineer"
+  subagent_type: "devops-engineer"
   model: "opus"
   description: "DevOps analysis"
   prompt: |
@@ -295,7 +295,7 @@ Task tool 3:
     Output: Standards Coverage Table + ISSUE-XXX for gaps
 
 Task tool 4:
-  subagent_type: "ring-dev-team:sre"
+  subagent_type: "sre"
   model: "opus"
   description: "Observability analysis"
   prompt: |
@@ -309,7 +309,7 @@ Task tool 4:
 
 ```yaml
 Task tool 1:
-  subagent_type: "ring-dev-team:backend-engineer-typescript"
+  subagent_type: "backend-engineer-typescript"
   model: "opus"
   description: "TypeScript backend standards analysis"
   prompt: |
@@ -341,7 +341,7 @@ Task tool 1:
 
 ```yaml
 Task tool 5:
-  subagent_type: "ring-dev-team:frontend-engineer"
+  subagent_type: "frontend-engineer"
   model: "opus"
   description: "Frontend standards analysis"
   prompt: |
@@ -364,7 +364,7 @@ Task tool 5:
 
 ```yaml
 Task tool 6:
-  subagent_type: "ring-dev-team:frontend-bff-engineer-typescript"
+  subagent_type: "frontend-bff-engineer-typescript"
   model: "opus"
   description: "BFF TypeScript standards analysis"
   prompt: |
@@ -836,7 +836,7 @@ traceability:
 ✅ CORRECT: Task(subagent_type="ring-default:codebase-explorer", model="opus")
 ❌ WRONG:   Bash(find/ls/tree)
 ❌ WRONG:   Task(subagent_type="Explore")
-❌ WRONG:   Task(subagent_type="general-purpose")
+❌ WRONG:   Task(subagent_type="ring-default:general-purpose")
 ```
 
 ### Rule 2: Todo Items MUST Be Initialized at Start
@@ -875,7 +875,7 @@ Step 5 (specialist agents) → ONLY runs if gate passes
 | `Bash find/ls` | Lists file paths | No architectural analysis, no pattern detection |
 | `Task(Explore)` | Fast codebase search | Different agent, lacks Ring standards context |
 | `Task(general-purpose)` | Generic tasks | No specialized codebase analysis output format |
-| `ring-default:codebase-explorer` | Deep architecture analysis | ✅ Correct - provides structured report for Step 5 |
+| `codebase-explorer` | Deep architecture analysis | ✅ Correct - provides structured report for Step 5 |
 
 ### If You Violated These Rules
 

--- a/dev-team/skills/shared-patterns/shared-orchestrator-principle.md
+++ b/dev-team/skills/shared-patterns/shared-orchestrator-principle.md
@@ -82,28 +82,28 @@ This principle is NON-NEGOTIABLE for all dev-team skills.
 
 | Gate | Specialized Agent | What Agent Does |
 |------|-------------------|-----------------|
-| 0 | `ring-dev-team:backend-engineer-golang` | Implements Go code, adds observability, runs TDD |
-| 0 | `ring-dev-team:backend-engineer-typescript` | Implements TS backend code, adds observability, runs TDD |
-| 0 | `ring-dev-team:frontend-engineer` | Implements React/Next.js components, runs TDD |
+| 0 | `backend-engineer-golang` | Implements Go code, adds observability, runs TDD |
+| 0 | `backend-engineer-typescript` | Implements TS backend code, adds observability, runs TDD |
+| 0 | `frontend-engineer` | Implements React/Next.js components, runs TDD |
 | 0 | `frontend-bff-engineer-typescript` | Implements BFF layer, API aggregation |
-| 0 | `ring-dev-team:frontend-designer` | Reviews UI/UX, accessibility, design system compliance |
-| 1 | `ring-dev-team:devops-engineer` | Updates Dockerfile, docker-compose, Helm |
+| 0 | `frontend-designer` | Reviews UI/UX, accessibility, design system compliance |
+| 1 | `devops-engineer` | Updates Dockerfile, docker-compose, Helm |
 | 2 | `sre` | Validates observability implementation |
-| 3 | `ring-dev-team:qa-analyst` | Writes tests, validates coverage |
-| 4 | `ring-default:code-reviewer` | Reviews code quality |
-| 4 | `ring-default:business-logic-reviewer` | Reviews business logic |
-| 4 | `ring-default:security-reviewer` | Reviews security |
+| 3 | `qa-analyst` | Writes tests, validates coverage |
+| 4 | `code-reviewer` | Reviews code quality |
+| 4 | `business-logic-reviewer` | Reviews business logic |
+| 4 | `security-reviewer` | Reviews security |
 
 ### dev-refactor Steps
 
 | Step | Specialized Agent | What Agent Does |
 |------|-------------------|-----------------|
-| 3 | `ring-default:codebase-explorer` | Deep architecture analysis, pattern discovery |
-| 4 | `ring-dev-team:backend-engineer-golang` | Go standards compliance analysis |
-| 4 | `ring-dev-team:backend-engineer-typescript` | TypeScript standards compliance analysis |
-| 4 | `ring-dev-team:frontend-engineer` | Frontend standards compliance analysis |
-| 4 | `ring-dev-team:qa-analyst` | Test coverage and pattern analysis |
-| 4 | `ring-dev-team:devops-engineer` | DevOps setup analysis |
+| 3 | `codebase-explorer` | Deep architecture analysis, pattern discovery |
+| 4 | `backend-engineer-golang` | Go standards compliance analysis |
+| 4 | `backend-engineer-typescript` | TypeScript standards compliance analysis |
+| 4 | `frontend-engineer` | Frontend standards compliance analysis |
+| 4 | `qa-analyst` | Test coverage and pattern analysis |
+| 4 | `devops-engineer` | DevOps setup analysis |
 | 4 | `sre` | Observability analysis |
 
 ## Agent Selection Guide
@@ -114,53 +114,53 @@ This principle is NON-NEGOTIABLE for all dev-team skills.
 
 | File Type / Task | Agent to Dispatch |
 |------------------|-------------------|
-| `*.go` files | `ring-dev-team:backend-engineer-golang` |
-| `*.ts` backend (Express, Fastify, NestJS) | `ring-dev-team:backend-engineer-typescript` |
-| `*.tsx` / `*.jsx` React components | `ring-dev-team:frontend-engineer` |
+| `*.go` files | `backend-engineer-golang` |
+| `*.ts` backend (Express, Fastify, NestJS) | `backend-engineer-typescript` |
+| `*.tsx` / `*.jsx` React components | `frontend-engineer` |
 | BFF / API Gateway layer | `frontend-bff-engineer-typescript` |
-| UI/UX review, design system | `ring-dev-team:frontend-designer` |
-| `Dockerfile`, `docker-compose.yml`, Helm | `ring-dev-team:devops-engineer` |
+| UI/UX review, design system | `frontend-designer` |
+| `Dockerfile`, `docker-compose.yml`, Helm | `devops-engineer` |
 | Logging, tracing | `sre` |
-| Test files (`*_test.go`, `*.spec.ts`) | `ring-dev-team:qa-analyst` |
+| Test files (`*_test.go`, `*.spec.ts`) | `qa-analyst` |
 
 ### Code Review (Always Parallel)
 
 | Review Type | Agent to Dispatch |
 |-------------|-------------------|
-| Code quality, patterns, maintainability | `ring-default:code-reviewer` |
-| Business logic, domain correctness | `ring-default:business-logic-reviewer` |
-| Security vulnerabilities, auth, input validation | `ring-default:security-reviewer` |
+| Code quality, patterns, maintainability | `code-reviewer` |
+| Business logic, domain correctness | `business-logic-reviewer` |
+| Security vulnerabilities, auth, input validation | `security-reviewer` |
 
 ### Research & Analysis
 
 | Task Type | Agent to Dispatch |
 |-----------|-------------------|
-| Codebase architecture understanding | `ring-default:codebase-explorer` |
-| Framework/library documentation | `ring-pm-team:framework-docs-researcher` |
-| Industry best practices | `ring-pm-team:best-practices-researcher` |
-| Repository/codebase analysis | `ring-pm-team:repo-research-analyst` |
+| Codebase architecture understanding | `codebase-explorer` |
+| Framework/library documentation | `framework-docs-researcher` |
+| Industry best practices | `best-practices-researcher` |
+| Repository/codebase analysis | `repo-research-analyst` |
 
 ### Documentation
 
 | Doc Type | Agent to Dispatch |
 |----------|-------------------|
-| Functional documentation, user guides | `ring-tw-team:functional-writer` |
-| API documentation, OpenAPI specs | `ring-tw-team:api-writer` |
-| Documentation review | `ring-tw-team:docs-reviewer` |
+| Functional documentation, user guides | `functional-writer` |
+| API documentation, OpenAPI specs | `api-writer` |
+| Documentation review | `docs-reviewer` |
 
 ### Financial Operations
 
 | Task Type | Agent to Dispatch |
 |-----------|-------------------|
-| Cost analysis, FinOps metrics | `ring-finops-team:finops-analyzer` |
-| FinOps automation, alerts | `ring-finops-team:finops-automation` |
+| Cost analysis, FinOps metrics | `finops-analyzer` |
+| FinOps automation, alerts | `finops-automation` |
 
 ### Planning & Quality
 
 | Task Type | Agent to Dispatch |
 |-----------|-------------------|
-| Implementation planning | `ring-default:write-plan` |
-| Prompt/agent quality analysis | `ring-dev-team:prompt-quality-reviewer` |
+| Implementation planning | `write-plan` |
+| Prompt/agent quality analysis | `prompt-quality-reviewer` |
 
 ## Agent Responsibilities (Implementation)
 

--- a/finance-team/agents/accounting-specialist.md
+++ b/finance-team/agents/accounting-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:accounting-specialist
+name: accounting-specialist
 version: 1.0.0
 description: Accounting Operations Specialist with expertise in journal entries, reconciliations, month-end close, GAAP/IFRS compliance, and audit support. Delivers accurate, compliant accounting with complete audit trails.
 type: specialist
@@ -417,9 +417,9 @@ Monthly amortization: $180,000 / 12 = $15,000
 
 ## What This Agent Does NOT Handle
 
-- Financial statement analysis (use `ring-finance-team:financial-analyst`)
-- Budget creation and forecasting (use `ring-finance-team:budget-planner`)
-- Financial model building (use `ring-finance-team:financial-modeler`)
-- Treasury and cash management (use `ring-finance-team:treasury-specialist`)
-- KPI dashboard design (use `ring-finance-team:metrics-analyst`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial statement analysis (use `financial-analyst`)
+- Budget creation and forecasting (use `budget-planner`)
+- Financial model building (use `financial-modeler`)
+- Treasury and cash management (use `treasury-specialist`)
+- KPI dashboard design (use `metrics-analyst`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finance-team/agents/budget-planner.md
+++ b/finance-team/agents/budget-planner.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:budget-planner
+name: budget-planner
 version: 1.0.0
 description: Budget and Forecasting Specialist with expertise in annual budgeting, rolling forecasts, variance analysis, and financial planning. Delivers comprehensive budgets with documented assumptions and approval workflows.
 type: specialist
@@ -354,9 +354,9 @@ Comparison to preliminary targets:
 
 ## What This Agent Does NOT Handle
 
-- Financial statement analysis (use `ring-finance-team:financial-analyst`)
-- Financial model building (use `ring-finance-team:financial-modeler`)
-- Treasury and cash management (use `ring-finance-team:treasury-specialist`)
-- Accounting entries and close (use `ring-finance-team:accounting-specialist`)
-- KPI dashboard design (use `ring-finance-team:metrics-analyst`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial statement analysis (use `financial-analyst`)
+- Financial model building (use `financial-modeler`)
+- Treasury and cash management (use `treasury-specialist`)
+- Accounting entries and close (use `accounting-specialist`)
+- KPI dashboard design (use `metrics-analyst`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finance-team/agents/financial-analyst.md
+++ b/finance-team/agents/financial-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:financial-analyst
+name: financial-analyst
 version: 1.0.0
 description: Senior Financial Analyst specialized in financial statement analysis, ratio analysis, trend analysis, benchmarking, and investment evaluation. Delivers actionable insights with documented methodology.
 type: specialist
@@ -343,9 +343,9 @@ Analysis of XYZ Corp FY2024 financial statements reveals strong profitability (R
 
 ## What This Agent Does NOT Handle
 
-- Financial model building (use `ring-finance-team:financial-modeler`)
-- Budget creation and forecasting (use `ring-finance-team:budget-planner`)
-- Treasury and cash management (use `ring-finance-team:treasury-specialist`)
-- Accounting entries and close (use `ring-finance-team:accounting-specialist`)
-- KPI dashboard design (use `ring-finance-team:metrics-analyst`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial model building (use `financial-modeler`)
+- Budget creation and forecasting (use `budget-planner`)
+- Treasury and cash management (use `treasury-specialist`)
+- Accounting entries and close (use `accounting-specialist`)
+- KPI dashboard design (use `metrics-analyst`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finance-team/agents/financial-modeler.md
+++ b/finance-team/agents/financial-modeler.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:financial-modeler
+name: financial-modeler
 version: 1.0.0
 description: Financial Modeling Expert specialized in DCF valuation, LBO models, merger models, scenario analysis, and sensitivity testing. Builds robust, auditable financial models with comprehensive documentation.
 type: specialist
@@ -418,9 +418,9 @@ If model is ALREADY complete and validated:
 
 ## What This Agent Does NOT Handle
 
-- Financial statement analysis (use `ring-finance-team:financial-analyst`)
-- Budget creation and forecasting (use `ring-finance-team:budget-planner`)
-- Treasury and cash management (use `ring-finance-team:treasury-specialist`)
-- Accounting entries and close (use `ring-finance-team:accounting-specialist`)
-- KPI dashboard design (use `ring-finance-team:metrics-analyst`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial statement analysis (use `financial-analyst`)
+- Budget creation and forecasting (use `budget-planner`)
+- Treasury and cash management (use `treasury-specialist`)
+- Accounting entries and close (use `accounting-specialist`)
+- KPI dashboard design (use `metrics-analyst`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finance-team/agents/metrics-analyst.md
+++ b/finance-team/agents/metrics-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:metrics-analyst
+name: metrics-analyst
 version: 1.0.0
 description: Financial Metrics and KPI Specialist with expertise in KPI definition, dashboard design, performance measurement, data visualization, and anomaly detection. Delivers actionable metrics with clear methodology and data lineage.
 type: specialist
@@ -459,9 +459,9 @@ Measurement: December 31, 2024 vs January 1, 2024
 
 ## What This Agent Does NOT Handle
 
-- Financial statement analysis (use `ring-finance-team:financial-analyst`)
-- Budget creation and forecasting (use `ring-finance-team:budget-planner`)
-- Financial model building (use `ring-finance-team:financial-modeler`)
-- Treasury and cash management (use `ring-finance-team:treasury-specialist`)
-- Accounting entries and close (use `ring-finance-team:accounting-specialist`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial statement analysis (use `financial-analyst`)
+- Budget creation and forecasting (use `budget-planner`)
+- Financial model building (use `financial-modeler`)
+- Treasury and cash management (use `treasury-specialist`)
+- Accounting entries and close (use `accounting-specialist`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finance-team/agents/treasury-specialist.md
+++ b/finance-team/agents/treasury-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finance-team:treasury-specialist
+name: treasury-specialist
 version: 1.0.0
 description: Treasury and Cash Management Specialist with expertise in cash flow forecasting, liquidity management, working capital optimization, FX exposure, and debt management. Delivers actionable treasury insights with risk awareness.
 type: specialist
@@ -414,9 +414,9 @@ If treasury analysis is ALREADY complete and current:
 
 ## What This Agent Does NOT Handle
 
-- Financial statement analysis (use `ring-finance-team:financial-analyst`)
-- Budget creation and forecasting (use `ring-finance-team:budget-planner`)
-- Financial model building (use `ring-finance-team:financial-modeler`)
-- Accounting entries and close (use `ring-finance-team:accounting-specialist`)
-- KPI dashboard design (use `ring-finance-team:metrics-analyst`)
-- Brazilian regulatory compliance (use `ring-finops-team:finops-analyzer`)
+- Financial statement analysis (use `financial-analyst`)
+- Budget creation and forecasting (use `budget-planner`)
+- Financial model building (use `financial-modeler`)
+- Accounting entries and close (use `accounting-specialist`)
+- KPI dashboard design (use `metrics-analyst`)
+- Brazilian regulatory compliance (use `finops-analyzer`)

--- a/finops-team/agents/finops-analyzer.md
+++ b/finops-team/agents/finops-analyzer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finops-team:finops-analyzer
+name: finops-analyzer
 version: 1.1.0
 description: Senior Regulatory Compliance Analyst specializing in Brazilian financial regulatory template analysis and field mapping validation (Gates 1-2). Expert in BACEN, RFB, and Open Banking compliance.
 type: specialist
@@ -429,7 +429,7 @@ You have access to critical regulatory documentation and data dictionaries:
 - Confirmed transformation rules
 - Template structure ready for implementation
 - All uncertainties resolved
-- Ready for ring-finops-team:finops-automation to implement
+- Ready for finops-automation to implement
 
 ---
 
@@ -539,7 +539,7 @@ specification_report:
     ready_for_implementation: true
 ```
 
-This report is the CONTRACT between you (analyzer) and ring-finops-team:finops-automation (implementer).
+This report is the CONTRACT between you (analyzer) and finops-automation (implementer).
 
 ---
 
@@ -552,7 +552,7 @@ You are the ANALYZER, not the implementer. Your role:
 4. **Validate** transformations are implementable
 5. **Ensure** 100% mandatory fields coverage (BLOCKER for Gate 3)
 6. **Document** any uncertainties clearly
-7. **Generate** complete Specification Report for ring-finops-team:finops-automation
+7. **Generate** complete Specification Report for finops-automation
 
 Key principle: Your Specification Report is the single source of truth for template implementation.
-The ring-finops-team:finops-automation agent will implement EXACTLY what you specify - no more, no less.
+The finops-automation agent will implement EXACTLY what you specify - no more, no less.

--- a/finops-team/agents/finops-automation.md
+++ b/finops-team/agents/finops-automation.md
@@ -1,5 +1,5 @@
 ---
-name: ring-finops-team:finops-automation
+name: finops-automation
 version: 1.1.0
 description: Senior Template Implementation Engineer specializing in .tpl template creation for Brazilian regulatory compliance (Gate 3). Expert in Reporter platform with XML, HTML and TXT template formats.
 type: specialist

--- a/ops-team/agents/cloud-cost-optimizer.md
+++ b/ops-team/agents/cloud-cost-optimizer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-ops-team:cloud-cost-optimizer
+name: cloud-cost-optimizer
 version: 1.0.0
 description: Cloud Cost Operations Specialist focused on cloud infrastructure cost analysis, optimization recommendations, reserved instance management, and FinOps practices. Expert in AWS, GCP, and Azure cost optimization.
 type: specialist
@@ -329,8 +329,8 @@ When reporting cost issues:
 
 ## What This Agent Does NOT Handle
 
-- Infrastructure provisioning (use `ring-ops-team:infrastructure-architect`)
-- Incident response (use `ring-ops-team:incident-responder`)
-- Platform engineering (use `ring-ops-team:platform-engineer`)
-- Security operations (use `ring-ops-team:security-operations`)
-- Application optimization (use `ring-dev-team:backend-engineer-*`)
+- Infrastructure provisioning (use `infrastructure-architect`)
+- Incident response (use `incident-responder`)
+- Platform engineering (use `platform-engineer`)
+- Security operations (use `security-operations`)
+- Application optimization (use `backend-engineer-*`)

--- a/ops-team/agents/incident-responder.md
+++ b/ops-team/agents/incident-responder.md
@@ -1,5 +1,5 @@
 ---
-name: ring-ops-team:incident-responder
+name: incident-responder
 version: 1.0.0
 description: Senior Incident Commander specialized in production incident management, root cause analysis, and incident response coordination. Expert in SRE incident practices for high-availability financial systems.
 type: specialist
@@ -315,8 +315,8 @@ Payment processing service experienced intermittent failures affecting 23% of tr
 
 ## What This Agent Does NOT Handle
 
-- Platform engineering changes (use `ring-ops-team:platform-engineer`)
-- Infrastructure provisioning (use `ring-ops-team:infrastructure-architect`)
-- Cost analysis during incidents (use `ring-ops-team:cloud-cost-optimizer`)
-- Security vulnerability remediation (use `ring-ops-team:security-operations`)
-- Application code fixes (use `ring-dev-team:backend-engineer-*`)
+- Platform engineering changes (use `platform-engineer`)
+- Infrastructure provisioning (use `infrastructure-architect`)
+- Cost analysis during incidents (use `cloud-cost-optimizer`)
+- Security vulnerability remediation (use `security-operations`)
+- Application code fixes (use `backend-engineer-*`)

--- a/ops-team/agents/infrastructure-architect.md
+++ b/ops-team/agents/infrastructure-architect.md
@@ -1,5 +1,5 @@
 ---
-name: ring-ops-team:infrastructure-architect
+name: infrastructure-architect
 version: 1.0.0
 description: Senior Infrastructure Architect specialized in cloud infrastructure design, capacity planning, disaster recovery, and infrastructure lifecycle management for high-availability financial systems.
 type: specialist
@@ -371,8 +371,8 @@ Designed multi-region active-passive architecture for payment processing platfor
 
 ## What This Agent Does NOT Handle
 
-- Day-to-day platform operations (use `ring-ops-team:platform-engineer`)
-- Incident response (use `ring-ops-team:incident-responder`)
-- Cost optimization analysis (use `ring-ops-team:cloud-cost-optimizer`)
-- Security operations (use `ring-ops-team:security-operations`)
-- Application development (use `ring-dev-team:backend-engineer-*`)
+- Day-to-day platform operations (use `platform-engineer`)
+- Incident response (use `incident-responder`)
+- Cost optimization analysis (use `cloud-cost-optimizer`)
+- Security operations (use `security-operations`)
+- Application development (use `backend-engineer-*`)

--- a/ops-team/agents/platform-engineer.md
+++ b/ops-team/agents/platform-engineer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-ops-team:platform-engineer
+name: platform-engineer
 version: 1.0.0
 description: Senior Platform Engineer specialized in building and maintaining internal developer platforms, service mesh, API gateways, and self-service infrastructure. Focuses on enabling developer productivity through golden paths and platform abstractions.
 type: specialist
@@ -275,8 +275,8 @@ $ curl -k https://api.example.com/health
 
 ## What This Agent Does NOT Handle
 
-- Application code development (use `ring-dev-team:backend-engineer-*`)
-- Infrastructure provisioning (use `ring-ops-team:infrastructure-architect`)
-- Incident response (use `ring-ops-team:incident-responder`)
-- Cost optimization (use `ring-ops-team:cloud-cost-optimizer`)
-- Security audits (use `ring-ops-team:security-operations`)
+- Application code development (use `backend-engineer-*`)
+- Infrastructure provisioning (use `infrastructure-architect`)
+- Incident response (use `incident-responder`)
+- Cost optimization (use `cloud-cost-optimizer`)
+- Security audits (use `security-operations`)

--- a/ops-team/agents/security-operations.md
+++ b/ops-team/agents/security-operations.md
@@ -1,5 +1,5 @@
 ---
-name: ring-ops-team:security-operations
+name: security-operations
 version: 1.0.0
 description: Security Operations Specialist focused on infrastructure security, compliance validation, vulnerability management, and security monitoring for financial services organizations.
 type: specialist
@@ -385,8 +385,8 @@ None - all HIGH findings must be remediated, not risk-accepted.
 
 ## What This Agent Does NOT Handle
 
-- Application security testing (use `ring-default:security-reviewer`)
-- Infrastructure provisioning (use `ring-ops-team:infrastructure-architect`)
-- Incident response coordination (use `ring-ops-team:incident-responder`)
-- Platform engineering (use `ring-ops-team:platform-engineer`)
-- Cost optimization (use `ring-ops-team:cloud-cost-optimizer`)
+- Application security testing (use `security-reviewer`)
+- Infrastructure provisioning (use `infrastructure-architect`)
+- Incident response coordination (use `incident-responder`)
+- Platform engineering (use `platform-engineer`)
+- Cost optimization (use `cloud-cost-optimizer`)

--- a/pm-team/agents/best-practices-researcher.md
+++ b/pm-team/agents/best-practices-researcher.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pm-team:best-practices-researcher
+name: best-practices-researcher
 description: |
   External research specialist for pre-dev planning. Searches web and documentation
   for industry best practices, open source examples, and authoritative guidance.

--- a/pm-team/agents/framework-docs-researcher.md
+++ b/pm-team/agents/framework-docs-researcher.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pm-team:framework-docs-researcher
+name: framework-docs-researcher
 description: |
   Tech stack analysis specialist for pre-dev planning. Detects project tech stack
   from manifest files and fetches relevant framework/library documentation.

--- a/pm-team/agents/repo-research-analyst.md
+++ b/pm-team/agents/repo-research-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pm-team:repo-research-analyst
+name: repo-research-analyst
 description: |
   Codebase research specialist for pre-dev planning. Searches target repository
   for existing patterns, conventions, and prior solutions. Returns findings with

--- a/pmm-team/agents/gtm-planner.md
+++ b/pmm-team/agents/gtm-planner.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:gtm-planner
+name: gtm-planner
 version: 1.0.0
 description: Go-to-Market Strategy Specialist for channel strategy, campaign planning, launch tactics, and GTM execution planning. Creates comprehensive GTM plans.
 type: specialist
@@ -332,8 +332,8 @@ If GTM plan already exists and is current:
 
 ## What This Agent Does NOT Handle
 
-- Market analysis (use `ring-pmm-team:market-researcher`)
-- Positioning strategy (use `ring-pmm-team:positioning-strategist`)
-- Messaging development (use `ring-pmm-team:messaging-specialist`)
-- Launch day execution (use `ring-pmm-team:launch-coordinator`)
-- Pricing strategy (use `ring-pmm-team:pricing-analyst`)
+- Market analysis (use `market-researcher`)
+- Positioning strategy (use `positioning-strategist`)
+- Messaging development (use `messaging-specialist`)
+- Launch day execution (use `launch-coordinator`)
+- Pricing strategy (use `pricing-analyst`)

--- a/pmm-team/agents/launch-coordinator.md
+++ b/pmm-team/agents/launch-coordinator.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:launch-coordinator
+name: launch-coordinator
 version: 1.0.0
 description: Launch Execution Specialist for launch checklists, stakeholder coordination, day-of execution, and post-launch monitoring. Ensures smooth launch execution.
 type: specialist
@@ -333,8 +333,8 @@ If launch is already well-coordinated:
 
 ## What This Agent Does NOT Handle
 
-- Market analysis (use `ring-pmm-team:market-researcher`)
-- Positioning strategy (use `ring-pmm-team:positioning-strategist`)
-- Messaging development (use `ring-pmm-team:messaging-specialist`)
-- GTM planning (use `ring-pmm-team:gtm-planner`)
-- Pricing strategy (use `ring-pmm-team:pricing-analyst`)
+- Market analysis (use `market-researcher`)
+- Positioning strategy (use `positioning-strategist`)
+- Messaging development (use `messaging-specialist`)
+- GTM planning (use `gtm-planner`)
+- Pricing strategy (use `pricing-analyst`)

--- a/pmm-team/agents/market-researcher.md
+++ b/pmm-team/agents/market-researcher.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:market-researcher
+name: market-researcher
 version: 1.0.0
 description: Market Intelligence Specialist for TAM/SAM/SOM analysis, market segmentation, trend analysis, and customer research. Provides data-driven market insights for strategic decisions.
 type: specialist
@@ -302,8 +302,8 @@ If market analysis already exists and is adequate:
 
 ## What This Agent Does NOT Handle
 
-- Positioning strategy (use `ring-pmm-team:positioning-strategist`)
-- Messaging development (use `ring-pmm-team:messaging-specialist`)
+- Positioning strategy (use `positioning-strategist`)
+- Messaging development (use `messaging-specialist`)
 - Competitive battlecards (use competitive-intelligence skill, then positioning-strategist)
-- GTM planning (use `ring-pmm-team:gtm-planner`)
-- Pricing strategy (use `ring-pmm-team:pricing-analyst`)
+- GTM planning (use `gtm-planner`)
+- Pricing strategy (use `pricing-analyst`)

--- a/pmm-team/agents/messaging-specialist.md
+++ b/pmm-team/agents/messaging-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:messaging-specialist
+name: messaging-specialist
 version: 1.0.0
 description: Messaging & Copywriting Specialist for value propositions, messaging frameworks, proof points, and channel-specific messaging. Creates compelling, consistent messaging.
 type: specialist
@@ -307,8 +307,8 @@ If messaging already exists and is effective:
 
 ## What This Agent Does NOT Handle
 
-- Market analysis (use `ring-pmm-team:market-researcher`)
-- Positioning strategy (use `ring-pmm-team:positioning-strategist`)
-- GTM channel strategy (use `ring-pmm-team:gtm-planner`)
-- Launch coordination (use `ring-pmm-team:launch-coordinator`)
-- Pricing strategy (use `ring-pmm-team:pricing-analyst`)
+- Market analysis (use `market-researcher`)
+- Positioning strategy (use `positioning-strategist`)
+- GTM channel strategy (use `gtm-planner`)
+- Launch coordination (use `launch-coordinator`)
+- Pricing strategy (use `pricing-analyst`)

--- a/pmm-team/agents/positioning-strategist.md
+++ b/pmm-team/agents/positioning-strategist.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:positioning-strategist
+name: positioning-strategist
 version: 1.0.0
 description: Strategic Positioning Specialist for differentiation strategy, category design, positioning statements, and competitive framing. Creates defensible market positions.
 type: specialist
@@ -293,8 +293,8 @@ UNLIKE [competitive alternative]
 
 ## What This Agent Does NOT Handle
 
-- Market sizing and research (use `ring-pmm-team:market-researcher`)
-- Messaging and copywriting (use `ring-pmm-team:messaging-specialist`)
-- GTM channel strategy (use `ring-pmm-team:gtm-planner`)
-- Launch coordination (use `ring-pmm-team:launch-coordinator`)
-- Pricing strategy (use `ring-pmm-team:pricing-analyst`)
+- Market sizing and research (use `market-researcher`)
+- Messaging and copywriting (use `messaging-specialist`)
+- GTM channel strategy (use `gtm-planner`)
+- Launch coordination (use `launch-coordinator`)
+- Pricing strategy (use `pricing-analyst`)

--- a/pmm-team/agents/pricing-analyst.md
+++ b/pmm-team/agents/pricing-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmm-team:pricing-analyst
+name: pricing-analyst
 version: 1.0.0
 description: Pricing Strategy Specialist for pricing model analysis, competitive pricing intelligence, value-based pricing, and pricing recommendations. Creates data-driven pricing strategies.
 type: specialist
@@ -330,8 +330,8 @@ If pricing already exists and is performing:
 
 ## What This Agent Does NOT Handle
 
-- Market analysis (use `ring-pmm-team:market-researcher`)
-- Positioning strategy (use `ring-pmm-team:positioning-strategist`)
-- Messaging development (use `ring-pmm-team:messaging-specialist`)
-- GTM planning (use `ring-pmm-team:gtm-planner`)
-- Launch coordination (use `ring-pmm-team:launch-coordinator`)
+- Market analysis (use `market-researcher`)
+- Positioning strategy (use `positioning-strategist`)
+- Messaging development (use `messaging-specialist`)
+- GTM planning (use `gtm-planner`)
+- Launch coordination (use `launch-coordinator`)

--- a/pmo-team/agents/executive-reporter.md
+++ b/pmo-team/agents/executive-reporter.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmo-team:executive-reporter
+name: executive-reporter
 version: 1.0.0
 description: Executive Reporting Specialist for creating dashboards, status summaries, board packages, and stakeholder communications. Focuses on actionable insights for leadership.
 type: specialist
@@ -338,8 +338,8 @@ Portfolio status: **YELLOW** - On track overall with two areas requiring attenti
 
 ## What This Agent Does NOT Handle
 
-- Portfolio analysis detail (use `ring-pmo-team:portfolio-manager`)
-- Resource planning (use `ring-pmo-team:resource-planner`)
-- Risk analysis depth (use `ring-pmo-team:risk-analyst`)
-- Governance process (use `ring-pmo-team:governance-specialist`)
-- Technical documentation (use `ring-tw-team:functional-writer`)
+- Portfolio analysis detail (use `portfolio-manager`)
+- Resource planning (use `resource-planner`)
+- Risk analysis depth (use `risk-analyst`)
+- Governance process (use `governance-specialist`)
+- Technical documentation (use `functional-writer`)

--- a/pmo-team/agents/governance-specialist.md
+++ b/pmo-team/agents/governance-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmo-team:governance-specialist
+name: governance-specialist
 version: 1.0.0
 description: Project Governance Specialist for gate reviews, process compliance, audit readiness, and governance framework implementation across portfolio projects.
 type: specialist
@@ -320,8 +320,8 @@ Conducted Gate 2 (Planning Complete) review for Project Phoenix. Recommendation:
 
 ## What This Agent Does NOT Handle
 
-- Project planning (use `ring-pm-team:pre-dev-feature`)
-- Portfolio prioritization (use `ring-pmo-team:portfolio-manager`)
-- Resource allocation (use `ring-pmo-team:resource-planner`)
-- Risk analysis detail (use `ring-pmo-team:risk-analyst`)
-- Executive communication (use `ring-pmo-team:executive-reporter`)
+- Project planning (use `pre-dev-feature`)
+- Portfolio prioritization (use `portfolio-manager`)
+- Resource allocation (use `resource-planner`)
+- Risk analysis detail (use `risk-analyst`)
+- Executive communication (use `executive-reporter`)

--- a/pmo-team/agents/portfolio-manager.md
+++ b/pmo-team/agents/portfolio-manager.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmo-team:portfolio-manager
+name: portfolio-manager
 version: 1.0.0
 description: Senior Portfolio Manager specialized in multi-project coordination, strategic alignment assessment, and portfolio optimization. Handles portfolio-level planning, prioritization, and health monitoring.
 type: specialist
@@ -280,8 +280,8 @@ Analyzed 12 active projects across 3 strategic objectives. Overall portfolio hea
 
 ## What This Agent Does NOT Handle
 
-- Single project detailed planning (use `ring-pm-team:pre-dev-feature`)
-- Resource individual assignments (use `ring-pmo-team:resource-planner`)
-- Detailed risk analysis (use `ring-pmo-team:risk-analyst`)
-- Executive report formatting (use `ring-pmo-team:executive-reporter`)
-- Project governance gates (use `ring-pmo-team:governance-specialist`)
+- Single project detailed planning (use `pre-dev-feature`)
+- Resource individual assignments (use `resource-planner`)
+- Detailed risk analysis (use `risk-analyst`)
+- Executive report formatting (use `executive-reporter`)
+- Project governance gates (use `governance-specialist`)

--- a/pmo-team/agents/resource-planner.md
+++ b/pmo-team/agents/resource-planner.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmo-team:resource-planner
+name: resource-planner
 version: 1.0.0
 description: Resource Planning Specialist for capacity planning, allocation optimization, skills management, and conflict resolution across portfolio projects.
 type: specialist
@@ -301,8 +301,8 @@ Analyzed 24 resources across 4 teams for Q1 2025 allocation. Current aggregate u
 
 ## What This Agent Does NOT Handle
 
-- Portfolio-level prioritization (use `ring-pmo-team:portfolio-manager`)
-- Individual project planning (use `ring-pm-team:pre-dev-feature-map`)
+- Portfolio-level prioritization (use `portfolio-manager`)
+- Individual project planning (use `pre-dev-feature-map`)
 - HR policies and compensation (organizational HR)
 - Team performance management (people managers)
 - Project scheduling (project managers)

--- a/pmo-team/agents/risk-analyst.md
+++ b/pmo-team/agents/risk-analyst.md
@@ -1,5 +1,5 @@
 ---
-name: ring-pmo-team:risk-analyst
+name: risk-analyst
 version: 1.0.0
 description: Portfolio Risk Analyst specialized in risk identification, assessment, correlation analysis, and mitigation planning across portfolio projects. Manages RAID logs and portfolio risk exposure.
 type: specialist
@@ -310,8 +310,8 @@ Analyzed 18 risks across portfolio. Portfolio risk exposure: MEDIUM-HIGH. 2 crit
 
 ## What This Agent Does NOT Handle
 
-- Portfolio prioritization (use `ring-pmo-team:portfolio-manager`)
-- Resource allocation (use `ring-pmo-team:resource-planner`)
-- Governance process (use `ring-pmo-team:governance-specialist`)
-- Executive reporting format (use `ring-pmo-team:executive-reporter`)
-- Financial risk deep dive (use `ring-finops-team:finops-analyzer`)
+- Portfolio prioritization (use `portfolio-manager`)
+- Resource allocation (use `resource-planner`)
+- Governance process (use `governance-specialist`)
+- Executive reporting format (use `executive-reporter`)
+- Financial risk deep dive (use `finops-analyzer`)

--- a/tw-team/agents/api-writer.md
+++ b/tw-team/agents/api-writer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-tw-team:api-writer
+name: api-writer
 version: 0.2.0
 description: Senior Technical Writer specialized in API reference documentation including endpoint descriptions, request/response schemas, and error documentation.
 type: specialist
@@ -62,8 +62,8 @@ API accuracy verification and comprehensive field documentation requires Opus at
 ## Related Skills
 
 This agent applies patterns from these skills:
-- `ring-tw-team:writing-api-docs` - Endpoint documentation structure and patterns
-- `ring-tw-team:api-field-descriptions` - Field description patterns by data type
+- `writing-api-docs` - Endpoint documentation structure and patterns
+- `api-field-descriptions` - Field description patterns by data type
 
 ## Standards Loading
 
@@ -349,10 +349,10 @@ Brief description of what this endpoint does.
 
 ## What This Agent Does NOT Handle
 
-- Conceptual documentation (use `ring-tw-team:functional-writer`)
-- Documentation review (use `ring-tw-team:docs-reviewer`)
-- API implementation (use `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript`)
-- API design decisions (use `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript`)
+- Conceptual documentation (use `functional-writer`)
+- Documentation review (use `docs-reviewer`)
+- API implementation (use `backend-engineer-golang` or `backend-engineer-typescript`)
+- API design decisions (use `backend-engineer-golang` or `backend-engineer-typescript`)
 
 ## Output Expectations
 

--- a/tw-team/agents/docs-reviewer.md
+++ b/tw-team/agents/docs-reviewer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-tw-team:docs-reviewer
+name: docs-reviewer
 version: 0.2.0
 description: Documentation Quality Reviewer specialized in checking voice, tone, structure, completeness, and technical accuracy of documentation.
 type: reviewer
@@ -65,9 +65,9 @@ Voice/tone consistency analysis and technical accuracy verification requires Opu
 ## Related Skills
 
 This agent applies review criteria from these skills:
-- `ring-tw-team:documentation-review` - Review checklist and quality criteria
-- `ring-tw-team:voice-and-tone` - Voice and tone compliance standards
-- `ring-tw-team:documentation-structure` - Structure and hierarchy standards
+- `documentation-review` - Review checklist and quality criteria
+- `voice-and-tone` - Voice and tone compliance standards
+- `documentation-structure` - Structure and hierarchy standards
 
 ## Standards Loading
 
@@ -81,8 +81,8 @@ This agent applies review criteria from these skills:
 
 2. **Loading Method:**
    - Search for `docs/standards/`, `CONTRIBUTING.md`, or style guides in repository
-   - Check `ring-tw-team:voice-and-tone` skill for voice standards
-   - Check `ring-tw-team:documentation-structure` skill for structure standards
+   - Check `voice-and-tone` skill for voice standards
+   - Check `documentation-structure` skill for structure standards
    - Reference industry documentation best practices (e.g., Google Developer Documentation Style Guide)
 
 3. **Verification:**
@@ -351,9 +351,9 @@ When reviewing documentation:
 
 ## What This Agent Does NOT Handle
 
-- Writing new documentation (use `ring-tw-team:functional-writer` or `ring-tw-team:api-writer`)
+- Writing new documentation (use `functional-writer` or `api-writer`)
 - Technical implementation (use `*` agents)
-- Code review (use `ring-default:code-reviewer`)
+- Code review (use `code-reviewer`)
 
 ## Output Expectations
 

--- a/tw-team/agents/functional-writer.md
+++ b/tw-team/agents/functional-writer.md
@@ -1,5 +1,5 @@
 ---
-name: ring-tw-team:functional-writer
+name: functional-writer
 version: 0.2.0
 description: Senior Technical Writer specialized in functional documentation including guides, conceptual explanations, tutorials, and best practices.
 type: specialist
@@ -62,9 +62,9 @@ Step accuracy verification and prerequisite completeness analysis requires Opus 
 ## Related Skills
 
 This agent applies patterns from these skills:
-- `ring-tw-team:writing-functional-docs` - Document structure and writing patterns
-- `ring-tw-team:voice-and-tone` - Voice and tone guidelines
-- `ring-tw-team:documentation-structure` - Content hierarchy and organization
+- `writing-functional-docs` - Document structure and writing patterns
+- `voice-and-tone` - Voice and tone guidelines
+- `documentation-structure` - Content hierarchy and organization
 
 ## Standards Loading
 
@@ -78,8 +78,8 @@ This agent applies patterns from these skills:
 
 2. **Loading Method:**
    - Search for `docs/standards/`, `CONTRIBUTING.md`, or documentation guides in repository
-   - Check `ring-tw-team:voice-and-tone` skill for voice standards
-   - Check `ring-tw-team:writing-functional-docs` skill for structure patterns
+   - Check `voice-and-tone` skill for voice standards
+   - Check `writing-functional-docs` skill for structure patterns
    - Reference existing documentation for tone and style consistency
 
 3. **Verification:**
@@ -310,10 +310,10 @@ Show, don't just tell. Provide realistic examples for technical concepts.
 
 ## What This Agent Does NOT Handle
 
-- API endpoint documentation (use `ring-tw-team:api-writer`)
-- Documentation quality review (use `ring-tw-team:docs-reviewer`)
+- API endpoint documentation (use `api-writer`)
+- Documentation quality review (use `docs-reviewer`)
 - Code implementation (use `*` agents)
-- Technical architecture decisions (use `ring-dev-team:backend-engineer-golang` or `ring-dev-team:backend-engineer-typescript`)
+- Technical architecture decisions (use `backend-engineer-golang` or `backend-engineer-typescript`)
 
 ## Output Expectations
 


### PR DESCRIPTION
Update all agent references to use the ring-{plugin}:{agent-name} format instead of bare agent names. This ensures consistent naming across all plugins and prevents ambiguity in multi-plugin environments.

X-Lerian-Ref: 0x1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified command and agent naming conventions by removing namespace prefixes. Commands now use shorter names (e.g., `/brainstorm`, `/codereview` instead of `/ring-default:codereview`). Agent and skill identifiers are now more concise and consistent across the platform, making them easier to reference and remember in workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->