### PR TITLE
feat: improve multi-tenant assertiveness across Ring skills (R1-R5)

### DIFF
--- a/dev-team/skills/dev-implementation/SKILL.md
+++ b/dev-team/skills/dev-implementation/SKILL.md
@@ -272,7 +272,7 @@ Task:
     For TS: `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/typescript.md`
     **Go minimum for tests:** WebFetch `quality.md` → Testing section for test conventions.
     Multi-Tenant: Handled post-cycle by ring:dev-multi-tenant — implement single-tenant in this gate.
-    Design for adaptability: use `r.connection` as a struct field, accept `ctx context.Context` in all methods, no global DB singletons. See TDD-GREEN prompt for full Multi-Tenant Adaptability section.
+    Design for adaptability (Go only): use `r.connection` as a struct field, accept `ctx context.Context` in all methods, no global DB singletons. See TDD-GREEN prompt for full Multi-Tenant Adaptability section.
 
     ## Frontend TDD Policy (React/Next.js only)
     If the component is purely visual/presentational (layout, styling, animations,
@@ -398,17 +398,19 @@ Task:
     
     Multi-Tenant: Handled post-cycle by ring:dev-multi-tenant — implement single-tenant in this gate.
     
-    ## ⛔ Multi-Tenant Adaptability (MANDATORY for Go backend)
+    ## ⛔ Multi-Tenant Adaptability (Go backend only — skip for TypeScript/Frontend)
     
-    Even though multi-tenant is implemented post-cycle by ring:dev-multi-tenant, the code MUST be structured for easy adaptation:
+    **Applies only when `language == "go"`.** TypeScript and frontend projects have different patterns.
     
-    1. **Database connection as struct field:** Repositories MUST store the connection as a struct field (`r.connection`) — NOT inline `db.GetDB()` calls. This allows ring:dev-multi-tenant to replace `r.connection.GetDB()` with `core.ResolvePostgres(ctx, r.connection)` without restructuring.
-    2. **Context propagation:** All service/repository methods MUST accept `ctx context.Context` as first parameter. Multi-tenant resolves connections from context.
-    3. **No global DB singletons:** Database connections MUST be injected via constructor, not accessed from package-level variables. Global state blocks per-tenant connection routing.
-    4. **Redis keys as parameters:** Redis operations MUST receive the key as a parameter (not hardcode it). Multi-tenant prefixes keys with `valkey.GetKeyFromContext(ctx, key)`.
-    5. **S3 keys as parameters:** S3 operations MUST receive the object key as a parameter. Multi-tenant prefixes with `s3.GetObjectStorageKeyForTenant(ctx, key)`.
+    Even though multi-tenant is implemented post-cycle by ring:dev-multi-tenant, Go code must be structured for easy adaptation:
     
-    **Verification:** If any repository uses `db.GetDB()` inline, `redis.Set("hardcoded-key", ...)`, or stores a global DB singleton → agent MUST refactor before gate passes.
+    1. **Database connection as struct field:** Repositories must store the connection as a struct field (`r.connection`) — not inline `db.GetDB()` calls. This allows ring:dev-multi-tenant to replace `r.connection.GetDB()` with `core.ResolvePostgres(ctx, r.connection)` without restructuring.
+    2. **Context propagation:** All service/repository methods must accept `ctx context.Context` as first parameter. Multi-tenant resolves connections from context.
+    3. **No global DB singletons:** Database connections must be injected via constructor, not accessed from package-level variables. Global state blocks per-tenant connection routing.
+    4. **Redis keys as parameters:** Redis operations must receive the key as a parameter (not hardcode it). Multi-tenant prefixes keys with `valkey.GetKeyFromContext(ctx, key)`.
+    5. **S3 keys as parameters:** S3 operations must receive the object key as a parameter. Multi-tenant prefixes with `s3.GetObjectStorageKeyForTenant(ctx, key)`.
+    
+    **Verification (Go only):** If any repository uses inline DB access (not via struct field), hardcoded Redis keys, or global DB singletons → agent must refactor before gate passes.
 
     ## ⛔ FILE SIZE ENFORCEMENT (MANDATORY)
     See [shared-patterns/file-size-enforcement.md](../shared-patterns/file-size-enforcement.md)

--- a/dev-team/skills/dev-multi-tenant/SKILL.md
+++ b/dev-team/skills/dev-multi-tenant/SKILL.md
@@ -49,7 +49,8 @@ input_schema:
       default: "FULL"
     - name: files_changed
       type: array
-      description: "Files changed during dev-cycle (only in SCOPED mode). Used to limit Gate 5 scope."
+      items: string
+      description: "File paths changed during dev-cycle (only in SCOPED mode). Used to limit Gate 5 scope."
       required: false
     - name: multi_tenant_exists
       type: boolean
@@ -61,11 +62,18 @@ input_schema:
       required: false
     - name: detected_dependencies
       type: object
-      description: "Stack detection from dev-cycle (postgresql, mongodb, redis, rabbitmq, s3)."
+      properties:
+        postgresql: boolean
+        mongodb: boolean
+        redis: boolean
+        rabbitmq: boolean
+        s3: boolean
+      description: "Stack detection from dev-cycle. Each key indicates whether that technology was detected."
       required: false
     - name: skip_gates
       type: array
-      description: "Gates to skip (set by dev-cycle based on execution_mode)."
+      items: string
+      description: "Gate identifiers to skip (e.g., '0', '1.5', '5.5'). Set by dev-cycle based on execution_mode."
       required: false
 
 output_schema:
@@ -164,7 +172,7 @@ HARD GATE: A client without circuit breaker can cascade failures across all tena
 
 ### MANDATORY: Sub-Package Import Reference
 
-Agents MUST use these exact import paths. Include this table in every gate dispatch to prevent hallucinated or outdated imports.
+Agents must use these exact import paths. Include this table in every gate dispatch to prevent hallucinated or outdated imports.
 
 | Alias | Import Path | Purpose |
 |-------|-------------|---------|
@@ -179,7 +187,7 @@ Agents MUST use these exact import paths. Include this table in every gate dispa
 | `s3` | `github.com/LerianStudio/lib-commons/v3/commons/tenant-manager/s3` | S3 key prefixing (GetObjectStorageKeyForTenant) |
 | `secretsmanager` | `github.com/LerianStudio/lib-commons/v3/commons/secretsmanager` | M2M credential retrieval (plugin only) |
 
-**HARD GATE:** Agent MUST NOT use v2 import paths or invent sub-package paths. If WebFetch truncates, this table is the authoritative reference.
+**⛔ HARD GATE:** Agent must not use v2 import paths or invent sub-package paths. If WebFetch truncates, this table is the authoritative reference.
 
 ### MANDATORY: Isolation Modes
 
@@ -190,9 +198,9 @@ The Tenant Manager determines the isolation mode per tenant. Agents MUST handle 
 | `isolated` (default) | Separate DB per tenant | Default `public` | None | Strong isolation, recommended |
 | `schema` | Shared DB | Schema per tenant | `options=-csearch_path="{schema}"` | Cost optimization |
 
-The agent does NOT choose the mode — lib-commons `postgres.Manager` reads `TenantConfig.IsolationMode` from the Tenant Manager API and resolves the connection accordingly. The agent's responsibility is to use `core.ResolvePostgres`/`core.ResolveModuleDB` which handles both modes transparently.
+The agent does not choose the mode — lib-commons `postgres.Manager` reads `TenantConfig.IsolationMode` from the Tenant Manager API and resolves the connection accordingly. The agent's responsibility is to use `core.ResolvePostgres`/`core.ResolveModuleDB` which handles both modes transparently.
 
-### MANDATORY: ConnectionSettings Override
+### ConnectionSettings Override
 
 Connection managers support per-tenant pool overrides via `TenantConfig.Databases[module].ConnectionSettings`:
 - `MaxOpenConns` and `MaxIdleConns` per tenant
@@ -200,7 +208,7 @@ Connection managers support per-tenant pool overrides via `TenantConfig.Database
 - When nil (older tenant associations), global defaults apply
 - Managers call `ApplyConnectionSettings()` automatically after resolving a connection
 
-Agents MUST NOT hardcode pool sizes — the Tenant Manager controls per-tenant pool tuning.
+Agents must not hardcode pool sizes — the Tenant Manager controls per-tenant pool tuning.
 
 ### MANDATORY: Agent Instruction (include in EVERY gate dispatch)
 
@@ -282,7 +290,12 @@ VALIDATE input:
    - multi_tenant_compliant MUST be true
    - skip_gates MUST include ["0", "1.5", "2", "3", "4", "10", "11"]
 3. If execution_mode == "FULL":
-   - All gates execute (skip_gates may only contain ["10", "11"])
+   - Core gates always execute (0, 1, 1.5, 2, 3, 4, 5, 7, 8, 9)
+   - Conditional gates may be in skip_gates based on stack detection:
+     - "5.5" may be skipped if service is NOT a plugin
+     - "6" may be skipped if RabbitMQ was NOT detected
+     - "10", "11" may be skipped when invoked from dev-cycle
+   - skip_gates MUST NOT contain core gates (0-5, 7-9)
 4. detected_dependencies (if provided) is used to pre-populate Gate 0 stack detection
    — still MUST verify with grep commands (trust but verify)
 

--- a/dev-team/skills/shared-patterns/multi-tenant-analysis.md
+++ b/dev-team/skills/shared-patterns/multi-tenant-analysis.md
@@ -33,12 +33,12 @@ See [multi-tenant.md § Canonical Model Compliance](../../docs/standards/golang/
 ### Connection Pool Health
 ```bash
 # Check pool configuration is parameterized (not hardcoded)
-grep -rn "WithMaxTenantPools\|WithIdleTimeout" internal/ --include="*.go"
+grep -rn "WithMaxTenantPools\|WithIdleTimeout" internal/ pkg/ cmd/ --include="*.go"
 # Expected: Pool limits come from config (env vars), not hardcoded values
 
-# Check for hardcoded pool sizes
-grep -rn "MaxOpenConns.*=\|MaxIdleConns.*=" internal/ --include="*.go" | grep -v "_test.go" | grep -v "config\."
-# Expected: 0 matches outside config. Pool sizes MUST come from config or ConnectionSettings.
+# Check for hardcoded pool sizes (outside config/bootstrap)
+grep -rn "MaxOpenConns.*=\|MaxIdleConns.*=" internal/ pkg/ --include="*.go" | grep -v "_test.go" | grep -v "config\.\|Config\.\|cfg\."
+# Expected: 0 matches outside config. Pool sizes should come from config or ConnectionSettings.
 ```
 - ISSUE if pool limits are hardcoded → MEDIUM: "Pool limits MUST come from MULTI_TENANT_MAX_TENANT_POOLS config"
 - ISSUE if idle timeout is missing → MEDIUM: "MUST configure WithIdleTimeout to prevent connection leaks"
@@ -46,7 +46,7 @@ grep -rn "MaxOpenConns.*=\|MaxIdleConns.*=" internal/ --include="*.go" | grep -v
 ### Circuit Breaker Configuration
 ```bash
 # Verify circuit breaker is configured with env-driven thresholds
-grep -rn "WithCircuitBreaker" internal/ --include="*.go"
+grep -rn "WithCircuitBreaker" internal/ pkg/ cmd/ --include="*.go"
 # Expected: threshold and timeout come from config, not hardcoded
 ```
 - ISSUE if circuit breaker uses hardcoded values → MEDIUM: "Circuit breaker thresholds MUST come from MULTI_TENANT_CIRCUIT_BREAKER_* config"
@@ -54,7 +54,7 @@ grep -rn "WithCircuitBreaker" internal/ --include="*.go"
 ### Metrics Implementation
 ```bash
 # Verify all 4 mandatory metrics exist
-grep -rn "tenant_connections_total\|tenant_connection_errors_total\|tenant_consumers_active\|tenant_messages_processed_total" internal/ --include="*.go"
+grep -rn "tenant_connections_total\|tenant_connection_errors_total\|tenant_consumers_active\|tenant_messages_processed_total" internal/ pkg/ --include="*.go"
 # Expected: All 4 metrics present
 ```
 - ISSUE if any metric missing → MEDIUM: "Missing multi-tenant metric: [name]. All 4 are MANDATORY."
@@ -62,31 +62,38 @@ grep -rn "tenant_connections_total\|tenant_connection_errors_total\|tenant_consu
 
 ### Graceful Shutdown
 ```bash
-# Verify managers are closed on shutdown
-grep -rn "\.Close()\|\.Shutdown()" internal/bootstrap/ --include="*.go"
+# Verify managers are closed on shutdown (check bootstrap, cmd, and pkg paths)
+grep -rn "\.Close()\|\.Shutdown()" internal/bootstrap/ cmd/ pkg/ --include="*.go" 2>/dev/null
 # Expected: PostgresManager.Close(), MongoManager.Close(), RabbitMQManager.Close() in shutdown path
 ```
 - ISSUE if managers not closed on shutdown → HIGH: "Connection managers MUST be closed on graceful shutdown to prevent leaks"
 
 ### Error Handling Completeness
 ```bash
-# Verify sentinel errors are handled
-grep -rn "ErrTenantNotFound\|ErrCircuitBreakerOpen\|ErrManagerClosed\|ErrServiceNotConfigured\|ErrTenantContextRequired\|IsTenantNotProvisionedError" internal/ --include="*.go"
+# Verify sentinel errors are handled (search all Go source paths)
+grep -rn "ErrTenantNotFound\|ErrCircuitBreakerOpen\|ErrManagerClosed\|ErrServiceNotConfigured\|ErrTenantContextRequired\|IsTenantNotProvisionedError" internal/ pkg/ --include="*.go"
 # Expected: All sentinel errors handled in middleware or error handler
 ```
 - ISSUE if sentinel errors not handled → HIGH: "Multi-tenant error [name] not handled. See multi-tenant.md § Error Handling."
 
 ### Single-Tenant Adaptability (for non-MT codebases analyzed by dev-refactor)
 ```bash
-# Check if repositories are MT-adaptable
-grep -rn "\.GetDB()\|\.Database()" internal/adapters/ --include="*.go" | grep -v "_test.go"
-# Expected: Connections accessed via struct field (r.connection), not inline
-# Flag if global singletons or inline DB access found
+# Check for global DB singletons (non-MT-adaptable)
+# This catches package-level var db = ... patterns, NOT struct field access like r.connection.GetDB()
+grep -rn "^var.*sql\.DB\|^var.*pgx\.Pool\|^var.*mongo\.Client\|^var.*redis\.Client" internal/ pkg/ --include="*.go" | grep -v "_test.go"
+# Expected: 0 matches. Database connections should be struct fields, not package-level vars.
 
-# Check context propagation
-grep -rn "func.*ctx context\.Context" internal/adapters/ --include="*.go" | wc -l
-grep -rn "^func " internal/adapters/ --include="*.go" | wc -l
-# Expected: ~100% of functions accept ctx as first param
+# Check that repository methods accept context as first parameter
+# Sample 5 repository files and verify ctx is first param
+for f in $(find internal/adapters/ pkg/adapters/ -name "*.go" ! -name "*_test.go" 2>/dev/null | head -5); do
+  missing=$(grep -c "^func (r \*.*) .*[^(](" "$f" 2>/dev/null)
+  with_ctx=$(grep -c "^func (r \*.*) .*(ctx context\.Context" "$f" 2>/dev/null)
+  total=$((missing + with_ctx))
+  if [ "$total" -gt 0 ] && [ "$with_ctx" -lt "$total" ]; then
+    echo "LOW CTX COVERAGE: $f ($with_ctx/$total methods have ctx)"
+  fi
+done
+# Expected: All repository methods accept ctx context.Context as first parameter.
 ```
-- ISSUE if repositories use inline DB access → MEDIUM: "Repository uses inline DB access. MUST use struct field for MT adaptability."
-- ISSUE if functions lack ctx parameter → MEDIUM: "Function [name] lacks ctx parameter. All methods MUST accept context for MT adaptation."
+- ISSUE if global DB singletons found → HIGH: "Package-level database variable blocks per-tenant connection routing. Refactor to struct field with constructor injection."
+- ISSUE if <80% of repository methods accept ctx → MEDIUM: "Repository methods must accept ctx context.Context as first parameter for MT adaptation."


### PR DESCRIPTION
## Context

Comprehensive audit of the Ring multi-tenant implementation compared standards (2270-line multi-tenant.md), the dev-multi-tenant skill (938 lines), and real-world tenant-manager implementation knowledge. The overall structure is solid, but 7 gaps were found between what standards require and what agents actually receive.

## Changes

### R1: Sub-package import reference (`dev-multi-tenant`)
- Added mandatory import table with all 10 lib-commons v3 sub-packages
- Added Isolation Modes section (isolated vs schema mode guidance)
- Added ConnectionSettings Override section (per-tenant pool tuning)
- Updated agent instruction template with `SUB-PACKAGES` reference
- **Why:** If WebFetch truncates multi-tenant.md, agents lose import paths and hallucinate

### R2: Multi-tenant adaptability (`dev-implementation`)
- Added `⛔ Multi-Tenant Adaptability (MANDATORY for Go backend)` with 5 rules:
  1. DB connection as struct field (not inline)
  2. Context propagation (ctx first param)
  3. No global DB singletons
  4. Redis keys as parameters
  5. S3 keys as parameters
- **Why:** Code written during dev-cycle must be MT-adaptable BEFORE post-cycle step

### R3: Expanded multi-tenant analysis (`shared-patterns/multi-tenant-analysis.md`)
- Extended from 24 to ~90 lines with performance + operational checks
- Pool health, circuit breaker, metrics, graceful shutdown, error handling, adaptability
- **Why:** dev-refactor was only checking compliance, not operational readiness

### R5: Input schema + handoff validation (`dev-multi-tenant`)
- Added `input_schema` with all handoff fields from dev-cycle
- Added Input Validation section with SCOPED vs FULL mode rules
- **Why:** dev-multi-tenant wasn't validating the context it receives from dev-cycle

## Files Changed
- `dev-team/skills/dev-multi-tenant/SKILL.md` — R1, R5
- `dev-team/skills/dev-implementation/SKILL.md` — R2
- `dev-team/skills/shared-patterns/multi-tenant-analysis.md` — R3

Requested by @jeffersonrodrigues