### PR TITLE
feat(pm,dev): add task status tracking between tasks.md and dev-cycle

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -972,8 +972,9 @@ Read tool:
 
 ### State Persistence Checkpoints
 
-| After | MUST Update | MUST Write File |
-|-------|-------------|-----------------|
+| Checkpoint | MUST Update | MUST Write File |
+|------------|-------------|-----------------|
+| **Before Gate 0 (task start)** | `task.status = "in_progress"` in JSON **+ tasks.md Status → `🔄 Doing`** | ✅ YES |
 | Gate 0.1 (TDD-RED) | `tdd_red.status`, `tdd_red.failure_output` | ✅ YES |
 | Gate 0.2 (TDD-GREEN) | `tdd_green.status`, `implementation.status` | ✅ YES |
 | Gate 1 (DevOps) | `devops.status`, `agent_outputs.devops` | ✅ YES |
@@ -984,9 +985,29 @@ Read tool:
 | Gate 6 (Integration Testing) | `integration_testing.status`, `agent_outputs.integration_testing` | ✅ YES |
 | Gate 7 (Chaos Testing) | `chaos_testing.status`, `agent_outputs.chaos_testing` | ✅ YES |
 | Gate 8 (Review) | `review.status`, `agent_outputs.review` | ✅ YES |
-| Gate 9 (Validation) | `validation.status`, task `status` | ✅ YES |
+| Gate 9 (Validation) | `validation.status` (execution unit only — do NOT touch task-level status here) | ✅ YES |
 | Step 11.1 (Unit Approval) | `status = "paused_for_approval"` | ✅ YES |
-| Step 11.2 (Task Approval) | `status = "paused_for_task_approval"` | ✅ YES |
+| Step 11.2 (Task Approval) | `task.status = "completed"` in JSON **+ tasks.md Status → `✅ Done`** | ✅ YES |
+| HARD BLOCK (any gate) | `task.status = "failed"` in JSON **+ tasks.md Status → `❌ Failed`** | ✅ YES |
+
+**tasks.md Status update rules (apply at the three checkpoints above):**
+
+```text
+If state.source_file is absent or file does not exist → log warning "tasks.md Status updates skipped: source_file missing" and skip all status updates for this cycle.
+
+task_id = state.tasks[state.current_task_index].id
+# Always the parent TASK ID — do NOT use current_subtask_index
+# Rows where column 1 is "TOTAL" or empty → skip, not a task row
+
+Use Edit tool on state.source_file (tasks.md):
+- Find the row starting with `| {task_id} |` in the `## Summary` table
+- Before Gate 0: replace `⏸️ Pending` with `🔄 Doing`
+  - If already `🔄 Doing` (resumed cycle) → skip, no change needed
+- Step 11.2 (all subtasks done, user approved): replace `🔄 Doing` with `✅ Done`
+- HARD BLOCK (any gate, task abandoned): replace `🔄 Doing` with `❌ Failed`
+  - If row shows `⏸️ Pending` (unexpected) → replace with target value anyway
+- If row not found or no Status column → log warning "Status update skipped: task {task_id} row not found in {source_file}" and continue, do not abort
+```
 
 ### Anti-Rationalization for State Persistence
 
@@ -1810,6 +1831,15 @@ Multi-tenant is MANDATORY for all services. Every service MUST support both sing
 **REQUIRED SUB-SKILL:** Use ring:dev-implementation
 
 **Execution Unit:** Task (if no subtasks) or Subtask (if task has subtasks)
+
+### Pre-Dispatch: Before Gate 0 Checkpoint (MANDATORY)
+
+MUST execute the **Before Gate 0 (task start)** row from the State Persistence Checkpoints table before sub-steps 2.1–2.3:
+- Set `task.status = "in_progress"` in state JSON
+- Update tasks.md Status → `🔄 Doing` (per tasks.md Status update rules in that table)
+- Write state to file
+
+CANNOT proceed to sub-steps 2.1–2.3 without completing this checkpoint.
 
 ### ⛔ MANDATORY: Invoke ring:dev-implementation Skill (not inline execution)
 
@@ -2916,7 +2946,8 @@ For current execution unit:
    - Tell the user the file path
    - See [shared-patterns/anti-rationalization-visual-report.md](../shared-patterns/anti-rationalization-visual-report.md) for anti-rationalization table
 
-1. Set task `status = "completed"`, cycle `status = "paused_for_task_approval"`, save state
+1. Set task `status = "completed"`, cycle `status = "paused_for_task_approval"`, save state, and update tasks.md Status → `✅ Done` (per Step 11.2 row in State Persistence Checkpoints table)
+
 2. Present summary: Task ID, Subtasks X/X, Total Duration, Review Iterations, Files Changed, Commit Status
 3. **AskUserQuestion:** "Task complete. Ready for next?" Options: (a) Continue (b) Integration Test (c) Stop Here
 4. **Handle response:**

--- a/pm-team/skills/pre-dev-task-breakdown/SKILL.md
+++ b/pm-team/skills/pre-dev-task-breakdown/SKILL.md
@@ -433,17 +433,30 @@ MUST open with two summary tables before the individual task details.
 
 #### Summary Table 1 — Technical Overview
 
-A quick-reference table for the engineering team:
+A quick-reference table for the engineering team. The `Status` column is initialized by `ring:pre-dev-task-breakdown` and updated by `ring:dev-cycle` during execution.
+
+- CANNOT set any value other than `⏸️ Pending` at task creation time
 
 ```markdown
 ## Summary
 
-| Task | Title | Type | Hours | Confidence | Blocks |
-|------|-------|------|-------|------------|--------|
-| T-001 | Project Foundation | Foundation | 3.0 | High | All |
-| T-002 | ... | Feature | 6.5 | Medium | T-004, T-008 |
-| | **TOTAL** | | **85.0h** | | |
+| Task | Title | Type | Hours | Confidence | Blocks | Status |
+|------|-------|------|-------|------------|--------|--------|
+| T-001 | Project Foundation | Foundation | 3.0 | High | All | ⏸️ Pending |
+| T-002 | ... | Feature | 6.5 | Medium | T-004, T-008 | ⏸️ Pending |
+| | **TOTAL** | | **85.0h** | | | |
 ```
+
+MUST leave the Status cell of the TOTAL row empty. CANNOT apply `⏸️ Pending` or any status value to the TOTAL row.
+
+**Status lifecycle (managed by `ring:dev-cycle`):**
+
+| Value | Meaning | Set by |
+|-------|---------|--------|
+| `⏸️ Pending` | Not started | `ring:pre-dev-task-breakdown` at task creation |
+| `🔄 Doing` | Execution started (Gate 0 began) | `ring:dev-cycle` |
+| `✅ Done` | Gate 9 approved | `ring:dev-cycle` |
+| `❌ Failed` | Execution terminated with unresolved blocker | `ring:dev-cycle` |
 
 #### Summary Table 2 — Business Deliverables View
 
@@ -673,6 +686,8 @@ These requirements are NON-NEGOTIABLE:
 - MUST run AI estimation for all tasks (no manual guesses)
 - MUST include Definition of Done checklist for every task
 - MUST include Business Deliverables View in summary section
+- MUST initialize Status column as `⏸️ Pending` for every task row
+- CANNOT set Status to any value other than `⏸️ Pending` at task creation
 - CANNOT use technical-only tasks without value connection
 
 ---


### PR DESCRIPTION
## Summary

Adds a `Status` column to the `tasks.md` Summary Table, updated atomically by `ring:dev-cycle` at the same moment the JSON state file is written — no separate step, no drift between files.

## Why

`current-cycle.json` is the authoritative execution state but is machine-readable JSON. `tasks.md` is the planning document that PMs, stakeholders, and new team members open first. The Status column bridges both worlds: execution state becomes visible in the planning document without touching any task detail sections.

## How it works

### Status lifecycle

| Value | Meaning | Set by |
|-------|---------|--------|
| `⏸️ Pending` | Not started | `ring:pre-dev-task-breakdown` at task creation |
| `🔄 Doing` | Execution started (Gate 0 began) | `ring:dev-cycle` |
| `✅ Done` | Gate 9 approved | `ring:dev-cycle` |
| `❌ Failed` | Execution terminated with unresolved blocker | `ring:dev-cycle` |

### Atomic updates — co-located with JSON writes

Both file updates (JSON + tasks.md) happen at the same checkpoint, never separately:

| Checkpoint | JSON update | tasks.md update |
|------------|-------------|-----------------|
| Before Gate 0 (task start) | `task.status = "in_progress"` | `⏸️ Pending` → `🔄 Doing` |
| Gate 9 approved | `task.status = "completed"` | `🔄 Doing` → `✅ Done` |
| Gate 9 HARD BLOCK | `task.status = "failed"` | `🔄 Doing` → `❌ Failed` |

### Example — tasks.md mid-cycle (T-001 done, T-002 in progress, T-003 pending)

```markdown
## Summary

| Task | Title | Type | Hours | Confidence | Blocks | Status |
|------|-------|------|-------|------------|--------|--------|
| T-001 | Project Foundation | Foundation | 3.0 | High | All | ✅ Done |
| T-002 | SFN Security Header | Foundation | 6.5 | Medium | T-004, T-008 | 🔄 Doing |
| T-003 | UTF-16 + XSD Validation | Foundation | 5.5 | Medium | T-002, T-004 | ⏸️ Pending |
| | **TOTAL** | | **85.0h** | | | |
```

### Simulation — full dev-cycle flow with subtasks

```
[PM] ring:pre-dev-task-breakdown generates tasks.md
     → T-001: ⏸️ Pending, T-002: ⏸️ Pending (all tasks)
     → TOTAL row Status cell: empty (CANNOT have status value)

[DEV] ring:dev-cycle starts — T-001 has subtasks ST-001-01, ST-001-02

  Pre-Dispatch (before sub-steps 2.1–2.3):
    JSON: T-001.status = "in_progress"  ← atomic write
    tasks.md: T-001 = 🔄 Doing          ← same moment

  Gates 0–8 execute for ST-001-01 → gate_progress updated, tasks.md unchanged
  Gates 0–8 execute for ST-001-02:
    Pre-Dispatch: T-001 already 🔄 Doing → skip (idempotent ✅)

  Gate 9 approved:
    JSON: T-001.status = "completed"  ← atomic write
    tasks.md: T-001 = ✅ Done          ← same moment

  Pre-Dispatch for T-002:
    JSON: T-002.status = "in_progress"  ← atomic write
    tasks.md: T-002 = 🔄 Doing          ← same moment

[RESUME] cycle interrupted mid-T-002:
    tasks.md persists T-002 = 🔄 Doing ✅
    On resume, Pre-Dispatch detects 🔄 Doing → skip, no double-write ✅

[HARD BLOCK] Gate N fails after 3 iterations:
    JSON: T-002.status = "failed"  ← atomic write
    tasks.md: T-002 = ❌ Failed     ← same moment ✅
```

## Changes

### `pm-team/skills/pre-dev-task-breakdown/SKILL.md`
- Summary Table 1 template now includes `Status` column with default `⏸️ Pending`
- Status lifecycle table defines all 4 states and which skill sets each
- TOTAL row rule: Status cell MUST be empty
- Two new rules in `Cannot Be Overridden`: initialize as Pending, CANNOT set other value at creation

### `dev-team/skills/dev-cycle/SKILL.md`
- State Persistence Checkpoints table: header renamed `After` → `Checkpoint`; added "Before Gate 0" row; updated "Gate 9" row
- `tasks.md Status update rules` block: single source of truth for how/when to edit tasks.md
- Step 2 `Pre-Dispatch` section: explicit checkpoint execution before sub-steps 2.1–2.3
- Step 11.2: references Gate 9 checkpoint (no logic duplication)
- Guards: missing source_file → warning + skip; TOTAL row → skip; row not found → warning + continue

## Edge cases covered

- Tasks without subtasks: Pre-Dispatch runs once before Gate 0
- Tasks with subtasks: Pre-Dispatch uses parent task ID (`state.tasks[current_task_index].id`), not subtask ID
- Resumed cycles: idempotent — `🔄 Doing` already set → skip, no double-write
- Missing tasks.md or no Status column: graceful warning, cycle continues
- TOTAL row: explicit guard prevents accidental status write

## Test plan

- [x] Run `ring:pre-dev-task-breakdown` → verify tasks.md Summary Table has `Status = ⏸️ Pending` for all task rows, TOTAL row Status is empty
- [x] Run `ring:dev-cycle` → verify tasks.md updates to `🔄 Doing` atomically with JSON write before Gate 0
- [x] Complete Gate 9 → verify tasks.md updates to `✅ Done` atomically with JSON write
- [x] Simulate HARD BLOCK → verify tasks.md shows `❌ Failed`
- [x] Resume an interrupted cycle → verify `🔄 Doing` is preserved, not reset to `⏸️ Pending`
- [x] Run on tasks.md without Status column → verify graceful skip (no abort)

_Validated via full mental simulation of the dev-cycle flow covering all scenarios above._