### PR TITLE
feat: enforce Ring standards across all gates (R1-R5)

### DIFF
--- a/default/skills/requesting-code-review/SKILL.md
+++ b/default/skills/requesting-code-review/SKILL.md
@@ -382,11 +382,20 @@ Task:
     **WebFetch the relevant standards modules and verify the changed code against them.**
     
     For Go projects, WebFetch these modules based on changed files:
-    - `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/core.md` (ALWAYS — lib-commons, license headers, deps)
-    - `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/domain.md` (if service/domain code changed)
-    - `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/quality.md` (ALWAYS — linting, testing)
-    - `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/architecture.md` (if structural changes)
-    - `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/api-patterns.md` (if handler/API code changed)
+    Base URL: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/`
+    
+    **Always load:**
+    - `core.md` (lib-commons, license headers, deps, MongoDB patterns)
+    - `quality.md` (linting, testing, production config validation)
+    
+    **Conditional (load if changed files match):**
+    - `domain.md` (if service/domain/model code changed)
+    - `domain-modeling.md` (if entity/value object code changed)
+    - `api-patterns.md` (if handler/API/route code changed)
+    - `architecture.md` (if structural/directory changes, new packages, concurrency patterns)
+    - `bootstrap.md` (if bootstrap/main/wire/health code changed)
+    - `security.md` (if auth/middleware/validation code changed)
+    - `messaging.md` (if RabbitMQ/message queue code changed)
     
     For TypeScript: WebFetch `typescript.md`
     

--- a/dev-team/skills/dev-delivery-verification/SKILL.md
+++ b/dev-team/skills/dev-delivery-verification/SKILL.md
@@ -267,19 +267,28 @@ For each new dependency added:
 #### A. File Size Verification
 See [shared-patterns/file-size-enforcement.md](../shared-patterns/file-size-enforcement.md)
 
-**Go:**
+**Go** (matches shared-patterns/file-size-enforcement.md):
 ```bash
 find . -name "*.go" \
+  ! -name "*_test.go" \
+  ! -path "*/docs/*" \
   ! -path "*/mocks*" ! -path "*/generated/*" ! -path "*/gen/*" \
   ! -name "*.pb.go" ! -name "*.gen.go" \
   -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
+
+# Also check test files separately (same threshold)
+find . -name "*_test.go" \
+  ! -path "*/mocks*" \
+  -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
 ```
 
-**TypeScript:**
+**TypeScript** (matches shared-patterns/file-size-enforcement.md):
 ```bash
 find . \( -name "*.ts" -o -name "*.tsx" \) \
   ! -path "*/node_modules/*" ! -path "*/dist/*" ! -path "*/build/*" \
-  ! -path "*/generated/*" ! -path "*/__generated__/*" ! -path "*/__mocks__/*" \
+  ! -path "*/out/*" ! -path "*/.next/*" \
+  ! -path "*/generated/*" ! -path "*/__generated__/*" \
+  ! -path "*/__mocks__/*" ! -path "*/mocks/*" \
   ! -name "*.d.ts" ! -name "*.gen.ts" ! -name "*.generated.ts" ! -name "*.mock.ts" \
   -exec wc -l {} + | awk '$1 > 300 && $NF != "total" {print}' | sort -rn
 ```
@@ -292,14 +301,17 @@ find . \( -name "*.ts" -o -name "*.tsx" \) \
 
 ```bash
 # Check all files created/modified by Gate 0 for license headers
+# Patterns checked: Copyright, Licensed, SPDX, License (covers Apache, MIT, etc.)
 for f in $files_changed; do
   if echo "$f" | grep -qE '\.(go|ts|tsx)$'; then
-    if ! head -5 "$f" | grep -qiE 'copyright|licensed|spdx'; then
+    if ! head -10 "$f" | grep -qiE 'copyright|licensed|spdx|license'; then
       echo "MISSING LICENSE HEADER: $f"
     fi
   fi
 done
 ```
+
+**Note:** Checks first 10 lines (not 5) to account for build tags, package declarations, or shebang lines that may precede the license block. The pattern is intentionally broad (`copyright|licensed|spdx|license`) to match common formats (Apache, MIT, BSD, SPDX identifiers).
 
 - Any source file missing license header → **PARTIAL** (return to Gate 0: "Add license header per core.md")
 
@@ -307,19 +319,26 @@ done
 **Reference:** quality.md → Linting (MANDATORY — 14 linters)
 
 ```bash
-# Go: Run golangci-lint if config exists
+# Go: Run golangci-lint
 if [ -f .golangci.yml ] || [ -f .golangci.yaml ]; then
   golangci-lint run ./...
+else
+  echo "WARNING: Missing .golangci.yml — quality.md requires it (14 mandatory linters)"
+  echo "FLAG: PARTIAL — create .golangci.yml per quality.md → Linting (MANDATORY)"
 fi
 
-# TypeScript: Run eslint if config exists
-if [ -f .eslintrc.js ] || [ -f .eslintrc.json ] || [ -f eslint.config.js ]; then
+# TypeScript: Run eslint
+if [ -f .eslintrc.js ] || [ -f .eslintrc.json ] || [ -f eslint.config.js ] || [ -f .eslintrc.yaml ] || [ -f .eslintrc.yml ]; then
   npx eslint . --ext .ts,.tsx
+else
+  echo "WARNING: Missing eslint config — typescript.md requires linting"
+  echo "FLAG: PARTIAL — create eslint config per typescript.md standards"
 fi
 ```
 
 - Lint failures → **PARTIAL** (return to Gate 0: "Fix lint issues: [errors]")
-- Missing .golangci.yml in a Go project → flag as warning (quality.md requires it)
+- Missing linter config in Go project → **PARTIAL** (quality.md requires .golangci.yml with 14 mandatory linters)
+- Missing linter config in TypeScript project → **PARTIAL** (typescript.md requires eslint)
 
 **Verdict integration:** ALL three checks (A, B, C) must pass for overall PASS. Any failure makes the overall verdict PARTIAL at best.
 

--- a/dev-team/skills/dev-implementation/SKILL.md
+++ b/dev-team/skills/dev-implementation/SKILL.md
@@ -523,6 +523,10 @@ Task:
     ⛔ Any ❌ = Implementation REJECTED. Fix before proceeding.
 
     ### Standards Compliance Summary
+    
+    **Quick reference derived from the Standards Coverage Table above.**
+    If any item is ❌ here, it MUST also appear as ❌ in the Coverage Table with file:line evidence.
+    
     - lib-commons Usage: ✅/❌
     - License Headers: ✅/❌
     - Structured Logging: ✅/❌
@@ -573,9 +577,9 @@ if pass_output contains "PASS" and all standards ✅ and Standards Coverage Tabl
     → Re-dispatch agent: "Linting failed. Fix all lint issues before proceeding. Output: [lint errors]"
   
   → Run license header check (R5 — core.md License Headers MANDATORY):
-    Go: check all created/modified .go files for license header
-         grep -L "Copyright\|Licensed\|SPDX" [files_created + files_modified] | grep "\.go$"
-    TypeScript: check all created/modified .ts files for license header
+    For each file in [files_created + files_modified] matching *.go, *.ts, *.tsx:
+      Check first 10 lines for: copyright|licensed|spdx|license (case-insensitive)
+      If not found → flag as missing
 
   if any file missing license header:
     → Re-dispatch agent: "Missing license headers in: [file list]. Add license headers per core.md → License Headers (MANDATORY)."


### PR DESCRIPTION
## Context

Gap analysis ([report](https://alfarrabio.lerian.net/ring-dev-cycle-gap-analysis.html)) found that dev-refactor checks 52 standards sections but dev-implementation (Gate 0) only instructs agents to check 4. Code was being born non-compliant in ~48 sections.

## Changes (5 recommendations implemented)

### R1: Standards Coverage Table mandatory at Gate 0 (`dev-implementation`)
- Agent MUST output full Standards Coverage Table with one row per loaded section
- Missing table = INCOMPLETE, any ❌ = REJECTED
- **Highest impact** — agents naturally check everything when forced to report

### R2: Modular WebFetch URLs (`dev-implementation`)
- Replaced monolithic `golang.md` with Module Loading Guide
- `core.md` always required (lib-commons, license headers, deps, MongoDB)
- Additional modules loaded by task type (api-patterns, domain, security, etc.)
- Agent prompt now lists ALL mandatory standards (not just telemetry)

### R3: Standards-aware reviewers at Gate 8 (`requesting-code-review`)
- `ring:code-reviewer`: WebFetches relevant modules, outputs Standards Compliance table
- `ring:security-reviewer`: WebFetches security.md, checks all 7 security sections with explicit compliance table

### R4: Linting verification (`dev-implementation` + `dev-delivery-verification`)
- golangci-lint / eslint run after TDD-GREEN in Gate 0
- Also added to Gate 0.5 Step 3.5
- Missing .golangci.yml flagged as warning

### R5: License header + file size at Gate 0.5 (`dev-delivery-verification`)
- Step 3.5 with 3 automated checks: file size, license headers, linting
- All must pass for PASS verdict

## Files Changed
- `dev-team/skills/dev-implementation/SKILL.md` — R1, R2, R4
- `dev-team/skills/dev-delivery-verification/SKILL.md` — R4, R5
- `default/skills/requesting-code-review/SKILL.md` — R3

Requested by @jeffersonrodrigues