### PR TITLE
feat(pm): add business deliverables view to task summary

### DIFF
--- a/pm-team/skills/pre-dev-task-breakdown/SKILL.md
+++ b/pm-team/skills/pre-dev-task-breakdown/SKILL.md
@@ -425,7 +425,7 @@ This file contains tasks filtered for the **{module}** module.
 
 ## Task Template Structure
 
-Output path depends on `topology.structure` (see [Output & After Approval](#output--after-approval)): single-repo produces one file at `docs/pre-dev/{feature}/tasks.md`; monorepo produces an index plus one file per module; multi-repo produces one file per repository with no central index. The file starts with two summary sections followed by the full task details.
+Output path depends on topology — see [Output & After Approval](#output--after-approval) for the full topology-dependent rules. The file starts with two summary sections followed by the full task details.
 
 ### File Summary Sections (top of tasks.md)
 
@@ -454,8 +454,8 @@ MUST appear immediately after Summary Table 1. A plain-language view for product
 
 | Task | Deliverable (business view) |
 |------|-----------------------------|
-| T-001 | The team can develop and test locally from day one — every contributor gets a working environment without manual setup. |
-| T-002 | Transactions reach their destination — messages conform to the agreed standard and counterparties accept every one sent. |
+| T-001 | The team can develop and test locally from day one — **every contributor gets a working environment without manual setup**. |
+| T-002 | **Transactions reach their destination** — messages conform to the agreed standard and counterparties accept every one sent. |
 | ... | _(additional tasks omitted for brevity)_ |
 ```
 


### PR DESCRIPTION
## Summary

- Adds **Summary Table 2 — Business Deliverables View** to the `tasks.md` output, immediately after the existing technical summary table
- Specifies writing rules: plain business language, active voice, no technical jargon, 1-3 sentences per task
- The view is derived from each task's existing `Deliverable` field, not invented separately
- Delivery Planning gate (Gate 9) inherits this view naturally since it reads `tasks.md`

## Why this placement (tasks.md, not delivery-roadmap.md)

Gate 7 (task-breakdown) owns the *"what will be delivered"* definition. The business deliverables view is an output of the same context (PRD + user stories) already loaded at this gate. Placing it here means the delivery-planner can use it without regenerating.

## Impact

- Plugin affected: `ring-pm-team` → MINOR bump (`0.16.x` → `0.17.0`) on merge
- No breaking changes — adds new required output section to `tasks.md`

## Test plan

- [ ] Run `ring:pre-dev-task-breakdown` on a feature and verify `tasks.md` contains both summary tables
- [ ] Verify business deliverables use plain language (no technical jargon)
- [ ] Verify each row maps to the task's `Deliverable` field
- [ ] Verify `ring:pre-dev-delivery-planning` can still consume `tasks.md` without changes