### PR TITLE
feat(dev-cycle): defer Gates 6-7 execution to end of cycle

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -102,7 +102,7 @@ The development cycle orchestrator loads tasks/subtasks from PM team output (or 
 
 This keeps test code current with each feature while avoiding redundant container spin-ups during development.
 
-**Announce at start:** "I'm using the ring:dev-cycle skill to orchestrate task execution through 10 gates (Gate 0–9). Gates 6-7 write tests per unit but execute at end of cycle."
+**MUST announce at start:** "I'm using the ring:dev-cycle skill to orchestrate task execution through 10 gates (Gate 0–9). Gates 6-7 write tests per unit but execute at end of cycle."
 
 ## ⛔ CRITICAL: Specialized Agents Perform All Tasks
 


### PR DESCRIPTION
Integration and chaos tests (Gates 6-7) now follow a write-then-execute model: test code is written/updated per unit during the gate pass (compilation verified, no containers), then all tests execute once at end of cycle (Step 12.0). This keeps tests current with each feature while avoiding redundant container spin-ups during development.

X-Lerian-Ref: 0x1