### PR TITLE
feat(standards): add Unit Test Scope & Boundaries section

### DIFF
--- a/dev-team/docs/standards/golang/index.md
+++ b/dev-team/docs/standards/golang/index.md
@@ -179,8 +179,8 @@ This directory contains modular Go standards for Lerian Studio. Load only the mo
 | 7 | Mock Generation (MANDATORY) | [#mock-generation-mandatory](testing-unit.md#mock-generation-mandatory) |
 | 8 | Environment Variables in Tests (MANDATORY) | [#environment-variables-in-tests-mandatory](testing-unit.md#environment-variables-in-tests-mandatory) |
 | 9 | Shared Test Utilities (MANDATORY) | [#shared-test-utilities-mandatory](testing-unit.md#shared-test-utilities-mandatory) |
-| 10 | Unit Test Quality Gate (MANDATORY) | [#unit-test-quality-gate-mandatory](testing-unit.md#unit-test-quality-gate-mandatory) |
-| 11 | Unit Test Scope & Boundaries (MANDATORY) | [#unit-test-scope--boundaries-mandatory](testing-unit.md#unit-test-scope--boundaries-mandatory) |
+| 10 | Unit Test Scope & Boundaries (MANDATORY) | [#unit-test-scope--boundaries-mandatory](testing-unit.md#unit-test-scope--boundaries-mandatory) |
+| 11 | Unit Test Quality Gate (MANDATORY) | [#unit-test-quality-gate-mandatory](testing-unit.md#unit-test-quality-gate-mandatory) |
 
 ### Fuzz Testing (testing-fuzz.md) - Gate 4
 

--- a/dev-team/docs/standards/golang/testing-unit.md
+++ b/dev-team/docs/standards/golang/testing-unit.md
@@ -21,8 +21,8 @@ This module covers unit testing patterns for Go projects. Unit tests verify code
 | 7 | [Mock Generation](#mock-generation-mandatory) | GoMock patterns |
 | 8 | [Environment Variables in Tests](#environment-variables-in-tests-mandatory) | t.Setenv patterns |
 | 9 | [Shared Test Utilities](#shared-test-utilities-mandatory) | testutils import patterns |
-| 10 | [Unit Test Quality Gate](#unit-test-quality-gate-mandatory) | Checklist before completion |
-| 11 | [Unit Test Scope & Boundaries](#unit-test-scope--boundaries-mandatory) | What belongs in unit tests vs integration tests |
+| 10 | [Unit Test Scope & Boundaries](#unit-test-scope--boundaries-mandatory) | What belongs in unit tests vs integration tests |
+| 11 | [Unit Test Quality Gate](#unit-test-quality-gate-mandatory) | Checklist before completion |
 
 **Meta-sections:** [Anti-Rationalization Table](#anti-rationalization-table-unit-testing)
 
@@ -610,6 +610,52 @@ grep -rn "func Ptr\[" --include="*_test.go" ./internal ./pkg
 
 ---
 
+## Unit Test Scope & Boundaries (MANDATORY)
+
+**HARD GATE:** Unit tests verify code behavior **in isolation**. All external dependencies MUST be mocked. Connecting to real databases, message queues, or external services in unit tests is FORBIDDEN.
+
+### What Belongs in Unit Tests
+
+| Allowed | Tool | Example |
+|---------|------|---------|
+| Mock repository interfaces | GoMock | `mockRepo.EXPECT().Create(gomock.Any(), gomock.Any())` |
+| Mock service interfaces | GoMock | `mockSvc.EXPECT().Process(gomock.Any())` |
+| Mock HTTP clients | GoMock | `mockClient.EXPECT().Get(gomock.Any())` |
+| In-memory data | Struct literals | `input := CreateRequest{Name: "test"}` |
+| Environment variables | t.Setenv | `t.Setenv("DB_HOST", "localhost")` |
+
+### What is FORBIDDEN in Unit Tests
+
+| FORBIDDEN | Why | Use Instead |
+|-----------|-----|-------------|
+| testcontainers | Spins up real containers — belongs in Gate 6 (integration) | GoMock interfaces |
+| Real PostgreSQL/MongoDB connections | Slow, flaky, not isolated | GoMock repository mocks |
+| Real Redis connections | External dependency | GoMock cache interface mocks |
+| Real RabbitMQ/Kafka | External dependency | GoMock publisher/consumer mocks |
+| `docker-compose` in test setup | Infrastructure dependency | GoMock all external interfaces |
+| HTTP calls to external APIs | Network dependency, flaky | GoMock HTTP client interface |
+
+### Boundary Rule
+
+```text
+Unit Test (Gate 3):     Code → Mock Interface → Assertion
+Integration Test (Gate 6): Code → testcontainers (real DB) → Assertion
+Chaos Test (Gate 7):    Code → Toxiproxy (failure injection) → Assertion
+```
+
+**If your test file imports `testcontainers-go` → it is NOT a unit test. Move it to `*_integration_test.go`.**
+
+### Anti-Rationalization: Scope Boundaries
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "Testing with real DB is more realistic" | Realistic = integration test (Gate 6). Unit tests verify logic in isolation. | **Mock the repository interface with GoMock** |
+| "GoMock is too verbose for DB tests" | Verbose mocks = explicit contracts. Implicit DB = hidden coupling. | **Use GoMock, complexity is the point** |
+| "I need to verify SQL queries" | SQL verification belongs in integration tests with testcontainers. | **Unit test the service logic, integration test the queries** |
+| "testcontainers is fast enough" | Speed is irrelevant. Unit tests MUST be isolated. No containers. | **Mock all external dependencies** |
+
+---
+
 ## Unit Test Quality Gate (MANDATORY)
 
 **Before marking unit tests complete:**
@@ -664,52 +710,6 @@ grep -rn "func Ptr\[" --include="*_test.go" ./internal ./pkg
 | Shared utilities | PASS | No local Ptr or duplicate helpers |
 | Edge cases | PASS | Minimum 3 per AC |
 ```
-
----
-
-## Unit Test Scope & Boundaries (MANDATORY)
-
-**HARD GATE:** Unit tests verify code behavior **in isolation**. All external dependencies MUST be mocked. Connecting to real databases, message queues, or external services in unit tests is FORBIDDEN.
-
-### What Belongs in Unit Tests
-
-| Allowed | Tool | Example |
-|---------|------|---------|
-| Mock repository interfaces | GoMock | `mockRepo.EXPECT().Create(gomock.Any(), gomock.Any())` |
-| Mock service interfaces | GoMock | `mockSvc.EXPECT().Process(gomock.Any())` |
-| Mock HTTP clients | GoMock | `mockClient.EXPECT().Get(gomock.Any())` |
-| In-memory data | Struct literals | `input := CreateRequest{Name: "test"}` |
-| Environment variables | t.Setenv | `t.Setenv("DB_HOST", "localhost")` |
-
-### What is FORBIDDEN in Unit Tests
-
-| FORBIDDEN | Why | Use Instead |
-|-----------|-----|-------------|
-| testcontainers | Spins up real containers — belongs in Gate 6 (integration) | GoMock interfaces |
-| Real PostgreSQL/MongoDB connections | Slow, flaky, not isolated | GoMock repository mocks |
-| Real Redis connections | External dependency | GoMock cache interface mocks |
-| Real RabbitMQ/Kafka | External dependency | GoMock publisher/consumer mocks |
-| `docker-compose` in test setup | Infrastructure dependency | GoMock all external interfaces |
-| HTTP calls to external APIs | Network dependency, flaky | GoMock HTTP client interface |
-
-### Boundary Rule
-
-```text
-Unit Test (Gate 3):     Code → Mock Interface → Assertion
-Integration Test (Gate 6): Code → testcontainers (real DB) → Assertion
-Chaos Test (Gate 7):    Code → Toxiproxy (failure injection) → Assertion
-```
-
-**If your test file imports `testcontainers-go` → it is NOT a unit test. Move it to `*_integration_test.go`.**
-
-### Anti-Rationalization: Scope Boundaries
-
-| Rationalization | Why It's WRONG | Required Action |
-|-----------------|----------------|-----------------|
-| "Testing with real DB is more realistic" | Realistic = integration test (Gate 6). Unit tests verify logic in isolation. | **Mock the repository interface with GoMock** |
-| "GoMock is too verbose for DB tests" | Verbose mocks = explicit contracts. Implicit DB = hidden coupling. | **Use GoMock, complexity is the point** |
-| "I need to verify SQL queries" | SQL verification belongs in integration tests with testcontainers. | **Unit test the service logic, integration test the queries** |
-| "testcontainers is fast enough" | Speed is irrelevant. Unit tests MUST be isolated. No containers. | **Mock all external dependencies** |
 
 ---
 

--- a/dev-team/skills/shared-patterns/standards-coverage-table.md
+++ b/dev-team/skills/shared-patterns/standards-coverage-table.md
@@ -410,8 +410,8 @@ These sections describe HOW to use the standards, not WHAT the standards are.
 | UNIT-7 | Mock Generation (MANDATORY) | `#mock-generation-mandatory` |
 | UNIT-8 | Environment Variables in Tests (MANDATORY) | `#environment-variables-in-tests-mandatory` |
 | UNIT-9 | Shared Test Utilities (MANDATORY) | `#shared-test-utilities-mandatory` |
-| UNIT-10 | Unit Test Quality Gate (MANDATORY) | `#unit-test-quality-gate-mandatory` |
-| UNIT-11 | Unit Test Scope & Boundaries (MANDATORY) | `#unit-test-scope--boundaries-mandatory` |
+| UNIT-10 | Unit Test Scope & Boundaries (MANDATORY) | `#unit-test-scope--boundaries-mandatory` |
+| UNIT-11 | Unit Test Quality Gate (MANDATORY) | `#unit-test-quality-gate-mandatory` |
 
 **For TypeScript projects (Unit Mode):**
 | # | Section to Check |


### PR DESCRIPTION
Adds explicit HARD GATE rule that unit tests MUST mock all external dependencies via GoMock. Using testcontainers, real databases, or any infrastructure in unit tests is FORBIDDEN. Clarifies the boundary: unit tests (Gate 3) verify logic in isolation, integration tests (Gate 6) verify real behavior with containers.

X-Lerian-Ref: 0x1