### PR TITLE
feat(dev-cycle): add Gate 0.5 — Delivery Verification Gate

### DIFF
--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -36,7 +36,7 @@ verification:
       success_pattern: "exit 0"
     - command: "cat docs/ring:dev-cycle/current-cycle.json 2>/dev/null || cat docs/ring:dev-refactor/current-cycle.json | jq '.current_gate'"
       description: "Current gate is valid"
-      success_pattern: "[0-5]"
+      success_pattern: "[0-5]|0\.5"
   manual:
     - "All gates for current task show PASS in state file"
     - "No tasks have status 'blocked' for more than 3 iterations"
@@ -57,7 +57,7 @@ examples:
     expected_flow: |
       1. Execute Gate 0, pause for approval
       2. User approves, execute Gate 1, pause
-      3. Continue until all 10 gates complete
+      3. Continue until all 11 gates complete
   - name: "Execute with custom context for agents"
     invocation: "/ring:dev-cycle tasks.md \"Focus on error handling. Use existing UserRepository.\""
     expected_flow: |
@@ -323,9 +323,9 @@ You CANNOT proceed when blocked. Report and wait for resolution.
 ### Cannot Be Overridden
 
 <cannot_skip>
-- All 10 gates must execute (0→1→2→3→4→5→6→7→8→9) - Each gate catches different issues
+- All 11 gates must execute (0→0.5→1→2→3→4→5→6→7→8→9) - Each gate catches different issues
 - All testing gates (3-7) are MANDATORY - Comprehensive test coverage ensures quality
-- Gates execute in order (0→1→2→3→4→5→6→7→8→9) - Dependencies exist between gates
+- Gates execute in order (0→0.5→1→2→3→4→5→6→7→8→9) - Dependencies exist between gates
 - Gate 8 requires all 6 reviewers - Different review perspectives are complementary
 - Coverage threshold ≥ 85% - Industry standard for quality code
 - PROJECT_RULES.md must exist - Cannot verify standards without target
@@ -452,7 +452,7 @@ Day 4: Production incident from Day 1 code
 
 ## Gate Order Enforcement (HARD GATE)
 
-**Gates MUST execute in order: 0 → 1 → 2 → 3 → 4 → 5 → 6(write) → 7(write) → 8 → 9. All 10 gates are MANDATORY.**
+**Gates MUST execute in order: 0 → 0.5 → 1 → 2 → 3 → 4 → 5 → 6(write) → 7(write) → 8 → 9. All 11 gates are MANDATORY.**
 
 **Deferred Execution Model for Gates 6-7:**
 - **Per unit:** Write/update test code + verify compilation (no container execution)
@@ -503,15 +503,15 @@ Day 4: Production incident from Day 1 code
 
 ## Execution Order
 
-**Core Principle:** Each execution unit passes through all 10 gates. Gates 6-7 write test code per unit but defer execution to end of cycle.
+**Core Principle:** Each execution unit passes through all 11 gates. Gates 6-7 write test code per unit but defer execution to end of cycle.
 
 **Per-Unit Flow:** Unit → Gate 0→0.5(delivery verify)→1→2→3→4→5→6(write)→7(write)→8→9 → 🔒 Unit Checkpoint → 🔒 Task Checkpoint → Next Unit
 **End-of-Cycle Flow:** All units done → Gate 6(execute)→7(execute) → **Multi-Tenant Adaptation** → Final Commit → Feedback
 
 | Scenario | Execution Unit | Gates Per Unit | End of Cycle |
 |----------|----------------|----------------|--------------|
-| Task without subtasks | Task itself | 10 gates (6-7 write only) | Gate 6-7 execute |
-| Task with subtasks | Each subtask | 10 gates per subtask (6-7 write only) | Gate 6-7 execute |
+| Task without subtasks | Task itself | 11 gates (6-7 write only) | Gate 6-7 execute |
+| Task with subtasks | Each subtask | 11 gates per subtask (6-7 write only) | Gate 6-7 execute |
 
 **Why deferred execution for Gates 6-7:**
 - Integration tests require testcontainers (slow to spin up/tear down)
@@ -631,6 +631,15 @@ State is persisted to `{state_path}` (either `docs/ring:dev-cycle/current-cycle.
             "test_pass_output": "PASS: TestFoo (0.003s)",
             "completed_at": "ISO timestamp"
           }
+        },
+        "delivery_verification": {
+          "status": "pending|in_progress|completed",
+          "requirements_total": 0,
+          "requirements_delivered": 0,
+          "requirements_missing": 0,
+          "dead_code_items": 0,
+          "remediation_items": 0,
+          "completed_at": "ISO timestamp"
         },
         "devops": {"status": "pending"},
         "sre": {"status": "pending"},
@@ -1962,6 +1971,75 @@ implementation_input = {
    │ TDD-RED:   FAIL captured ✓                     │
    │ TDD-GREEN: PASS verified ✓                     │
    │ STANDARDS: [N]/[N] sections compliant ✓        │
+   │                                                 │
+   │ Proceeding to Gate 1 (DevOps)...               │
+   └─────────────────────────────────────────────────┘
+
+7. MANDATORY: ⛔ Save state to file — Write tool → [state.state_path]
+   See "State Persistence Rule" section.
+
+8. Proceed to Gate 0.5
+```
+
+## Step 2.5: Gate 0.5 - Delivery Verification (Per Execution Unit)
+
+```text
+1. Load Skill:
+   Skill("ring:dev-delivery-verification")
+
+2. Invoke with Gate 0 outputs:
+   - unit_id: current task/subtask ID
+   - requirements: original task requirements from tasks.md
+   - files_changed: from Gate 0 agent_outputs.implementation (## Files Changed)
+   - gate0_handoff: full Gate 0 output
+
+3. Parse result from skill output:
+   - result: PASS | PARTIAL | FAIL
+   - requirements_total: from "## Requirement Coverage Matrix"
+   - requirements_delivered: count of ✅ DELIVERED rows
+   - requirements_missing: count of ❌ NOT DELIVERED rows
+   - dead_code_items: count from "## Dead Code Detection"
+   - remediation_items: count from "## Return to Gate 0" (0 if PASS)
+
+4. Update state:
+   - gate_progress.delivery_verification = {
+       status: "completed",
+       requirements_total: [N],
+       requirements_delivered: [N],
+       requirements_missing: [N],
+       dead_code_items: [N],
+       remediation_items: [N],
+       completed_at: "[ISO timestamp]"
+     }
+
+5. Control flow based on result:
+
+   IF PASS:
+     → Display ✓ GATE 0.5 COMPLETE, proceed to Gate 1
+   
+   IF PARTIAL:
+     → Extract undelivered requirements from "## Return to Gate 0"
+     → Display ⚠ GATE 0.5 PARTIAL — [N] of [M] requirements not delivered
+     → Return to Gate 0 (Step 2) with explicit fix instructions:
+       "Deliver the following requirements: [list from Return to Gate 0]"
+     → After Gate 0 re-run, re-execute Gate 0.5
+     → Max 2 retries. If still PARTIAL after 2 retries → escalate to user
+   
+   IF FAIL:
+     → Extract all gaps from "## Return to Gate 0"
+     → Display ✗ GATE 0.5 FAIL — critical requirements not delivered
+     → Return to Gate 0 (Step 2) with full remediation list
+     → After Gate 0 re-run, re-execute Gate 0.5
+     → Max 2 retries. If still FAIL after 2 retries → escalate to user
+
+6. Display to user:
+   ┌─────────────────────────────────────────────────┐
+   │ ✓ GATE 0.5 COMPLETE                            │
+   ├─────────────────────────────────────────────────┤
+   │ Skill: ring:dev-delivery-verification           │
+   │ Requirements: [delivered]/[total] DELIVERED     │
+   │ Dead Code: [N] items                            │
+   │ Verdict: [PASS|PARTIAL|FAIL]                    │
    │                                                 │
    │ Proceeding to Gate 1 (DevOps)...               │
    └─────────────────────────────────────────────────┘

--- a/dev-team/skills/dev-delivery-verification/SKILL.md
+++ b/dev-team/skills/dev-delivery-verification/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: ring:dev-delivery-verification
+version: 1.0.0
 description: |
   Delivery Verification Gate — verifies that what was requested is actually delivered
   as reachable, integrated code. Not quality review (Gate 8), not test verification
@@ -62,6 +63,10 @@ output_schema:
     - name: "Verdict"
       pattern: "^## Verdict"
       required: true
+    - name: "Return to Gate 0"
+      pattern: "^## Return to Gate 0"
+      required: true
+      description: "Mandatory when verdict is PARTIAL or FAIL. Lists specific undelivered requirements with fix instructions for Gate 0."
   metrics:
     - name: result
       type: enum
@@ -74,6 +79,9 @@ output_schema:
       type: integer
     - name: dead_code_items
       type: integer
+    - name: remediation_items
+      type: integer
+      description: "Number of fix instructions returned to Gate 0 (0 when PASS)"
 ---
 
 # Delivery Verification Gate
@@ -258,8 +266,13 @@ Identify any code created by Gate 0 that is not reachable:
 
 #### Go
 ```bash
-# Find exported functions/methods in changed files that are never called outside tests
-changed_files=$(git diff --name-only HEAD~1 | grep "\.go$" | grep -v "_test.go")
+# Use files_changed from Gate 0 handoff (NOT git diff — avoids drift on stacked/squashed commits)
+# files_changed is provided as input to this gate
+if [ -z "$files_changed" ]; then
+  echo "ERROR: files_changed not provided. Cannot verify delivery."
+  exit 1
+fi
+changed_files=$(echo "$files_changed" | tr ',' '\n' | grep "\.go$" | grep -v "_test.go")
 for f in $changed_files; do
   # Extract exported function/method names
   grep -oP 'func (\(.*?\) )?(\K[A-Z]\w+)' "$f" | while read func_name; do
@@ -273,7 +286,7 @@ done
 ```
 
 ```bash
-# For each new file, check if its package is imported by bootstrap/wire/main
+# For each changed file, check if its package is imported by bootstrap/wire/main
 for f in $changed_files; do
   pkg_path=$(dirname "$f")
   importers=$(grep -rn "\".*$pkg_path\"" internal/bootstrap/ cmd/ --include="*.go" | grep -v "_test.go")
@@ -285,9 +298,9 @@ done
 
 #### TypeScript
 ```bash
-# Find exported functions/classes never imported
-changed_files=$(git diff --name-only HEAD~1 | grep "\.ts$" | grep -v "\.test\.\|\.spec\.")
-for f in $changed_files; do
+# Use files_changed from Gate 0 handoff
+changed_ts_files=$(echo "$files_changed" | tr ',' '\n' | grep "\.ts$" | grep -v "\.test\.\|\.spec\.")
+for f in $changed_ts_files; do
   grep -oP 'export (function|class|const|interface) \K\w+' "$f" | while read name; do
     refs=$(grep -rn "import.*$name\|require.*$name" --include="*.ts" src/ | grep -v "$f" | wc -l)
     if [ "$refs" -eq 0 ]; then


### PR DESCRIPTION
## What

Adds a new gate (0.5) between implementation (Gate 0) and DevOps (Gate 1) that verifies delivered code is actually wired into the running application.

## Problem

Agents generate code that compiles and passes unit tests but is never integrated into the application bootstrap/wire. This creates dead code that gives false confidence — tasks appear complete but functionality doesn't exist at runtime.

**Real-world example:** `metrics.go` in tenant-manager had 5 counters/histograms, 12 passing unit tests, but `NewMetrics()` was never called in `wire.go`. All gates passed. Problem discovered weeks later during manual Grafana investigation.

## Core Principle

```
REQUESTED ≠ CREATED ≠ DELIVERED
- REQUESTED: What the task/requirement asks for
- CREATED: What files/structs/functions were written
- DELIVERED: What code is reachable from main() at runtime
Only DELIVERED counts. CREATED without DELIVERED is dead code.
```

## Changes

### New skill: `ring:dev-delivery-verification` (Gate 0.5)
- Extracts discrete requirements from task
- Verifies each requirement is DELIVERED (reachable from main), not just CREATED
- Integration checklist for: structs, functions, middleware, interfaces, config, dependencies
- Dead code detection with language-specific analysis (Go-focused)
- Requirement Coverage Matrix output
- Anti-Rationalization table
- FAIL → return to Gate 0 with explicit fix instructions

### Updated: `ring:dev-cycle`
- Gate sequence: `0→0.5→1→2→3→4→5→6→7→8→9` (11 gates)
- Gate 0.5 added to mandatory sub-skill loading block
- State persistence updated with `delivery_verification` fields
- Per-unit flow updated

## Verification Checklist (from the new gate)

For every new artifact:
- [ ] Structs: instantiated and reachable from main()?
- [ ] Functions: called from non-test code?
- [ ] Middleware: registered in router in correct order?
- [ ] Interfaces: concrete type registered via DI?
- [ ] Config: read from env and passed to consumer?
- [ ] Dependencies: imported and used in non-test code?

## Impact

This gate would have caught the tenant-manager metrics dead code at implementation time, saving weeks of false confidence and manual debugging.