### PR TITLE
feat(standards): enforce HARD GATE verification for all agents in dev…

### DIFF
--- a/dev-team/skills/shared-patterns/standards-coverage-table.md
+++ b/dev-team/skills/shared-patterns/standards-coverage-table.md
@@ -252,27 +252,33 @@ These sections describe HOW to use the standards, not WHAT the standards are.
 
 ---
 
-### typescript.md (Used by: backend-engineer-typescript, frontend-bff-engineer-typescript)
+### backend-engineer-typescript → typescript.md
 
 | # | Section to Check | Key Subsections |
 |---|------------------|-----------------|
-| 1 | Version (MANDATORY) | |
-| 2 | Strict Configuration (MANDATORY) | |
+| 1 | Version (MANDATORY) | TypeScript 5.0+, Node.js 20+ |
+| 2 | Strict Configuration (MANDATORY) | tsconfig.json strict mode |
 | 3 | Frameworks & Libraries (MANDATORY) | Express, Fastify, NestJS, Hono, tRPC, Prisma, Drizzle, TypeORM, Kysely, Zod, Yup, joi, class-validator, Vitest, Jest, Supertest, testcontainers |
-| 4 | Type Safety Rules (MANDATORY) | |
-| 5 | Zod Validation Patterns (MANDATORY) | |
-| 6 | Dependency Injection (MANDATORY) | |
-| 7 | AsyncLocalStorage for Context (MANDATORY) | |
-| 8 | Testing Patterns (MANDATORY) | |
-| 9 | Error Handling (MANDATORY) | |
-| 10 | Function Design (MANDATORY) | |
-| 11 | Naming Conventions (MANDATORY) | |
+| 4 | Type Safety Rules (MANDATORY) | No any, branded types, discriminated unions |
+| 5 | Zod Validation Patterns (MANDATORY) | Schema validation |
+| 6 | Dependency Injection (MANDATORY) | TSyringe patterns |
+| 7 | AsyncLocalStorage for Context (MANDATORY) | Request context propagation |
+| 8 | Testing Patterns (MANDATORY) | Type-safe mocks, fixtures, edge cases |
+| 9 | Error Handling (MANDATORY) | Custom error classes |
+| 10 | Function Design (MANDATORY) | Single responsibility |
+| 11 | Naming Conventions (MANDATORY) | Files, interfaces, types |
 | 12 | Directory Structure (MANDATORY) | Midaz pattern |
-| 13 | RabbitMQ Worker Pattern (MANDATORY) | |
+| 13 | RabbitMQ Worker Pattern (MANDATORY) | Async message processing |
 
 ---
 
-### frontend.md (Used by: frontend-engineer, frontend-designer)
+### frontend-bff-engineer-typescript → typescript.md
+
+**Same sections as backend-engineer-typescript (13 sections).** See above.
+
+---
+
+### frontend-engineer → frontend.md
 
 | # | Section to Check |
 |---|------------------|
@@ -289,6 +295,12 @@ These sections describe HOW to use the standards, not WHAT the standards are.
 | 11 | Directory Structure (MANDATORY) |
 | 12 | FORBIDDEN Patterns (MANDATORY) |
 | 13 | Standards Compliance Categories (MANDATORY) |
+
+---
+
+### frontend-designer → frontend.md
+
+**Same sections as frontend-engineer (13 sections).** See above.
 
 ---
 

--- a/dev-team/skills/shared-patterns/template-tdd-prompts.md
+++ b/dev-team/skills/shared-patterns/template-tdd-prompts.md
@@ -79,27 +79,62 @@ Example failure output:
 4. Run the test
 5. **CAPTURE THE PASS OUTPUT** - this is MANDATORY
 6. Refactor if needed (keeping tests green)
-7. Commit
+7. **VERIFY STANDARDS COMPLIANCE** - Complete the checklist below
+8. Commit
 
-**RING STANDARDS REQUIREMENTS (MANDATORY):**
-- Follow architecture patterns from Ring Standards (Hexagonal, Clean Architecture, etc.)
-- Implement proper error handling (no panic, wrap errors with context)
-- Add structured JSON logging for all operations
-- Add OpenTelemetry tracing spans for external calls and key operations
-- Ensure trace_id propagation in all log entries
+**⛔ RING STANDARDS REQUIREMENTS (MANDATORY - ALL MUST BE IMPLEMENTED):**
+
+**You MUST WebFetch and implement ALL sections from Ring Standards for your language:**
+- **Go:** `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang.md`
+- **TypeScript:** `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md`
+
+**⛔ HARD GATE: You MUST implement ALL sections listed in [standards-coverage-table.md](../shared-patterns/standards-coverage-table.md).**
+
+- **Go projects:** See `backend-engineer-golang → golang.md` section index (20 sections)
+- **TypeScript projects:** See `backend-engineer-typescript → typescript.md` section index (13 sections)
+
+**You CANNOT skip ANY section. Mark N/A only with explicit justification.**
 
 **PROJECT-SPECIFIC (from PROJECT_RULES.md, if exists):**
 - Use internal libraries referenced in PROJECT_RULES.md
 - Follow project-specific naming conventions (if different from Ring Standards)
 - Use tech stack choices defined in PROJECT_RULES.md (database, frameworks, etc.)
 
-**REQUIRED OUTPUT:**
-- Implementation file path
-- **PASS OUTPUT** (copy/paste the actual test pass)
-- Files changed
-- Ring Standards followed: Y/N
-- Observability added (logging: Y/N, tracing: Y/N)
-- Commit SHA
+**⛔ REQUIRED OUTPUT (HARD GATE - ALL SECTIONS MANDATORY):**
+
+## Implementation Summary
+- Implementation file path: [path]
+- Files changed: [list]
+- Commit SHA: [sha]
+
+## Test Results
+**PASS OUTPUT** (copy/paste the actual test pass):
+```
+[paste actual output here]
+```
+
+## Standards Coverage Table
+
+**You MUST output a Standards Coverage Table per [shared-patterns/standards-coverage-table.md](../shared-patterns/standards-coverage-table.md).**
+
+**Format:**
+```
+| # | Section (from standards-coverage-table.md) | Status | Evidence |
+|---|-------------------------------------------|--------|----------|
+| 1 | [Section Name] | ✅/❌ | [file:line] |
+| ... | ... | ... | ... |
+```
+
+**Status Legend:**
+- ✅ Implemented - Code follows this standard (with file:line evidence)
+- ❌ Not Implemented - Missing or incorrect (BLOCKS proceeding)
+- N/A - Not applicable (with reason)
+
+## Compliance Summary
+- **ALL STANDARDS MET:** ✅ YES / ❌ NO
+- **If NO, what's missing:** [list missing items with section names]
+
+**⛔ IF "ALL STANDARDS MET" = NO → Implementation is INCOMPLETE. Fix before proceeding.**
 
 Example pass output:
 ```
@@ -124,7 +159,66 @@ IF failure_output is empty OR contains "PASS":
 IF pass_output is empty OR contains "FAIL":
   → Return to TDD-GREEN (retry implementation)
   → Max 3 retries, then STOP and report blocker
+
+IF "ALL STANDARDS MET" = NO:
+  → STOP. Cannot proceed to Gate 1.
+  → Re-dispatch to same agent with fix request:
+    "Fix missing standards: [list from compliance checklist]"
+  → Max 3 retries, then STOP and report blocker
 ```
+
+### Standards Compliance Verification (HARD GATE)
+
+**The orchestrator MUST verify the agent's Standards Coverage Table before proceeding:**
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│  GATE 0 COMPLETION CHECK                                                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                             │
+│  1. Parse agent output for "## Standards Coverage Table"                    │
+│  2. Verify table has ALL sections from standards-coverage-table.md          │
+│  3. Check "ALL STANDARDS MET" value in Compliance Summary                   │
+│                                                                             │
+│  IF "ALL STANDARDS MET: ✅ YES" AND all sections have ✅ or N/A:            │
+│    → Gate 0 PASSED. Proceed to Gate 1 (DevOps)                              │
+│                                                                             │
+│  IF ANY section has ❌:                                                      │
+│    → Gate 0 BLOCKED. Standards not implemented.                             │
+│    → Extract ❌ sections from Standards Coverage Table                       │
+│    → Re-dispatch to SAME agent with fix request:                            │
+│                                                                             │
+│      Task tool:                                                             │
+│        subagent_type: "[same agent that did TDD-GREEN]"                     │
+│        model: "opus"                                                        │
+│        description: "Fix missing Ring Standards for [unit_id]"              │
+│        prompt: |                                                            │
+│          ⛔ FIX REQUIRED - Ring Standards Not Implemented                   │
+│                                                                             │
+│          Your Standards Coverage Table shows these sections as ❌:          │
+│          [list ❌ sections from table]                                       │
+│                                                                             │
+│          WebFetch the standards again:                                      │
+│          [URL for language-specific standards]                              │
+│                                                                             │
+│          Implement ALL missing sections.                                    │
+│          Return updated Standards Coverage Table with ALL ✅ or N/A.        │
+│                                                                             │
+│    → After fix: Re-verify Standards Coverage Table                          │
+│    → Max 3 iterations, then STOP and escalate to user                       │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Anti-Rationalization for Standards Compliance
+
+See [shared-patterns/standards-coverage-table.md](../shared-patterns/standards-coverage-table.md) for the complete anti-rationalization table.
+
+**Key rules:**
+- ALL sections from standards-coverage-table.md MUST be checked
+- ❌ on ANY section = BLOCKED (dispatch fix to same agent)
+- N/A requires explicit reason
+- Evidence (file:line) REQUIRED for all ✅ items
 
 ## Standards Priority Summary
 


### PR DESCRIPTION
- Add HARD GATE enforcement to Gates 0, 1, 2, 4 with Standards Coverage Table verification
- Require ALL agents to output Standards Coverage Table with evidence for each section
- Add fix dispatch loops: if ANY section fails, dispatch fix and re-verify (max 3 iterations)
- Standardize agent indexes in standards-coverage-table.md for all 9 dev-team agents
- Reference standards-coverage-table.md as single source of truth (no content duplication)

Agent → Standards mapping:
- backend-engineer-golang → golang.md (20 sections)
- backend-engineer-typescript → typescript.md (13 sections)
- frontend-bff-engineer-typescript → typescript.md (13 sections)
- frontend-engineer → frontend.md (13 sections)
- frontend-designer → frontend.md (13 sections)
- devops-engineer → devops.md (7 sections)
- sre → sre.md (6 sections)
- qa-analyst → golang.md OR typescript.md (testing sections)

Every agent MUST follow Ring Standards. No negotiation. No exceptions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced development cycle gates with mandatory compliance checks for artifact validation, observability standards, and code review requirements.
  * Standardized requirements mapping across backend and frontend engineering roles with explicit standards enforcement sections.
  * Expanded gate workflows with structured output formats for standards coverage tracking, compliance verification, and issue routing.
  * Introduced iterative review cycles with escalation paths and anti-rationalization guidance to prevent shortcutting critical quality gates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->