### PR TITLE
refactor(shared-patterns): extract codebase-explorer anti-rationaliza…

### DIFF
--- a/dev-team/skills/dev-refactor-frontend/SKILL.md
+++ b/dev-team/skills/dev-refactor-frontend/SKILL.md
@@ -379,13 +379,7 @@ Do not complete without outputting full report in the format above.
 
 ### Anti-Rationalization Table for Step 3
 
-| Rationalization | Why It's WRONG | Required Action |
-|-----------------|----------------|-----------------|
-| "I'll use Bash find/ls to quickly explore" | Bash cannot analyze patterns, just lists files. ring:codebase-explorer provides architectural analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "The Explore agent is faster" | "Explore" subagent_type is not "ring:codebase-explorer". Different agents. | **Use exact string: "ring:codebase-explorer"** |
-| "I already know the structure from find output" | Knowing file paths is not understanding architecture. Agent provides analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "This is a small codebase, Bash is enough" | Size is irrelevant. The agent provides standardized output format required by Step 4. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "I'll explore manually then dispatch agents" | Manual exploration skips the codebase-report.md artifact required for Step 4 gate. | **Use Task with subagent_type="ring:codebase-explorer"** |
+See [shared-patterns/anti-rationalization-codebase-explorer.md](../shared-patterns/anti-rationalization-codebase-explorer.md) for the ring:codebase-explorer dispatch anti-rationalization table.
 
 ### FORBIDDEN Actions for Step 3
 

--- a/dev-team/skills/dev-refactor/SKILL.md
+++ b/dev-team/skills/dev-refactor/SKILL.md
@@ -264,13 +264,7 @@ Do not complete without outputting full report in the format above.
 
 ### Anti-Rationalization Table for Step 3
 
-| Rationalization | Why It's WRONG | Required Action |
-|-----------------|----------------|-----------------|
-| "I'll use Bash find/ls to quickly explore" | Bash cannot analyze patterns, just lists files. ring:codebase-explorer provides architectural analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "The Explore agent is faster" | "Explore" subagent_type ≠ "ring:codebase-explorer". Different agents. | **Use exact string: "ring:codebase-explorer"** |
-| "I already know the structure from find output" | Knowing file paths ≠ understanding architecture. Agent provides analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "This is a small codebase, Bash is enough" | Size is irrelevant. The agent provides standardized output format required by Step 4. | **Use Task with subagent_type="ring:codebase-explorer"** |
-| "I'll explore manually then dispatch agents" | Manual exploration skips the codebase-report.md artifact required for Step 4 gate. | **Use Task with subagent_type="ring:codebase-explorer"** |
+See [shared-patterns/anti-rationalization-codebase-explorer.md](../shared-patterns/anti-rationalization-codebase-explorer.md) for the ring:codebase-explorer dispatch anti-rationalization table.
 
 ### FORBIDDEN Actions for Step 3
 

--- a/dev-team/skills/shared-patterns/anti-rationalization-codebase-explorer.md
+++ b/dev-team/skills/shared-patterns/anti-rationalization-codebase-explorer.md
@@ -1,0 +1,11 @@
+# Anti-Rationalization: ring:codebase-explorer Dispatch (Step 3)
+
+**MANDATORY: Step 3 MUST use `Task(subagent_type="ring:codebase-explorer")`.**
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "I'll use Bash find/ls to quickly explore" | Bash cannot analyze patterns, just lists files. ring:codebase-explorer provides architectural analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
+| "The Explore agent is faster" | "Explore" subagent_type is not "ring:codebase-explorer". Different agents. | **Use exact string: "ring:codebase-explorer"** |
+| "I already know the structure from find output" | Knowing file paths is not understanding architecture. Agent provides analysis. | **Use Task with subagent_type="ring:codebase-explorer"** |
+| "This is a small codebase, Bash is enough" | Size is irrelevant. The agent provides standardized output format required by Step 4. | **Use Task with subagent_type="ring:codebase-explorer"** |
+| "I'll explore manually then dispatch agents" | Manual exploration skips the codebase-report.md artifact required for Step 4 gate. | **Use Task with subagent_type="ring:codebase-explorer"** |


### PR DESCRIPTION
Move duplicated 5-row anti-rationalization table from dev-refactor and dev-refactor-frontend into shared-patterns/anti-rationalization-codebase-explorer.md. Both skills now reference the shared file.

X-Lerian-Ref: 0x1