### PR TITLE
feat: wire file-size enforcement into sub-skills (Gate 0, 0.5, 8)

### DIFF
--- a/dev-team/skills/dev-delivery-verification/SKILL.md
+++ b/dev-team/skills/dev-delivery-verification/SKILL.md
@@ -293,8 +293,9 @@ find . \( -name "*.ts" -o -name "*.tsx" \) \
   -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
 ```
 
-- Any modified file > 500 lines → **FAIL**
+- Any modified file > 500 lines → **FAIL** (hard block, return to Gate 0 with split instructions)
 - Any modified file > 300 lines → **PARTIAL** (return to Gate 0 with split instructions)
+- **This check applies to ALL files in the project, not just files changed by Gate 0.** Existing oversized files are flagged but do not block unless they were modified by Gate 0.
 
 #### B. License Header Verification
 **Reference:** core.md → License Headers (MANDATORY)

--- a/dev-team/skills/dev-implementation/SKILL.md
+++ b/dev-team/skills/dev-implementation/SKILL.md
@@ -398,6 +398,17 @@ Task:
     Multi-Tenant: Handled post-cycle by ring:dev-multi-tenant — implement single-tenant in this gate.
     Design for adaptability: use `r.connection` as a struct field so ring:dev-multi-tenant can replace `r.connection.GetDB()` with `core.ResolvePostgres(ctx, r.connection)` without restructuring.
 
+    ## ⛔ FILE SIZE ENFORCEMENT (MANDATORY)
+    See [shared-patterns/file-size-enforcement.md](../shared-patterns/file-size-enforcement.md)
+    - You MUST NOT create or modify files to exceed 300 lines (including test files)
+    - If implementing a feature would push a file past 300 lines, you MUST split it proactively
+    - Split by responsibility boundaries (not arbitrary line counts)
+    - **Go:** Each split file stays in the same package; all methods remain on the same receiver; verify with `go build ./... && go test ./...`
+    - **TypeScript:** Split files stay in the same module/directory; update barrel exports (index.ts) if needed; verify with `tsc --noEmit && npm test`
+    - Test files MUST be split to match source files
+    - Files > 300 lines = loop back for split. Files > 500 lines = HARD BLOCK.
+    - Reference: golang/domain.md → File Organization (MANDATORY), typescript.md → File Organization (MANDATORY)
+
     ## ⛔ CRITICAL: all Ring Standards Apply (no DEFERRAL)
     
     **You MUST check ALL sections from the modules you loaded.** Not just telemetry — ALL of them.
@@ -568,6 +579,18 @@ if any standards compliance summary is ❌:
   → Re-dispatch agent to fix
 
 if pass_output contains "PASS" and all standards ✅ and Standards Coverage Table complete:
+  → Run file-size verification (see shared-patterns/file-size-enforcement.md):
+    Go: find . -name "*.go" ! -path "*/mocks*" ! -path "*/generated/*" ! -path "*/gen/*" ! -name "*.pb.go" ! -name "*.gen.go" -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
+    TS: find . \( -name "*.ts" -o -name "*.tsx" \) ! -path "*/node_modules/*" ! -path "*/dist/*" ! -path "*/build/*" ! -path "*/generated/*" ! -path "*/__mocks__/*" ! -name "*.d.ts" ! -name "*.gen.ts" -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
+  
+  if any file > 500 lines:
+    → HARD BLOCK: "File [path] has [N] lines (max 500). MUST split before proceeding."
+    → Re-dispatch agent with split instructions from shared-patterns/file-size-enforcement.md
+
+  if any file > 300 lines:
+    → LOOP BACK: "File [path] has [N] lines (max 300). Split by responsibility boundaries."
+    → Re-dispatch agent with file path and split strategy suggestion
+
   → Run linting verification (R4 — quality.md mandates 14 linters):
     Go: if .golangci.yml exists, run: golangci-lint run ./...
          if .golangci.yml does not exist, flag as warning (quality.md requires it)
@@ -584,15 +607,17 @@ if pass_output contains "PASS" and all standards ✅ and Standards Coverage Tabl
   if any file missing license header:
     → Re-dispatch agent: "Missing license headers in: [file list]. Add license headers per core.md → License Headers (MANDATORY)."
 
-  → implementation_state.tdd_green = {
-      status: "completed",
-      implementation_files: [extracted files],
-      pass_output: [extracted output],
-      commit_sha: [extracted SHA],
-      linting: "PASS",
-      license_headers: "PASS"
-    }
-  → Proceed to Step 8
+  if all checks pass:
+    → implementation_state.tdd_green = {
+        status: "completed",
+        implementation_files: [extracted files],
+        pass_output: [extracted output],
+        commit_sha: [extracted SHA],
+        file_size: "PASS",
+        linting: "PASS",
+        license_headers: "PASS"
+      }
+    → Proceed to Step 8
 ```
 
 ## Step 8: Prepare Output
@@ -626,6 +651,7 @@ Generate skill output:
 - OpenTelemetry Spans: ✅
 - Error Handling: ✅
 - Context Propagation: ✅
+- File Size (≤300 lines): ✅
 ## Handoff to Next Gate
 - Implementation status: COMPLETE
 - Code compiles: ✅


### PR DESCRIPTION
## Follow-up to #225

PR #225 added file-size enforcement to dev-cycle (orchestrator), dev-refactor, and the shared pattern. However, it was merged before the sub-skills that *actually execute* the gates were updated — meaning the enforcement was declared but not wired.

This PR closes that gap by adding explicit file-size enforcement to the 3 sub-skills that need it.

## Changes

### 1. `dev-implementation` (Gate 0)
- Added `⛔ FILE SIZE ENFORCEMENT` block to TDD-GREEN agent prompt with Go + TypeScript specific split instructions
- Added post-implementation verification in Step 7 (Validate TDD-GREEN Output):
  - Runs `find`/`wc` verification command
  - `> 500 lines` → HARD BLOCK, re-dispatch with split instructions
  - `> 300 lines` → LOOP BACK, re-dispatch with split strategy
  - `≤ 300 lines` → proceed
- Added `File Size (≤300 lines): ✅` to Standards Compliance output

### 2. `dev-delivery-verification` (Gate 0.5)
- Added Step 3.5: File Size Verification (MANDATORY) between integration checks and dead code detection
- Language-specific verification commands (Go + TypeScript)
- FAIL if modified file > 500 lines, PARTIAL if > 300 lines
- Added file-size to PASS verdict criteria

### 3. `requesting-code-review` (Gate 8)
- Added file size compliance to code-reviewer focus areas
- `> 300 lines` = MEDIUM+ issue, `> 500 lines` = CRITICAL

All three reference `shared-patterns/file-size-enforcement.md` from #225.