### PR TITLE
fix(hooks): replace heredoc with printf in all session-start hooks

### DIFF
--- a/default/hooks/session-start.sh
+++ b/default/hooks/session-start.sh
@@ -165,13 +165,7 @@ doubt_questions_escaped=$(json_escape "$DOUBT_QUESTIONS")
 additional_context="<ring-critical-rules>\n${critical_rules_escaped}\n</ring-critical-rules>\n\n<ring-doubt-questions>\n${doubt_questions_escaped}\n</ring-doubt-questions>\n\n<ring-skills-system>\n${overview_escaped}\n</ring-skills-system>"
 
 # Build JSON output
-cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${additional_context}"
-  }
-}
-EOF
+# Use printf %s to prevent shell interpretation of metacharacters in content
+printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$additional_context"
 
 exit 0

--- a/dev-team/hooks/session-start.sh
+++ b/dev-team/hooks/session-start.sh
@@ -80,14 +80,8 @@ For full details: Skill tool with \"ring-dev-team:using-dev-team\"
     # Escape for JSON using shared utility
     context_escaped=$(json_escape "$context")
 
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${context_escaped}"
-  }
-}
-EOF
+    # Use printf %s to prevent shell interpretation of metacharacters in agent descriptions
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context_escaped"
   else
     # Fallback to static output if script fails
     cat <<'EOF'

--- a/finops-team/hooks/session-start.sh
+++ b/finops-team/hooks/session-start.sh
@@ -65,14 +65,8 @@ For full details: Skill tool with \"ring-finops-team:using-finops-team\"
     # Escape for JSON using shared utility
     context_escaped=$(json_escape "$context")
 
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${context_escaped}"
-  }
-}
-EOF
+    # Use printf %s to prevent shell interpretation of metacharacters in agent descriptions
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context_escaped"
   else
     # Fallback to static output
     cat <<'EOF'

--- a/pm-team/hooks/session-start.sh
+++ b/pm-team/hooks/session-start.sh
@@ -118,14 +118,8 @@ For full details: Skill tool with \"ring-pm-team:using-pm-team\"
     # Escape for JSON using shared utility
     context_escaped=$(json_escape "$context")
 
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${context_escaped}"
-  }
-}
-EOF
+    # Use printf %s to prevent shell interpretation of metacharacters in agent descriptions
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context_escaped"
   else
     # Fallback to static output if dynamic discovery fails
     cat <<'EOF'

--- a/pmo-team/hooks/session-start.sh
+++ b/pmo-team/hooks/session-start.sh
@@ -74,14 +74,8 @@ For full details: Skill tool with \"ring-pmo-team:using-pmo-team\"
     # Escape for JSON using shared utility
     context_escaped=$(json_escape "$context")
 
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${context_escaped}"
-  }
-}
-EOF
+    # Use printf %s to prevent shell interpretation of metacharacters in agent descriptions
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context_escaped"
   else
     # Fallback to static output if script fails
     cat <<'EOF'

--- a/tw-team/hooks/session-start.sh
+++ b/tw-team/hooks/session-start.sh
@@ -67,14 +67,8 @@ For full details: Skill tool with \"ring-tw-team:using-tw-team\"
     # Escape for JSON using shared utility
     context_escaped=$(json_escape "$context")
 
-    cat <<EOF
-{
-  "hookSpecificOutput": {
-    "hookEventName": "SessionStart",
-    "additionalContext": "${context_escaped}"
-  }
-}
-EOF
+    # Use printf %s to prevent shell interpretation of metacharacters in agent descriptions
+    printf '{\n  "hookSpecificOutput": {\n    "hookEventName": "SessionStart",\n    "additionalContext": "%s"\n  }\n}\n' "$context_escaped"
   else
     # Fallback to static output if script fails
     cat <<'EOF'


### PR DESCRIPTION
All 6 plugin session-start.sh hooks used cat <<EOF with variable interpolation, causing bash parse errors when agent descriptions contained shell metacharacters (!), backticks, $()). Replace with printf '%s' to treat content as literal strings.

X-Lerian-Ref: 0x1