### PR TITLE
fix(dev-team): add anti-deferral enforcement for Ring Standards

### DIFF
--- a/dev-team/skills/dev-sre/SKILL.md
+++ b/dev-team/skills/dev-sre/SKILL.md
@@ -121,7 +121,8 @@ This skill VALIDATES that observability was correctly implemented by developers:
 | **CRITICAL** | Missing ALL observability (no structured logs) | FAIL | ❌ Return to Gate 0 |
 | **CRITICAL** | fmt.Println/echo instead of JSON logs | FAIL | ❌ Return to Gate 0 |
 | **CRITICAL** | Verification commands not run | FAIL | ❌ Cannot mark complete |
-| **LOW** | Dashboard deferred for non-critical service | PARTIAL | ✅ Can proceed with note |
+| **CRITICAL** | "DEFERRED" appears in validation output | FAIL | ❌ Return to Gate 0 |
+| **LOW** | Dashboard not yet created (dashboards are optional) | PARTIAL | ✅ Can proceed with note |
 
 ## Pressure Resistance
 
@@ -245,8 +246,7 @@ See [shared-patterns/shared-anti-rationalization.md](../shared-patterns/shared-a
 |-------------|--------|-------|
 | Structured JSON logs | **REQUIRED** | With trace_id correlation |
 
-**Can be deferred with explicit approval:**
-- Distributed tracing (for standalone workers only)
+**Distributed tracing** is optional for standalone workers (no external calls).
 
 ## Handling Pushback
 

--- a/dev-team/skills/shared-patterns/shared-anti-rationalization.md
+++ b/dev-team/skills/shared-patterns/shared-anti-rationalization.md
@@ -6,6 +6,27 @@ AI models naturally attempt to be "helpful" by making autonomous decisions. This
 
 ---
 
+## ⛔ Standards Deferral Anti-Rationalizations (CRITICAL)
+
+**Ring Standards apply from Task 1. DEFERRED = FAILED. No exceptions.**
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "PM plan says X is for later tasks" | PM defines WHAT to build, not HOW. Ring Standards define HOW. | **Implement ALL standards NOW** |
+| "Task 1 is just initial setup" | Setup WITH standards = correct setup. Without = wrong from Day 1. | **Implement ALL standards NOW** |
+| "Basic implementation is sufficient initially" | "Basic" is not compliant. Full standards or fail. | **Implement ALL standards NOW** |
+| "DEFERRED to later tasks as per plan" | DEFERRED = FAILED. Standards are not deferrable. | **Implement ALL standards NOW** |
+| "Task dependency graph shows standards later" | Dependency graph is for features, NOT for standards. Standards are prerequisites. | **Implement ALL standards NOW** |
+| "This standard doesn't apply to Task 1 scope" | ALL standards apply to ALL tasks. Scope is irrelevant. | **Implement ALL standards NOW** |
+| "Will add observability/testing/error-handling later" | Later = never. Retrofitting is 10x harder. | **Implement ALL standards NOW** |
+| "MVP doesn't need full standards" | MVP with standards = correct MVP. Without = technical debt from Day 1. | **Implement ALL standards NOW** |
+
+**⛔ HARD GATE:** If your output contains "DEFERRED" regarding ANY Ring Standard → Implementation is INCOMPLETE. Fix before proceeding.
+
+**⛔ SEVERITY:** Any agent outputting "DEFERRED" for a Ring Standard = CRITICAL FAILURE = Return to previous gate.
+
+---
+
 ## Universal Anti-Rationalizations
 
 These rationalizations are ALWAYS wrong, regardless of context:

--- a/dev-team/skills/shared-patterns/template-tdd-prompts.md
+++ b/dev-team/skills/shared-patterns/template-tdd-prompts.md
@@ -72,6 +72,14 @@ Example failure output:
 **PROJECT CONTEXT (if PROJECT_RULES.md exists):**
 [Insert relevant project-specific info: tech stack, internal libs, conventions]
 
+## ⛔ CRITICAL: ALL Ring Standards Apply from Task 1 (NO DEFERRAL)
+
+**See [shared-anti-rationalization.md](./shared-anti-rationalization.md) → "Standards Deferral Anti-Rationalizations" section.**
+
+**Summary:** Ring Standards are NOT phased. They apply IMMEDIATELY to EVERY task. PM defines WHAT, Ring Standards define HOW.
+
+**⛔ HARD GATE:** If you output "DEFERRED" regarding ANY Ring Standard → Implementation is INCOMPLETE. Fix before proceeding.
+
 **INSTRUCTIONS (TDD-GREEN):**
 1. Follow Ring Standards for architecture, error handling, and patterns
 2. Write MINIMAL code to make the test pass


### PR DESCRIPTION
- Add Standards Deferral Anti-Rationalizations section to shared-anti-rationalization.md
- Add DEFERRED as CRITICAL failure in dev-sre severity calibration
- Add NO DEFERRAL warning section to template-tdd-prompts.md
- Clarify that dashboards are optional, not deferrable standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified service dashboard requirements: dashboards are now explicitly noted as optional rather than deferred for non-critical services
  * Updated distributed tracing guidance to clarify it is optional for standalone workers with no external calls
  * Enhanced standards compliance documentation with critical guidance emphasizing standards must be implemented immediately without deferral exceptions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->