### PR TITLE
refactor(standards): remove DDD patterns, adopt Midaz directory struc…

### DIFF
--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -298,11 +298,11 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 
 **If task involves async processing or messaging → Worker patterns are MANDATORY.**
 
-## Domain-Driven Design (DDD)
+## Architecture Patterns
 
-You have deep expertise in DDD. DDD patterns are MANDATORY for all Go services.
+You have deep expertise in Hexagonal Architecture and Clean Architecture. The **Midaz pattern** (simplified hexagonal without explicit DDD folders) is MANDATORY for all Go services.
 
-**→ For DDD patterns and Go implementation, see Ring Go Standards (fetched via WebFetch).**
+**→ For directory structure and architecture patterns, see Ring Go Standards (fetched via WebFetch) → Directory Structure section.**
 
 ## Test-Driven Development (TDD)
 
@@ -562,7 +562,7 @@ The Standards Compliance section exists to:
 - You MUST use EXACT section names from the table below
 - You CANNOT invent names like "Security", "Code Quality", "Config"
 - You CANNOT merge sections like "Error Handling & Logging"
-- You CANNOT abbreviate like "DDD" instead of "DDD Patterns"
+- You CANNOT abbreviate like "Bootstrap" instead of "Bootstrap Pattern"
 - If section doesn't apply → Mark as N/A, do NOT skip
 
 | # | Section | Key Subsections |
@@ -584,10 +584,9 @@ The Standards Compliance section exists to:
 | 15 | Logging Standards (MANDATORY) | |
 | 16 | Linting (MANDATORY) | |
 | 17 | Architecture Patterns (MANDATORY) | |
-| 18 | Directory Structure (MANDATORY) | |
+| 18 | Directory Structure (MANDATORY) | Midaz pattern |
 | 19 | Concurrency Patterns (MANDATORY) | |
-| 20 | DDD Patterns (MANDATORY) | |
-| 21 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 20 | RabbitMQ Worker Pattern (MANDATORY) | |
 
 **→ See [shared-patterns/standards-coverage-table.md](../skills/shared-patterns/standards-coverage-table.md) for:**
 - Output table format

--- a/dev-team/agents/backend-engineer-typescript.md
+++ b/dev-team/agents/backend-engineer-typescript.md
@@ -396,11 +396,11 @@ After WebFetch completes, you MUST be able to cite specific patterns:
 
 **If task involves async processing or messaging → Worker patterns are MANDATORY.**
 
-## Domain-Driven Design (DDD)
+## Architecture Patterns
 
-You have deep expertise in DDD. DDD patterns are MANDATORY for all TypeScript services.
+You have deep expertise in Clean Architecture and Hexagonal Architecture. The **Midaz pattern** (simplified hexagonal without explicit DDD folders) is MANDATORY for all TypeScript services.
 
-**→ For DDD patterns and TypeScript implementation, see Ring TypeScript Standards (fetched via WebFetch).**
+**→ For directory structure and architecture patterns, see Ring TypeScript Standards (fetched via WebFetch) → Directory Structure section.**
 
 ## Test-Driven Development (TDD)
 
@@ -617,10 +617,9 @@ When invoked from the `dev-refactor` skill with a codebase-report.md, you MUST p
 | 8 | Testing Patterns (MANDATORY) | |
 | 9 | Error Handling (MANDATORY) | |
 | 10 | Function Design (MANDATORY) | |
-| 11 | DDD Patterns (MANDATORY) | |
-| 12 | Naming Conventions (MANDATORY) | |
-| 13 | Directory Structure (MANDATORY) | |
-| 14 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 11 | Naming Conventions (MANDATORY) | |
+| 12 | Directory Structure (MANDATORY) | Midaz pattern |
+| 13 | RabbitMQ Worker Pattern (MANDATORY) | |
 
 **→ See [shared-patterns/standards-coverage-table.md](../skills/shared-patterns/standards-coverage-table.md) for:**
 - Output table format

--- a/dev-team/agents/frontend-bff-engineer-typescript.md
+++ b/dev-team/agents/frontend-bff-engineer-typescript.md
@@ -253,9 +253,9 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 | **Standards File** | typescript.md |
 | **Prompt** | "Extract all TypeScript coding standards, patterns, and requirements" |
 
-## Domain-Driven Design (DDD)
+## Architecture Patterns
 
-You have deep expertise in DDD. DDD patterns are MANDATORY for all BFF services.
+You have deep expertise in Clean Architecture and Hexagonal Architecture. The **Midaz pattern** (simplified hexagonal without explicit DDD folders) is MANDATORY for all BFF services.
 
 ### Strategic Patterns (Knowledge)
 
@@ -507,10 +507,9 @@ See [shared-patterns/shared-anti-rationalization.md](../skills/shared-patterns/s
 | 8 | Testing Patterns (MANDATORY) | |
 | 9 | Error Handling (MANDATORY) | |
 | 10 | Function Design (MANDATORY) | |
-| 11 | DDD Patterns (MANDATORY) | |
-| 12 | Naming Conventions (MANDATORY) | |
-| 13 | Directory Structure (MANDATORY) | |
-| 14 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 11 | Naming Conventions (MANDATORY) | |
+| 12 | Directory Structure (MANDATORY) | Midaz pattern |
+| 13 | RabbitMQ Worker Pattern (MANDATORY) | |
 
 **→ See [shared-patterns/standards-coverage-table.md](../skills/shared-patterns/standards-coverage-table.md) for:**
 - Output table format

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -53,9 +53,9 @@ If counts don't match → SKILL FAILURE. Go back and add missing findings.
 
 **Not all architecture patterns apply to all services.** Before flagging gaps, verify the pattern is applicable.
 
-| Service Type | Hexagonal/Clean Architecture | DDD Patterns |
-|--------------|------------------------------|--------------|
-| CRUD API (with domains, entities) | ✅ APPLY | ✅ APPLY |
+| Service Type | Hexagonal/Clean Architecture | Directory Structure |
+|--------------|------------------------------|---------------------|
+| CRUD API (with services, adapters) | ✅ APPLY | ✅ APPLY (Midaz pattern) |
 | Complex business logic | ✅ APPLY | ✅ APPLY |
 | Multiple bounded contexts | ✅ APPLY | ✅ APPLY |
 | Event-driven systems | ✅ APPLY | ✅ APPLY |
@@ -66,19 +66,19 @@ If counts don't match → SKILL FAILURE. Go back and add missing findings.
 
 ### Detection Criteria
 
-**CRUD API (Hexagonal/DDD APPLICABLE):**
+**CRUD API (Hexagonal/Midaz Pattern APPLICABLE):**
 - Service exposes API endpoints (REST, gRPC, GraphQL)
-- Contains domain entities and models
+- Contains business logic and models
 - Has CRUD operations (Create, Read, Update, Delete)
 - Uses repositories for data access
-- → **MUST follow Hexagonal Architecture and DDD patterns**
+- → **MUST follow Hexagonal Architecture and Midaz directory pattern**
 
-**Simple Service (Hexagonal/DDD NOT applicable):**
+**Simple Service (Hexagonal/Midaz NOT applicable):**
 - CLI tools and scripts
 - Workers and background jobs
 - Simple utility functions
 - Lambda functions with single responsibility
-- No domain model or entities
+- No business logic layer
 
 ### Agent Instruction
 
@@ -86,10 +86,10 @@ When dispatching specialist agents, include:
 
 ```
 ⛔ ARCHITECTURE APPLICABILITY CHECK:
-1. If service is an API with CRUD operations and domains → APPLY Hexagonal/DDD standards
-2. If service is CLI tool, script, or simple utility → Do NOT flag Hexagonal/DDD gaps
+1. If service is an API with CRUD operations → APPLY Hexagonal/Midaz standards
+2. If service is CLI tool, script, or simple utility → Do NOT flag Hexagonal/Midaz gaps
 
-CRUD APIs with domain entities MUST follow Hexagonal Architecture (ports/adapters) and DDD patterns.
+CRUD APIs MUST follow Hexagonal Architecture (ports/adapters) and Midaz directory pattern.
 ```
 
 ---

--- a/dev-team/skills/shared-patterns/standards-compliance-detection.md
+++ b/dev-team/skills/shared-patterns/standards-compliance-detection.md
@@ -118,14 +118,14 @@ If detection is ambiguous, INCLUDE Standards Compliance section. Better to over-
 ### Section Name Validation
 
 **For golang.md, section names MUST be:**
-- Version, Core Dependency: lib-commons, Frameworks & Libraries, Configuration Loading, Telemetry & Observability, Bootstrap Pattern, Data Transformation: ToEntity/FromEntity, Error Codes Convention, Error Handling, Function Design, Pagination Patterns, Testing Patterns, Logging Standards, Linting, Architecture Patterns, Directory Structure, Concurrency Patterns, DDD Patterns, RabbitMQ Worker Pattern
+- Version, Core Dependency: lib-commons, Frameworks & Libraries, Configuration Loading, Telemetry & Observability, Bootstrap Pattern, Data Transformation: ToEntity/FromEntity, Error Codes Convention, Error Handling, Function Design, Pagination Patterns, Testing Patterns, Logging Standards, Linting, Architecture Patterns, Directory Structure, Concurrency Patterns, RabbitMQ Worker Pattern
 
 **NOT:**
 - ❌ "Error Handling" (missing "Error Codes Convention" as separate row)
 - ❌ "Logging" (should be "Logging Standards")
 - ❌ "Configuration" (should be "Configuration Loading")
 - ❌ "Security" (not a section in golang.md)
-- ❌ "DDD" (should be "DDD Patterns")
+- ❌ "Bootstrap" (should be "Bootstrap Pattern")
 
 ### Anti-Rationalization for Section Names
 

--- a/dev-team/skills/shared-patterns/standards-coverage-table.md
+++ b/dev-team/skills/shared-patterns/standards-coverage-table.md
@@ -30,7 +30,7 @@ This file defines the MANDATORY output format for agents comparing codebases aga
 | Invent names | "Security", "Code Quality" | Not in coverage table |
 | Rename sections | "Config" instead of "Configuration Loading" | Breaks traceability |
 | Merge sections | "Error Handling & Logging" | Each section = one row |
-| Use abbreviations | "DDD" instead of "DDD Patterns" | Must match exactly |
+| Use abbreviations | "Bootstrap" instead of "Bootstrap Pattern" | Must match exactly |
 | Skip sections | Omitting "RabbitMQ Worker Pattern" | Mark N/A instead |
 
 **Your output table section names MUST match the "Section to Check" column below EXACTLY.**
@@ -179,14 +179,13 @@ The Coverage Table ensures nothing is skipped. The Detailed Findings provide act
 | 15 | Logging Standards | ⚠️ | Missing structured fields |
 | 16 | Linting | ✅ | .golangci.yml present |
 | 17 | Architecture Patterns | ✅ | Hexagonal structure |
-| 18 | Directory Structure | ✅ | Follows convention |
+| 18 | Directory Structure | ✅ | Follows Midaz pattern |
 | 19 | Concurrency Patterns | N/A | No concurrent code |
-| 20 | DDD Patterns | ✅ | Entities, Value Objects present |
-| 21 | RabbitMQ Worker Pattern | N/A | No message queue |
+| 20 | RabbitMQ Worker Pattern | N/A | No message queue |
 
 **Completeness Verification:**
-- Sections in standards: 21
-- Rows in table: 21
+- Sections in standards: 20
+- Rows in table: 20
 - Status: ✅ Complete
 ```
 
@@ -247,10 +246,9 @@ These sections describe HOW to use the standards, not WHAT the standards are.
 | 15 | Logging Standards (MANDATORY) | |
 | 16 | Linting (MANDATORY) | |
 | 17 | Architecture Patterns (MANDATORY) | |
-| 18 | Directory Structure (MANDATORY) | |
+| 18 | Directory Structure (MANDATORY) | Midaz pattern |
 | 19 | Concurrency Patterns (MANDATORY) | |
-| 20 | DDD Patterns (MANDATORY) | |
-| 21 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 20 | RabbitMQ Worker Pattern (MANDATORY) | |
 
 ---
 
@@ -268,10 +266,9 @@ These sections describe HOW to use the standards, not WHAT the standards are.
 | 8 | Testing Patterns (MANDATORY) | |
 | 9 | Error Handling (MANDATORY) | |
 | 10 | Function Design (MANDATORY) | |
-| 11 | DDD Patterns (MANDATORY) | |
-| 12 | Naming Conventions (MANDATORY) | |
-| 13 | Directory Structure (MANDATORY) | |
-| 14 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 11 | Naming Conventions (MANDATORY) | |
+| 12 | Directory Structure (MANDATORY) | Midaz pattern |
+| 13 | RabbitMQ Worker Pattern (MANDATORY) | |
 
 ---
 


### PR DESCRIPTION
Remove explicit DDD sections from golang.md and typescript.md standards files. Update Directory Structure sections to follow Midaz pattern (simplified hexagonal without /domain folder). Update all related agents and skills to reference Midaz pattern instead of DDD.

X-Lerian-Ref: 0x1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural guidance across all engineering standards documents, replacing Domain-Driven Design with the new Midaz pattern (simplified hexagonal architecture).
  * Reorganized standards compliance requirements and reference materials for backend and frontend engineering teams.
  * Established Midaz pattern as the mandatory architecture approach in directory structure and compliance tables across all service types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->