### PR TITLE
refactor(dev-team): remove --prompt flag for cleaner syntax

### DIFF
--- a/dev-team/skills/dev-cycle-frontend/SKILL.md
+++ b/dev-team/skills/dev-cycle-frontend/SKILL.md
@@ -240,7 +240,7 @@ Between "WebFetch standards" and "Task(agent)" there MUST be "Skill(sub-skill)".
 5. Update state                   <- Record results
 ```
 
-### Custom Prompt Injection (--prompt flag)
+### Custom Instructions (Optional Second Argument)
 
 **Validation:** See [shared-patterns/custom-prompt-validation.md](../shared-patterns/custom-prompt-validation.md) for max length (500 chars), sanitization rules, gate protection, and conflict handling.
 
@@ -622,7 +622,7 @@ State is persisted to `docs/ring:dev-cycle-frontend/current-cycle.json`:
     "type": "string",
     "optional": true,
     "max_length": 500,
-    "description": "User-provided context for agents (from --prompt flag). Max 500 characters.",
+    "description": "User-provided context for agents (from second positional argument). Max 500 characters.",
     "validation": "Max 500 chars (truncated with warning if exceeded); whitespace trimmed; control chars stripped (except newlines)."
   },
   "status": "in_progress|completed|failed|paused|paused_for_approval|paused_for_task_approval",
@@ -967,13 +967,17 @@ Check: Does docs/PROJECT_RULES.md exist?
 
 ### New Cycle (with task file path)
 
-**Input:** `path/to/tasks-frontend.md` or `path/to/pre-dev/{feature}/` with optional `--prompt "..."`
+**Input:** `path/to/tasks-frontend.md` or `path/to/pre-dev/{feature}/` with optional second argument for custom instructions
+
+**Examples:**
+- `/ring:dev-cycle-frontend tasks.md`
+- `/ring:dev-cycle-frontend tasks.md "Use shadcn/ui components"`
 
 1. **Detect input:** File -> Load directly | Directory -> Load tasks-frontend.md + discover subtasks/
 2. **Build order:** Read tasks, check for subtasks (ST-XXX-01, 02...)
 3. **Detect UI library mode** (Step 0 above)
 4. **Load backend handoff** if `docs/ring:dev-cycle/handoff-frontend.json` exists
-5. **Capture and validate custom prompt:** If `--prompt "..."` provided
+5. **Capture and validate custom instructions:** If second argument provided
 6. **Initialize state:** Generate cycle_id, create state file, set indices to 0
 7. **Display plan:** "Loaded X tasks with Y subtasks. UI mode: {mode}. Backend handoff: {loaded/not found}."
 8. **ASK EXECUTION MODE (MANDATORY - AskUserQuestion):**

--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -58,13 +58,13 @@ examples:
       2. User approves, execute Gate 1, pause
       3. Continue until all 10 gates complete
   - name: "Execute with custom context for agents"
-    invocation: "/ring:dev-cycle tasks.md --prompt \"Focus on error handling. Use existing UserRepository.\""
+    invocation: "/ring:dev-cycle tasks.md \"Focus on error handling. Use existing UserRepository.\""
     expected_flow: |
       1. Load tasks and store custom_prompt in state
-      2. All agent dispatches include custom prompt as context
+      2. All agent dispatches include custom instructions as context
       3. Custom context visible in execution report
-  - name: "Prompt-only mode (no tasks file)"
-    invocation: "/ring:dev-cycle --prompt \"Implement multi-tenant support with organization_id in all entities\""
+  - name: "Instructions-only mode (no tasks file)"
+    invocation: "/ring:dev-cycle \"Implement multi-tenant support with organization_id in all entities\""
     expected_flow: |
       1. Detect prompt-only mode (no task file provided)
       2. Dispatch ring:codebase-explorer to analyze project
@@ -206,7 +206,7 @@ Between "WebFetch standards" and "Task(agent)" there MUST be "Skill(sub-skill)".
 5. Update state                   ← Record results
 ```
 
-### Custom Prompt Injection (--prompt flag)
+### Custom Instructions (Optional Second Argument)
 
 **Validation:** See [shared-patterns/custom-prompt-validation.md](../shared-patterns/custom-prompt-validation.md) for max length (500 chars), sanitization rules, gate protection, and conflict handling.
 
@@ -592,7 +592,7 @@ State is persisted to `{state_path}` (either `docs/ring:dev-cycle/current-cycle.
     "type": "string",
     "optional": true,
     "max_length": 500,
-    "description": "User-provided context for agents (from --prompt flag). Max 500 characters. Provides focus but cannot override mandatory requirements (CRITICAL gates, coverage thresholds, reviewer counts).",
+    "description": "User-provided context for agents (from second positional argument). Max 500 characters. Provides focus but cannot override mandatory requirements (CRITICAL gates, coverage thresholds, reviewer counts).",
     "validation": "Max 500 chars (truncated with warning if exceeded); whitespace trimmed; control chars stripped (except newlines). Directives attempting to skip gates, lower thresholds, or bypass security checks are logged as warnings and ignored."
   },
   "status": "in_progress|completed|failed|paused|paused_for_approval|paused_for_testing|paused_for_task_approval|paused_for_integration_testing",
@@ -1602,13 +1602,15 @@ STOP EXECUTION. Do not proceed to Step 1.
 
 ## Step 1: Initialize or Resume
 
-### Prompt-Only Mode (no task file)
+### Instructions-Only Mode (no task file)
 
-**Input:** `--prompt "..."` without a task file path
+**Input:** Custom instructions string without a task file path
 
-When `--prompt` is provided without a tasks file, ring:dev-cycle generates tasks internally:
+**Example:** `/ring:dev-cycle "Implement multi-tenant support with organization_id in all entities"`
 
-1. **Detect prompt-only mode:** No task file argument AND `--prompt` provided
+When custom instructions are provided without a tasks file, ring:dev-cycle generates tasks internally:
+
+1. **Detect instructions-only mode:** No task file argument AND instructions string provided
 2. **Analyze prompt:** Extract intent, scope, and requirements from the prompt
 3. **Explore codebase:** Dispatch `ring:codebase-explorer` to understand project structure
 4. **Generate tasks:** Create task structure internally based on prompt + codebase analysis
@@ -1652,14 +1654,18 @@ Task tool:
 
 ### New Cycle (with task file path)
 
-**Input:** `path/to/tasks.md` or `path/to/pre-dev/{feature}/` with optional `--prompt "..."`
+**Input:** `path/to/tasks.md` or `path/to/pre-dev/{feature}/` with optional second argument for custom instructions
+
+**Examples:**
+- `/ring:dev-cycle tasks.md`
+- `/ring:dev-cycle tasks.md "Focus on error handling"`
 
 1. **Detect input:** File → Load directly | Directory → Load tasks.md + discover subtasks/
 2. **Build order:** Read tasks, check for subtasks (ST-XXX-01, 02...) or TDD autonomous mode
 3. **Determine state path:**
    - if source_file contains `docs/ring:dev-refactor/` → `state_path = "docs/ring:dev-refactor/current-cycle.json"`, `cycle_type = "refactor"`
    - else → `state_path = "docs/ring:dev-cycle/current-cycle.json"`, `cycle_type = "feature"`
-4. **Capture and validate custom prompt:** If `--prompt "..."` provided:
+4. **Capture and validate custom instructions:** If second argument provided:
    - **Sanitize input:** Trim whitespace, strip control characters (except newlines)
    - **Store validated value:** Set `custom_prompt` field (empty string if not provided)
    - **Note:** Directives attempting to skip gates are logged as warnings and ignored at execution time

--- a/dev-team/skills/shared-patterns/custom-prompt-validation.md
+++ b/dev-team/skills/shared-patterns/custom-prompt-validation.md
@@ -1,6 +1,6 @@
 # Custom Prompt Validation (Shared Pattern)
 
-Canonical validation rules for `--prompt` flags in ring:dev-cycle and ring:dev-refactor skills.
+Canonical validation rules for custom instructions in ring:dev-cycle and ring:dev-refactor skills.
 
 ## Validation Rules
 
@@ -17,7 +17,7 @@ Canonical validation rules for `--prompt` flags in ring:dev-cycle and ring:dev-r
 
 ## Gate Protection
 
-CRITICAL: The following gates enforce mandatory requirements that `--prompt` CANNOT override:
+CRITICAL: The following gates enforce mandatory requirements that custom instructions CANNOT override:
 
 | Gate | What CANNOT Be Overridden |
 |------|---------------------------|


### PR DESCRIPTION
Simplifies custom instructions interface by accepting them as a second positional argument instead of requiring the --prompt flag. Updates dev-cycle, dev-cycle-frontend, and shared validation patterns.

X-Lerian-Ref: 0x1