### PR TITLE
fix(hooks): replace heredoc with printf to prevent shell parse errors

### DIFF
--- a/default/hooks/claude-md-reminder.sh
+++ b/default/hooks/claude-md-reminder.sh
@@ -191,13 +191,8 @@ duplication_guard="${duplication_guard}</duplication-prevention-guard>\n"
 reminder="${reminder}${duplication_guard}"
 
 # Output hook response with injected context
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "UserPromptSubmit",
-    "additionalContext": "${reminder}"
-  }
-}
-EOF
+# Use printf with %s to prevent shell interpretation of special characters
+# (heredoc with ${reminder} would expand $(), backticks, and ! in file content)
+printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "UserPromptSubmit",\n    "additionalContext": "%s"\n  }\n}\n' "$reminder"
 
 exit 0


### PR DESCRIPTION
The heredoc in claude-md-reminder.sh expanded ${reminder} which contained CLAUDE.md content with shell metacharacters (!, ), $(), backticks). This caused bash parse errors when the hook ran. Replace cat <<EOF with printf '%s' to treat content as a literal string.

X-Lerian-Ref: 0x1