### PR TITLE
refactor(skills): rename version-release-info to release-guide-info

### DIFF
--- a/default/commands/release-guide.md
+++ b/default/commands/release-guide.md
@@ -1,88 +1,35 @@
 ---
 name: release-guide
 description: Generate an Ops Update Guide from git diff between two refs
-argument-hint: "<base-ref> <target-ref> [--version <version>] [--lang <en|pt-br|both>]"
 ---
 
-Generate an internal Operations-facing update/migration guide based on git diff analysis between two refs.
+Generate an internal Operations-facing update/migration guide based on git diff analysis.
 
 ## Usage
 
 ```
-/release-guide <base-ref> <target-ref> [options]
+/release-guide
 ```
 
-## Arguments
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `<base-ref>` | Yes | Starting point (branch, tag, or SHA) |
-| `<target-ref>` | Yes | Ending point (branch, tag, or SHA) |
-| `--version <version>` | No | Explicit version number (auto-detected from tags if not provided) |
-| `--lang <en\|pt-br\|both>` | No | Output language(s), default: `en` |
-| `--mode <strict\|clone>` | No | Execution mode, default: `strict` (STRICT_NO_TOUCH) |
-
-## Examples
-
-### Basic usage (main to HEAD)
-
-```
-/release-guide main HEAD
-```
-
-### Between tags (version auto-detected)
-
-```
-/release-guide <previous-tag> <current-tag>
-```
-
-### With explicit version
-
-```
-/release-guide main HEAD --version <version>
-```
-
-### Both languages
-
-```
-/release-guide <base-ref> <target-ref> --lang both
-```
-
-### Portuguese only
-
-```
-/release-guide <base-ref> <target-ref> --lang pt-br
-```
+This command invokes the `release-guide-info` skill, which will interactively collect all required information:
+- Base ref (starting point)
+- Target ref (ending point)
+- Version (optional, auto-detected from tags)
+- Language (en, pt-br, or both)
+- Execution mode
 
 ## Output
 
-The command generates:
+The skill generates:
 1. **Preview summary** - Shows configuration and change counts
 2. **User confirmation** - Waits for approval before writing
 3. **Release guide file(s)** - Written to `notes/releases/`
-
-**File naming:**
-- With version: `{DATE}_{REPO}-{VERSION}.md`
-- Without version: `{DATE}_{REPO}-{BASE}-to-{TARGET}.md`
-- Portuguese suffix: `_pt-br.md`
-
-## Process
-
-The command follows the `version-release-info` skill workflow:
-
-1. **Resolve refs** - Verify both refs exist
-2. **Tag detection** - Auto-extract version from tags
-3. **Commit analysis** - Parse commit messages for context
-4. **Diff analysis** - Analyze changes between refs
-5. **Build inventory** - Categorize changes
-6. **Preview** - Show summary for confirmation
-7. **Generate guide** - Write file(s) to disk
 
 ## Related
 
 | Command/Skill | Relationship |
 |---------------|--------------|
-| `version-release-info` skill | Underlying skill with full workflow |
+| `release-guide-info` skill | Full workflow with all options |
 | `/commit` | Use after release guide to commit changes |
 | `finishing-a-development-branch` | Complementary workflow for branch completion |
 
@@ -93,7 +40,7 @@ The command follows the `version-release-info` skill workflow:
 **This command MUST load the skill for complete workflow execution.**
 
 ```
-Use Skill tool: version-release-info
+Use Skill tool: release-guide-info
 ```
 
 The skill contains the complete workflow with:

--- a/default/skills/release-guide-info/SKILL.md
+++ b/default/skills/release-guide-info/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: version-release-info
-version: 1.1.0
+name: release-guide-info
+version: 1.2.0
 description: |
   Generate Ops Update Guide from Git Diff. Produces internal Operations-facing
   update/migration guides based on git diff analysis. Supports STRICT_NO_TOUCH (default)
@@ -78,7 +78,7 @@ related:
   complementary: [finishing-a-development-branch, handoff-tracking]
 ---
 
-# Version Release Info — Ops Update Guide Generator
+# Release Guide Info — Ops Update Guide Generator
 
 ## Overview
 


### PR DESCRIPTION
Rename skill from version-release-info to release-guide-info for consistency with the /release-guide command. Simplify command to invoke skill interactively without requiring arguments.

X-Lerian-Ref: 0x1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified release-guide command documentation, shifting from detailed CLI argument definitions to an interactive workflow description.
  * Updated skill reference and expanded workflow documentation to include dual language support, preview steps, and quality checklists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->