### PR TITLE
fix: use fully qualified name for requesting-code-review skill in dev…

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -25,7 +25,7 @@ sequence:
   before: [dev-feedback-loop]
 
 related:
-  complementary: [dev-implementation, dev-devops, dev-sre, dev-testing, requesting-code-review, dev-validation, dev-feedback-loop]
+  complementary: [dev-implementation, dev-devops, dev-sre, dev-testing, ring-default:requesting-code-review, dev-validation, dev-feedback-loop]
 
 verification:
   automated:
@@ -166,7 +166,7 @@ This is not negotiable:
 - Gate 1: `Skill("dev-devops")` → then `Task(subagent_type="devops-engineer", ...)`
 - Gate 2: `Skill("dev-sre")` → then `Task(subagent_type="sre", ...)`
 - Gate 3: `Skill("dev-testing")` → then `Task(subagent_type="qa-analyst", ...)`
-- Gate 4: `Skill("requesting-code-review")` → then 3x `Task(...)` in parallel
+- Gate 4: `Skill("ring-default:requesting-code-review")` → then 3x `Task(...)` in parallel
 - Gate 5: `Skill("dev-validation")` → N/A (verification only)
 </cannot_skip>
 
@@ -402,7 +402,7 @@ Day 4: Production incident from Day 1 code
 | 1 | dev-devops | Infrastructure and deployment | devops-engineer |
 | 2 | dev-sre | Observability (health, logging, tracing) | sre |
 | 3 | dev-testing | Unit tests for acceptance criteria | qa-analyst |
-| 4 | requesting-code-review | Parallel code review | code-reviewer, business-logic-reviewer, security-reviewer (3x parallel) |
+| 4 | ring-default:requesting-code-review | Parallel code review | code-reviewer, business-logic-reviewer, security-reviewer (3x parallel) |
 | 5 | dev-validation | Final acceptance validation | N/A (verification) |
 
 ## Integrated PM → Dev Workflow
@@ -2151,9 +2151,9 @@ testing_input = {
 
 ## Step 6: Gate 4 - Review (Per Execution Unit)
 
-**REQUIRED SUB-SKILL:** Use `requesting-code-review`
+**REQUIRED SUB-SKILL:** Use `ring-default:requesting-code-review`
 
-### Step 6.1: Prepare Input for requesting-code-review Skill
+### Step 6.1: Prepare Input for ring-default:requesting-code-review Skill
 
 ```text
 Gather from previous gates:
@@ -2172,14 +2172,14 @@ review_input = {
 }
 ```
 
-### Step 6.2: Invoke requesting-code-review Skill
+### Step 6.2: Invoke ring-default:requesting-code-review Skill
 
 ```text
 1. Record gate start timestamp
 
-2. Invoke requesting-code-review skill with structured input:
+2. Invoke ring-default:requesting-code-review skill with structured input:
 
-   Skill("requesting-code-review") with input:
+   Skill("ring-default:requesting-code-review") with input:
      unit_id: review_input.unit_id
      base_sha: review_input.base_sha
      head_sha: review_input.head_sha
@@ -2220,7 +2220,7 @@ review_input = {
 ### Step 6.3: Gate 4 Complete
 
 ```text
-5. When requesting-code-review skill returns PASS:
+5. When ring-default:requesting-code-review skill returns PASS:
    
    Parse from skill output:
    - reviewers_passed: extract from "## Reviewer Verdicts" (should be "3/3")
@@ -2230,7 +2230,7 @@ review_input = {
    - iterations: extract from "Iterations:" line
    
    - agent_outputs.review = {
-       skill: "requesting-code-review",
+       skill: "ring-default:requesting-code-review",
        output: "[full skill output]",
        iterations: [count],
        timestamp: "[ISO timestamp]",


### PR DESCRIPTION
The skill was failing to load because it referenced 'requesting-code-review' without the plugin prefix. Updated all 10 occurrences to use 'ring-default:requesting-code-review'.

X-Lerian-Ref: 0x1