### PR TITLE
feat(dev-multi-tenant): add M2M Secret Manager gate for plugin authentication

### DIFF
--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -1,6 +1,6 @@
 # Go Standards - Multi-Tenant
 
-> **Module:** multi-tenant.md | **Sections:** §24 | **Parent:** [index.md](index.md)
+> **Module:** multi-tenant.md | **Sections:** §25 | **Parent:** [index.md](index.md)
 
 This module covers multi-tenant patterns with Tenant Manager.
 
@@ -15,6 +15,7 @@ This module covers multi-tenant patterns with Tenant Manager.
 | 1b | [Multi-module middleware (MultiPoolMiddleware)](#multi-module-middleware-multipoolmiddleware) | Multi-module unified services (midaz ledger) |
 | 2 | [Tenant Isolation Verification (⚠️ CONDITIONAL)](#tenant-isolation-verification-conditional) | Database-per-tenant verification, context-based connection checks |
 | 24 | [Multi-Tenant Message Queue Consumers (Lazy Mode)](#multi-tenant-message-queue-consumers-lazy-mode) | Lazy consumer initialization, on-demand connection, exponential backoff |
+| 25 | [M2M Credentials via Secret Manager (Plugin-Only)](#m2m-credentials-via-secret-manager-plugin-only) | AWS Secrets Manager integration for plugin-to-product authentication per tenant |
 
 ---
 
@@ -1635,4 +1636,403 @@ if m.consumerTrigger != nil {  // Nil in single-tenant mode
 
 ---
 
-This section can be added to `golang/multi-tenant.md` as **§24: Message Queue Lazy Consumer Pattern**.
+## M2M Credentials via Secret Manager (Plugin-Only)
+
+**CONDITIONAL:** Only implement if the service is a **plugin** that needs to authenticate with a **product** (e.g., ledger, midaz, CRM). Products do NOT need this — only plugins that call product APIs.
+
+### When This Applies
+
+| Service Type | `MULTI_TENANT_ENABLED` | Needs Secret Manager? | Reason |
+|-------------|------------------------|----------------------|--------|
+| **Plugin** (plugin-pix, plugin-crm, etc.) | `true` | ✅ YES | Plugin must authenticate with product APIs per tenant |
+| **Plugin** (plugin-pix, plugin-crm, etc.) | `false` | ❌ NO | Single-tenant — plugin uses existing static auth, no Secrets Manager calls |
+| **Product** (midaz, ledger, CRM) | any | ❌ NO | Products don't call other products via M2M |
+| **Infrastructure** (tenant-manager, reporter) | any | ❌ NO | Infrastructure services use internal auth |
+
+**⛔ Backward Compatibility:** When `MULTI_TENANT_ENABLED=false` (the default), the plugin MUST continue working with its existing authentication mechanism — no AWS Secrets Manager calls, no M2M credential fetching. The Secret Manager path is activated **only** when multi-tenant mode is enabled. This follows the same conditional pattern as all other tenant-manager resources (PostgreSQL, MongoDB, Redis, S3, RabbitMQ).
+
+### How It Works
+
+When `MULTI_TENANT_ENABLED=true`, each tenant has its own M2M credentials stored in **AWS Secrets Manager**. When a plugin needs to call a product API (e.g., ledger), it must:
+
+1. Extract `tenantOrgID` from the JWT context (already available via tenant middleware)
+2. Call `secretsmanager.GetM2MCredentials()` to fetch `clientId` + `clientSecret` for that tenant
+3. Pass the credentials to the existing Plugin Access Manager integration (which handles JWT acquisition)
+
+**Note:** The plugin already handles JWT token acquisition via Plugin Access Manager. This section only covers **how to retrieve M2M credentials** from AWS Secrets Manager — not how to exchange them for tokens.
+
+### Required lib-commons Package
+
+```go
+import (
+    secretsmanager "github.com/LerianStudio/lib-commons/v3/commons/secretsmanager"
+)
+```
+
+### Secret Path Convention
+
+Credentials are stored in AWS Secrets Manager following this path:
+
+```
+tenants/{env}/{tenantOrgID}/{applicationName}/m2m/{targetService}/credentials
+```
+
+| Segment | Source | Example |
+|---------|--------|---------|
+| `env` | `MULTI_TENANT_ENVIRONMENT` env var | `staging`, `production` |
+| `tenantOrgID` | JWT `owner` claim via `auth.GetTenantID(ctx)` | `org_01KHVKQQP6D2N4RDJK0ADEKQX1` |
+| `applicationName` | Plugin's own service name constant | `plugin-pix`, `plugin-crm` |
+| `targetService` | The product being called | `ledger`, `midaz` |
+
+### Environment Variables (Plugin-Only)
+
+In addition to the 7 canonical multi-tenant env vars, plugins MUST add:
+
+| Env Var | Description | Default | Required |
+|---------|-------------|---------|----------|
+| `AWS_REGION` | AWS region for Secrets Manager | - | Yes (for plugins) |
+| `M2M_TARGET_SERVICE` | Target product service name | - | Yes (for plugins) |
+| `M2M_CREDENTIAL_CACHE_TTL_SEC` | Local cache TTL for credentials | `300` | No |
+
+### Implementation Pattern
+
+#### 1. Fetching M2M Credentials
+
+```go
+package m2m
+
+import (
+    "context"
+    "fmt"
+
+    awsconfig "github.com/aws/aws-sdk-go-v2/config"
+    awssm "github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+    secretsmanager "github.com/LerianStudio/lib-commons/v3/commons/secretsmanager"
+)
+
+// FetchCredentials retrieves M2M credentials from AWS Secrets Manager for a specific tenant.
+func FetchCredentials(ctx context.Context, env, tenantOrgID, applicationName, targetService string) (*secretsmanager.M2MCredentials, error) {
+    cfg, err := awsconfig.LoadDefaultConfig(ctx)
+    if err != nil {
+        return nil, fmt.Errorf("loading AWS config: %w", err)
+    }
+
+    client := awssm.NewFromConfig(cfg)
+
+    creds, err := secretsmanager.GetM2MCredentials(ctx, client, env, tenantOrgID, applicationName, targetService)
+    if err != nil {
+        return nil, fmt.Errorf("fetching M2M credentials for tenant %s: %w", tenantOrgID, err)
+    }
+
+    return creds, nil
+}
+```
+
+#### 2. Credential Caching (MANDATORY)
+
+**MUST cache credentials locally.** Hitting AWS Secrets Manager on every request is expensive and adds latency.
+
+```go
+package m2m
+
+import (
+    "context"
+    "fmt"
+    "sync"
+    "time"
+
+    secretsmanager "github.com/LerianStudio/lib-commons/v3/commons/secretsmanager"
+)
+
+type cachedCredentials struct {
+    creds     *secretsmanager.M2MCredentials
+    expiresAt time.Time
+}
+
+// M2MCredentialProvider handles per-tenant M2M credential retrieval with caching.
+// Token acquisition is handled by Plugin Access Manager — this only provides credentials.
+type M2MCredentialProvider struct {
+    smClient        secretsmanager.SecretsManagerClient
+    env             string
+    applicationName string
+    targetService   string
+    credCacheTTL    time.Duration
+
+    credCache sync.Map // map[tenantOrgID]*cachedCredentials
+}
+
+// NewM2MCredentialProvider creates a credential provider with configurable cache TTL.
+func NewM2MCredentialProvider(
+    smClient secretsmanager.SecretsManagerClient,
+    env, applicationName, targetService string,
+    credCacheTTL time.Duration,
+) *M2MCredentialProvider {
+    return &M2MCredentialProvider{
+        smClient:        smClient,
+        env:             env,
+        applicationName: applicationName,
+        targetService:   targetService,
+        credCacheTTL:    credCacheTTL,
+    }
+}
+
+// GetCredentials returns M2M credentials for the given tenant, using cache when possible.
+// The caller (Plugin Access Manager integration) handles token acquisition.
+func (p *M2MCredentialProvider) GetCredentials(ctx context.Context, tenantOrgID string) (*secretsmanager.M2MCredentials, error) {
+    if cached, ok := p.credCache.Load(tenantOrgID); ok {
+        cc := cached.(*cachedCredentials)
+        if time.Now().Before(cc.expiresAt) {
+            return cc.creds, nil
+        }
+    }
+
+    creds, err := secretsmanager.GetM2MCredentials(ctx, p.smClient, p.env, tenantOrgID, p.applicationName, p.targetService)
+    if err != nil {
+        return nil, fmt.Errorf("fetching M2M credentials for tenant %s: %w", tenantOrgID, err)
+    }
+
+    p.credCache.Store(tenantOrgID, &cachedCredentials{
+        creds:     creds,
+        expiresAt: time.Now().Add(p.credCacheTTL),
+    })
+
+    return creds, nil
+}
+```
+
+#### 3. Single-Tenant vs Multi-Tenant: Conditional Flow
+
+This is the core pattern. The plugin MUST work in both modes — the `M2MCredentialProvider` is **nil** in single-tenant mode.
+
+**Few-shot 1 — Bootstrap wiring (picks the right path at startup):**
+
+```go
+// In bootstrap/config.go or bootstrap/dependencies.go
+
+var m2mProvider *m2m.M2MCredentialProvider // nil = single-tenant mode
+
+if cfg.MultiTenantEnabled {
+    // MULTI-TENANT: create credential provider that fetches from AWS Secrets Manager
+    awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+    if err != nil {
+        logger.Fatalf("Failed to load AWS config for M2M: %v", err)
+    }
+    smClient := awssm.NewFromConfig(awsCfg)
+
+    m2mProvider = m2m.NewM2MCredentialProvider(
+        smClient,
+        cfg.MultiTenantEnvironment,
+        constant.ApplicationName,
+        cfg.M2MTargetService,
+        time.Duration(cfg.M2MCredentialCacheTTLSec) * time.Second,
+    )
+}
+// SINGLE-TENANT: m2mProvider stays nil — no AWS calls, no Secret Manager
+
+// Both modes use the same client — it checks internally if m2mProvider is nil
+productClient := product.NewClient(cfg.ProductURL, m2mProvider)
+```
+
+**Few-shot 2 — Product client (handles both modes transparently):**
+
+```go
+// internal/adapters/product/client.go
+
+type Client struct {
+    baseURL     string
+    m2mProvider *m2m.M2MCredentialProvider // nil in single-tenant mode
+    httpClient  *http.Client
+}
+
+func NewClient(baseURL string, m2mProvider *m2m.M2MCredentialProvider) *Client {
+    return &Client{
+        baseURL:     baseURL,
+        m2mProvider: m2mProvider,
+        httpClient:  &http.Client{Timeout: 30 * time.Second},
+    }
+}
+
+func (c *Client) CreateTransaction(ctx context.Context, input TransactionInput) (*TransactionOutput, error) {
+    req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/v1/transactions", marshal(input))
+    if err != nil {
+        return nil, err
+    }
+
+    if c.m2mProvider != nil {
+        // MULTI-TENANT: fetch per-tenant credentials from Secret Manager
+        tenantOrgID := auth.GetTenantID(ctx)
+        creds, err := c.m2mProvider.GetCredentials(ctx, tenantOrgID)
+        if err != nil {
+            return nil, fmt.Errorf("fetching M2M credentials for tenant %s: %w", tenantOrgID, err)
+        }
+        req.SetBasicAuth(creds.ClientID, creds.ClientSecret)
+    }
+    // SINGLE-TENANT: no credentials injected — plugin uses existing auth
+    // (e.g., static token from env var, already set in headers by middleware, etc.)
+
+    resp, err := c.httpClient.Do(req)
+    if err != nil {
+        return nil, fmt.Errorf("calling product API: %w", err)
+    }
+    defer resp.Body.Close()
+
+    // ... handle response
+}
+```
+
+**Few-shot 3 — Service layer (no branching needed, client handles it):**
+
+```go
+func (uc *ProcessPaymentUseCase) Execute(ctx context.Context, input PaymentInput) error {
+    // Works in both modes:
+    // - Single-tenant: client calls product API with existing static auth
+    // - Multi-tenant: client fetches per-tenant creds from Secret Manager first
+    resp, err := uc.ledgerClient.CreateTransaction(ctx, input.Transaction)
+    if err != nil {
+        return fmt.Errorf("creating transaction in ledger: %w", err)
+    }
+
+    return nil
+}
+```
+
+**The pattern:** The conditional logic lives in the **client/adapter layer**, not in the service/use-case layer. The service layer calls the same method regardless of mode — it doesn't know or care whether credentials came from Secret Manager or static config.
+
+### Error Handling
+
+The `secretsmanager` package provides sentinel errors for precise error handling:
+
+```go
+import (
+    "errors"
+    secretsmanager "github.com/LerianStudio/lib-commons/v3/commons/secretsmanager"
+)
+
+creds, err := secretsmanager.GetM2MCredentials(ctx, client, env, tenantOrgID, appName, target)
+if err != nil {
+    switch {
+    case errors.Is(err, secretsmanager.ErrM2MCredentialsNotFound):
+        // Tenant not provisioned yet — return 503 or queue for retry
+    case errors.Is(err, secretsmanager.ErrM2MVaultAccessDenied):
+        // IAM permissions missing or token expired — alert ops
+    case errors.Is(err, secretsmanager.ErrM2MInvalidCredentials):
+        // Secret exists but clientId/clientSecret missing — alert ops
+    default:
+        // Infrastructure error — retry with backoff
+    }
+}
+```
+
+### AWS IAM Permissions
+
+The plugin's IAM role (or ECS task role / EKS service account) MUST have permission to read the tenant secrets. Minimal policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:*:*:secret:tenants/*/m2m/*/credentials-*"
+    }
+  ]
+}
+```
+
+For tighter scoping, replace wildcards with specific values:
+
+| Wildcard | Scoped Example |
+|----------|---------------|
+| First `*` (env) | `production` or `staging` |
+| Second `*` (target) | `ledger` or `midaz` |
+| Trailing `-*` | Required — AWS appends a random suffix to secret ARNs |
+
+**MUST NOT** grant `secretsmanager:*` — only `GetSecretValue` is needed.
+
+### Testing Guidance
+
+The `secretsmanager.SecretsManagerClient` is an interface, so it can be mocked in unit tests without hitting AWS.
+
+#### Mocking the client
+
+```go
+type mockSMClient struct {
+    getSecretValueFunc func(ctx context.Context, input *awssm.GetSecretValueInput, opts ...func(*awssm.Options)) (*awssm.GetSecretValueOutput, error)
+}
+
+func (m *mockSMClient) GetSecretValue(ctx context.Context, input *awssm.GetSecretValueInput, opts ...func(*awssm.Options)) (*awssm.GetSecretValueOutput, error) {
+    return m.getSecretValueFunc(ctx, input, opts...)
+}
+```
+
+#### Testing credential cache TTL
+
+```go
+func TestCredentialCacheExpiry(t *testing.T) {
+    callCount := 0
+    mock := &mockSMClient{
+        getSecretValueFunc: func(_ context.Context, _ *awssm.GetSecretValueInput, _ ...func(*awssm.Options)) (*awssm.GetSecretValueOutput, error) {
+            callCount++
+            secret := `{"clientId":"id","clientSecret":"secret"}`
+            return &awssm.GetSecretValueOutput{SecretString: &secret}, nil
+        },
+    }
+
+    provider := NewM2MCredentialProvider(mock, "test", "plugin-pix", "ledger", 1*time.Second)
+
+    // First call — fetches from AWS
+    _, err := provider.GetCredentials(context.Background(), "tenant-1")
+    require.NoError(t, err)
+    assert.Equal(t, 1, callCount)
+
+    // Second call — served from cache
+    _, err = provider.GetCredentials(context.Background(), "tenant-1")
+    require.NoError(t, err)
+    assert.Equal(t, 1, callCount) // still 1
+
+    // Wait for cache expiry
+    time.Sleep(1100 * time.Millisecond)
+
+    // Third call — cache expired, fetches again
+    _, err = provider.GetCredentials(context.Background(), "tenant-1")
+    require.NoError(t, err)
+    assert.Equal(t, 2, callCount)
+}
+```
+
+#### Testing error scenarios
+
+Test each sentinel error path (`ErrM2MCredentialsNotFound`, `ErrM2MVaultAccessDenied`, `ErrM2MInvalidCredentials`) by returning the corresponding error from the mock.
+
+### Observability & Metrics
+
+Instrument `M2MCredentialProvider` to track credential retrieval health. Recommended counters and histogram:
+
+| Metric | Type | Where to Increment | Description |
+|--------|------|-------------------|-------------|
+| `m2m_credential_cache_hits` | Counter | `GetCredentials` — cache hit path | Credential served from local cache |
+| `m2m_credential_cache_misses` | Counter | `GetCredentials` — cache miss path | Cache miss, fetching from AWS |
+| `m2m_credential_fetch_errors` | Counter | `GetCredentials` — error return | AWS Secrets Manager call failed |
+| `m2m_credential_fetch_duration_seconds` | Histogram | `GetCredentials` — around the `GetM2MCredentials` call | Latency of AWS Secrets Manager requests |
+
+Labels: `tenant_org_id`, `target_service`, `environment`.
+
+**MUST NOT** include `clientId` or `clientSecret` in metric labels or log fields.
+
+### Security Considerations
+
+1. **MUST NOT log credentials** — never log `clientId` or `clientSecret` values
+2. **MUST NOT store credentials in environment variables** — always fetch from Secrets Manager at runtime
+3. **MUST cache locally** — avoid per-request AWS API calls (latency + cost)
+4. **MUST handle credential rotation** — cache TTL ensures stale credentials are refreshed automatically
+
+### Anti-Rationalization
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "Product service doesn't need M2M" | Correct. Only plugins need M2M. | **Skip this gate for products** |
+| "We can hardcode credentials per tenant" | Hardcoded creds don't scale and are a security risk. | **MUST use Secrets Manager** |
+| "Caching is optional, we'll add it later" | Every request hitting AWS adds ~50-100ms latency + cost. | **MUST implement caching from day one** |
+| "We'll use env vars for client credentials" | Env vars are shared across tenants. M2M is per-tenant. | **MUST use Secrets Manager per tenant** |
+| "Single-tenant plugins don't need this" | Correct if MULTI_TENANT_ENABLED=false. | **Skip when single-tenant** |

--- a/dev-team/skills/dev-multi-tenant/SKILL.md
+++ b/dev-team/skills/dev-multi-tenant/SKILL.md
@@ -5,9 +5,12 @@ version: 2.0.0
 type: skill
 description: |
   Multi-tenant development cycle orchestrator following Ring Standards.
-  Auto-detects the service stack (PostgreSQL, MongoDB, Redis, RabbitMQ, S3),
+  Auto-detects the service stack (PostgreSQL, MongoDB, Redis, RabbitMQ, S3)
+  and service type (plugin vs product),
   then executes a gate-based implementation using tenantId from JWT
   for database-per-tenant isolation via lib-commons v3 tenant-manager sub-packages (postgres.Manager, mongo.Manager).
+  For plugins: includes mandatory M2M credential retrieval from AWS Secrets Manager
+  via lib-commons v3 secretsmanager package (per-tenant authentication with product APIs).
   MUST update lib-commons v3 first; lib-auth v2 depends on it. Both are required dependencies.
   Each gate dispatches ring:backend-engineer-golang with context and section references.
   The agent loads multi-tenant.md via WebFetch and has all code examples.
@@ -58,15 +61,17 @@ examples:
   - name: "Add multi-tenant to a service"
     invocation: "/ring:dev-multi-tenant"
     expected_flow: |
-      1. Gate 0: Auto-detect stack
+      1. Gate 0: Auto-detect stack + service type (plugin vs product)
       2. Gate 1: Analyze codebase (build implementation roadmap)
       3. Gate 1.5: Visual implementation preview (HTML report for developer approval)
-      4. Gates 2-6: Implementation (agent loads multi-tenant.md, follows roadmap)
-      5. Gate 7: Metrics & Backward compatibility
-      6. Gate 8: Tests
-      7. Gate 9: Code review
-      8. Gate 10: User validation
-      9. Gate 11: Activation guide
+      4. Gates 2-5: Implementation (agent loads multi-tenant.md, follows roadmap)
+      5. Gate 5.5: M2M Secret Manager for plugin auth (if plugin)
+      6. Gate 6: RabbitMQ multi-tenant (if RabbitMQ detected)
+      7. Gate 7: Metrics & Backward compatibility
+      8. Gate 8: Tests
+      9. Gate 9: Code review
+      10. Gate 10: User validation
+      11. Gate 11: Activation guide
 ---
 
 # Multi-Tenant Development Cycle
@@ -163,6 +168,9 @@ MUST include these instructions in every dispatch to `ring:backend-engineer-gola
 | "I'll make a quick edit directly" | CODE_BYPASS | "FORBIDDEN: All code changes go through ring:backend-engineer-golang. Dispatch the agent." |
 | "It's just one line, no need for an agent" | CODE_BYPASS | "FORBIDDEN: Even single-line changes MUST be dispatched. Agent ensures standards compliance." |
 | "Agent is slow, I'll edit faster" | CODE_BYPASS | "FORBIDDEN: Speed is not a justification. Agent applies TDD and standards checks." |
+| "This plugin doesn't need Secret Manager" | SCOPE_REDUCTION | "If it's a plugin with MULTI_TENANT_ENABLED=true that calls product APIs, M2M via Secret Manager is MANDATORY." |
+| "We can use env vars for M2M credentials" | SECURITY_BYPASS | "Env vars are shared across tenants. M2M credentials are PER-TENANT. MUST use Secrets Manager." |
+| "Caching M2M credentials is optional" | QUALITY_BYPASS | "Every request to AWS adds ~50-100ms latency + cost. Caching is MANDATORY from day one." |
 
 ---
 
@@ -177,6 +185,7 @@ MUST include these instructions in every dispatch to `ring:backend-engineer-gola
 | 3 | Multi-Tenant Configuration | Skip if already configured | ring:backend-engineer-golang |
 | 4 | Tenant Middleware (TenantMiddleware or MultiPoolMiddleware) | Always (core) | ring:backend-engineer-golang |
 | 5 | Repository Adaptation | Per detected DB/storage | ring:backend-engineer-golang |
+| 5.5 | M2M Secret Manager (Plugin Auth) | Skip if NOT a plugin | ring:backend-engineer-golang |
 | 6 | RabbitMQ Multi-Tenant | Skip if no RabbitMQ | ring:backend-engineer-golang |
 | 7 | Metrics & Backward Compat | Always | ring:backend-engineer-golang |
 | 8 | Tests | Always | ring:backend-engineer-golang |
@@ -208,7 +217,21 @@ DETECT (run in parallel):
    - Context:    grep -rn "tenant-manager/core\|GetMongoForTenant\|GetPostgresForTenant" internal/
    - S3 keys:    grep -rn "tenant-manager/s3\|GetObjectStorageKeyForTenant" internal/
    - RMQ:        grep -rn "X-Tenant-ID" internal/
+8. Service type (plugin vs product):
+   - Plugin:     grep -rn "plugin-\|Plugin" go.mod cmd/ internal/bootstrap/
+   - M2M client: grep -rn "client_credentials\|M2M\|secretsmanager\|GetM2MCredentials" internal/ pkg/
+   - Product API calls: grep -rn "ledger.*client\|midaz.*client\|product.*client" internal/
 ```
+
+**Service type classification:**
+
+| Signal | Classification |
+|--------|---------------|
+| Module name contains `plugin-` (in go.mod) | **Plugin** → Gate 5.5 MANDATORY |
+| Service calls product APIs (ledger, midaz, etc.) | **Plugin** → Gate 5.5 MANDATORY |
+| No product API calls, serves own data | **Product** → Gate 5.5 SKIP |
+
+MUST confirm with user: "Is this service a **plugin** (calls product APIs like ledger/midaz) or a **product** (serves its own data)?"
 
 MUST confirm: user explicitly approves detection results before proceeding.
 
@@ -237,6 +260,7 @@ MUST confirm: user explicitly approves detection results before proceeding.
 > 7. **Redis** (if detected): Where are Redis operations? Any Lua scripts? Where would GetKeyFromContext be needed?
 > 8. **S3/Object Storage** (if detected): Where are Upload/Download/Delete operations? How are object keys constructed? List every file:line that builds an S3 key. What bucket env var is used?
 > 9. **Existing multi-tenant code**: Any tenant-manager sub-package imports (`tenant-manager/core`, `tenant-manager/middleware`, `tenant-manager/postgres`, etc.)? TenantMiddleware or MultiPoolMiddleware? `core.GetPostgresForTenant`/`core.GetMongoForTenant`/`s3.GetObjectStorageKeyForTenant` calls? MULTI_TENANT_ENABLED config? (NOTE: organization_id is NOT related to multi-tenant — ignore it completely)
+> 10. **M2M / Plugin authentication** (if service is a plugin): Does the service call product APIs (ledger, midaz, CRM)? How does it authenticate today (static token, env var, hardcoded)? Where is the HTTP client that calls the product? Is there an existing M2M or `client_credentials` flow? Any `secretsmanager` imports? List every file:line where product API calls are made and where authentication credentials are injected.
 >
 > OUTPUT FORMAT: Structured report with file:line references for every point above.
 > DO NOT write code. Analysis only.
@@ -288,6 +312,9 @@ Table with columns: Gate, File, Current Code, New Code, Lines Changed. One row p
 | 5 | `metadata.mongodb.go` | Static mongo → `core.GetMongoForTenant(ctx)` | ~2 lines per method |
 | 5 | `consumer.redis.go` | Key prefixing with `valkey.GetKeyFromContext(ctx, key)` | ~1 line per operation |
 | 5 | `storage.go` | S3 key prefixing with `s3.GetObjectStorageKeyForTenant(ctx, key)` | ~1 line per operation |
+| 5.5 | `m2m/provider.go` | New file: M2MCredentialProvider with credential caching (plugin only) | ~80 lines |
+| 5.5 | `config.go` | Add M2M_TARGET_SERVICE, cache TTL, AWS_REGION env vars (plugin only) | ~10 lines added |
+| 5.5 | `bootstrap.go` | Conditional M2M wiring when multi-tenant + plugin (plugin only) | ~20 lines added |
 | 6 | `producer.rabbitmq.go` | Dual constructor (single-tenant + multi-tenant) | ~20 lines added |
 | 6 | `rabbitmq.server.go` | MultiTenantConsumer setup with lazy mode | ~40 lines added |
 | 7 | `config.go` | Backward compat validation | ~10 lines added |
@@ -519,6 +546,72 @@ HARD GATE: CANNOT proceed without TenantMiddleware.
 
 ---
 
+## Gate 5.5: M2M Secret Manager (Plugin Auth)
+
+**SKIP IF:** service is NOT a plugin (i.e., it is a product or infrastructure service).
+
+**This gate is MANDATORY for plugins** that need to authenticate with product APIs (e.g., ledger, midaz) in multi-tenant mode. Each tenant has its own M2M credentials stored in AWS Secrets Manager.
+
+**Dispatch `ring:backend-engineer-golang` with context from Gate 0/1 analysis:**
+
+> TASK: Implement M2M credential retrieval from AWS Secrets Manager with per-tenant caching.
+> SERVICE TYPE: Plugin (confirmed in Gate 0)
+> APPLICATION NAME: {ApplicationName constant from codebase, e.g., "plugin-pix"}
+> TARGET SERVICE: {product the plugin calls, e.g., "ledger", "midaz"}
+>
+> Follow multi-tenant.md section "M2M Credentials via Secret Manager (Plugin-Only)" for all implementation patterns.
+>
+> **What to implement:**
+>
+> 1. **M2M Authenticator struct** with credential caching (`sync.Map`) and token caching.
+>    Use `secretsmanager.GetM2MCredentials()` from `github.com/LerianStudio/lib-commons/v3/commons/secretsmanager`.
+>    The function signature is:
+>    ```go
+>    secretsmanager.GetM2MCredentials(ctx, smClient, env, tenantOrgID, applicationName, targetService) (*M2MCredentials, error)
+>    ```
+>    It returns `*M2MCredentials{ClientID, ClientSecret}` fetched from path:
+>    `tenants/{env}/{tenantOrgID}/{applicationName}/m2m/{targetService}/credentials`
+>
+> 2. **Credential cache** with configurable TTL (default 300s). MUST NOT hit AWS on every request.
+>
+> 3. **Bootstrap wiring** — conditional on `cfg.MultiTenantEnabled`:
+>    ```go
+>    if cfg.MultiTenantEnabled {
+>        awsCfg, _ := awsconfig.LoadDefaultConfig(ctx)
+>        smClient := awssm.NewFromConfig(awsCfg)
+>        m2mProvider := m2m.NewM2MCredentialProvider(smClient, cfg.MultiTenantEnvironment,
+>            constant.ApplicationName, cfg.M2MTargetService,
+>            time.Duration(cfg.M2MCredentialCacheTTLSec)*time.Second)
+>        productClient = product.NewClient(cfg.ProductURL, m2mProvider)
+>    } else {
+>        productClient = product.NewClient(cfg.ProductURL, nil) // single-tenant: static auth
+>    }
+>    ```
+>
+> 4. **Config env vars** — add to Config struct:
+>    - `M2M_TARGET_SERVICE` (string, required for plugins)
+>    - `M2M_CREDENTIAL_CACHE_TTL_SEC` (int, default 300)
+>    - `AWS_REGION` (string, required for plugins)
+>
+> 6. **Error handling** using sentinel errors from lib-commons:
+>    - `secretsmanager.ErrM2MCredentialsNotFound` → tenant not provisioned
+>    - `secretsmanager.ErrM2MVaultAccessDenied` → IAM issue, alert ops
+>    - `secretsmanager.ErrM2MInvalidCredentials` → secret malformed, alert ops
+>
+> **SECURITY:**
+> - MUST NOT log clientId or clientSecret values
+> - MUST NOT store credentials in environment variables (fetch from Secrets Manager at runtime)
+> - MUST cache locally to avoid per-request AWS API calls
+> - MUST handle credential rotation via cache TTL expiry
+
+**Verification:** `grep "secretsmanager.GetM2MCredentials\|M2MAuthenticator\|NewM2MAuthenticator" internal/` + `go build ./...`
+
+<block_condition>
+HARD GATE: If service is a plugin and MULTI_TENANT_ENABLED=true, M2M Secret Manager integration is NON-NEGOTIABLE. The plugin cannot authenticate with product APIs without it.
+</block_condition>
+
+---
+
 ## Gate 6: RabbitMQ Multi-Tenant
 
 **SKIP IF:** no RabbitMQ detected.
@@ -632,6 +725,7 @@ MUST approve: present checklist for explicit user approval.
 - [ ] Repositories use context-based connections
 - [ ] S3 keys prefixed with tenantId (if applicable)
 - [ ] RabbitMQ X-Tenant-ID (if applicable)
+- [ ] M2M Secret Manager with credential + token caching (if plugin)
 - [ ] Backward compat (MULTI_TENANT_ENABLED=false works)
 - [ ] Tests pass
 - [ ] Code review passed
@@ -650,10 +744,11 @@ The file is built from Gate 0 (stack) and Gate 1 (analysis). See [multi-tenant.m
 The guide MUST include:
 1. **Components table**: Component name, Service const, Module const, Resources, what was adapted
 2. **Environment variables**: the 7 canonical MULTI_TENANT_* vars (MULTI_TENANT_ENABLED, MULTI_TENANT_URL, MULTI_TENANT_ENVIRONMENT, MULTI_TENANT_MAX_TENANT_POOLS, MULTI_TENANT_IDLE_TIMEOUT_SEC, MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD, MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC) with required/default/description
-3. **How to activate**: set envs + start alongside Tenant Manager
-4. **How to verify**: check logs, test with JWT tenantId
-5. **How to deactivate**: set MULTI_TENANT_ENABLED=false
-6. **Common errors**: see [multi-tenant.md § Error Handling](../../docs/standards/golang/multi-tenant.md)
+3. **M2M environment variables (plugin only)**: If the service is a plugin, include M2M_TARGET_SERVICE, M2M_CREDENTIAL_CACHE_TTL_SEC, AWS_REGION
+4. **How to activate**: set envs + start alongside Tenant Manager (+ AWS credentials for plugins)
+5. **How to verify**: check logs, test with JWT tenantId (+ verify M2M credential retrieval for plugins)
+6. **How to deactivate**: set MULTI_TENANT_ENABLED=false
+7. **Common errors**: see [multi-tenant.md § Error Handling](../../docs/standards/golang/multi-tenant.md)
 
 ---
 
@@ -664,8 +759,9 @@ Save to `docs/ring-dev-multi-tenant/current-cycle.json` for resume support:
 ```json
 {
   "cycle": "multi-tenant",
+  "service_type": "plugin",
   "stack": {"postgresql": false, "mongodb": true, "redis": true, "rabbitmq": true, "s3": true},
-  "gates": {"0": "PASS", "1": "PASS", "1.5": "PASS", "2": "IN_PROGRESS", "3": "PENDING"},
+  "gates": {"0": "PASS", "1": "PASS", "1.5": "PASS", "2": "IN_PROGRESS", "3": "PENDING", "5.5": "PENDING"},
   "current_gate": 2
 }
 ```
@@ -685,3 +781,6 @@ See [multi-tenant.md](../../docs/standards/golang/multi-tenant.md) for the canon
 | "Skip review" | Security implications. One mistake = data leak. | **MANDATORY** |
 | "Using TENANT_MANAGER_ADDRESS instead" | Non-standard name. Only the 7 canonical MULTI_TENANT_* vars are valid. | **STOP. Use MULTI_TENANT_URL** |
 | "The service already uses a different env name" | Legacy names are non-compliant. Rename to canonical names. | **Replace with canonical env vars** |
+| "Plugin doesn't need Secret Manager for M2M" | If multi-tenant is active, each tenant has different credentials. Env vars can't hold per-tenant secrets. | **MUST use Secret Manager for per-tenant M2M** |
+| "We'll add M2M caching later" | Without caching, every request hits AWS (~50-100ms + cost). This is a production blocker. | **MUST implement caching from day one** |
+| "Hardcoded credentials work for now" | Hardcoded creds don't scale across tenants and are a security risk. | **MUST fetch from Secrets Manager per tenant** |


### PR DESCRIPTION
## Summary

Adds **Gate 5.5** to the multi-tenant development cycle that mandates AWS Secrets Manager integration for **plugins** authenticating with product APIs in multi-tenant mode.

## Problem

When a plugin (e.g., plugin-pix, plugin-crm) runs in multi-tenant mode, it needs to authenticate with product APIs (ledger, midaz) using **per-tenant** M2M credentials. Environment variables can't hold per-tenant secrets, so credentials must be fetched from AWS Secrets Manager at runtime.

## Changes

### Standards (`multi-tenant.md`)
- New section **§25: M2M Credentials via Secret Manager (Plugin-Only)**
- When it applies: plugin vs product vs infrastructure classification
- Secret path convention: `tenants/{env}/{tenantOrgID}/{app}/m2m/{target}/credentials`
- 5 new plugin-only env vars (AWS_REGION, M2M_TARGET_SERVICE, etc.)
- Complete code examples using `lib-commons/v3/commons/secretsmanager`:
  - `GetM2MCredentials()` usage
  - `M2MAuthenticator` with dual caching (credentials + tokens via `sync.Map`)
  - Conditional bootstrap wiring
  - Service layer usage pattern
- Error handling with sentinel errors
- Security considerations and anti-rationalization table

### Skill (`dev-multi-tenant/SKILL.md`)
- **Gate 0**: Added plugin vs product auto-detection + user confirmation
- **Gate 1**: Added M2M analysis point to codebase explorer dispatch
- **Gate 1.5**: Added Gate 5.5 rows to change map preview
- **Gate 5.5 (NEW)**: Full agent dispatch with code examples from lib-commons
- Updated pressure resistance (3 new scenarios)
- Updated anti-rationalization table (3 new entries)
- Updated Gate 10 checklist, Gate 11 activation guide, state persistence

## Key Design Decisions

1. **Gate 5.5 (not a new top-level gate)** — fits naturally between repository adaptation (5) and RabbitMQ (6)
2. **Plugin-only** — products and infrastructure services skip this gate entirely
3. **Caching is mandatory from day one** — per-request AWS calls add ~50-100ms latency + cost
4. **Dual cache** — credential cache (TTL 300s) + token cache (TTL 3500s < actual 3600s expiry)
5. **Code examples from lib-commons** — uses actual `secretsmanager.GetM2MCredentials()` API with few-shot patterns