### PR TITLE
feat(dev-helm): add kindIs image declaration pattern as standard

### DIFF
--- a/dev-team/docs/standards/helm/templates.md
+++ b/dev-team/docs/standards/helm/templates.md
@@ -87,6 +87,57 @@ securityContext:
 
 ---
 
+## Image Declaration Pattern (MANDATORY)
+
+All container image references in templates (Deployments, Jobs, CronJobs, initContainers) MUST use the structured `repository/tag/pullPolicy` format from values.yaml AND include a `kindIs` backward-compatibility guard.
+
+### Why
+
+The CI `gitops-update` workflow uses `yq` to update image tags independently. A flat string like `image: "repo/name:tag"` cannot be targeted by tag alone — the tag field must be a separate key. Additionally, existing gitops values files may still use the old string format during migration, so templates must handle both.
+
+### values.yaml Structure
+
+```yaml
+{component}:
+  image:
+    repository: ghcr.io/lerianstudio/{service-name}
+    pullPolicy: IfNotPresent
+    tag: "1.0.0"
+```
+
+### Template Pattern (with kindIs guard)
+
+```yaml
+{{- $img := .Values.{component}.image -}}
+{{- if kindIs "string" $img }}
+image: {{ $img | quote }}
+imagePullPolicy: Always
+{{- else }}
+image: "{{ $img.repository | default "ghcr.io/lerianstudio/{service-name}" }}:{{ $img.tag | default "latest" }}"
+imagePullPolicy: {{ $img.pullPolicy | default "IfNotPresent" }}
+{{- end }}
+```
+
+### Rules
+
+```text
+1. EVERY container spec (main, sidecar, init, migration, job) MUST use this pattern
+2. The `kindIs "string"` branch provides backward compatibility during migration
+3. The `else` branch (map format) is the target state — new charts MUST use map format in values.yaml
+4. Default repository MUST match the ghcr.io/lerianstudio/{service-name} convention
+5. Default tag SHOULD be "latest" for jobs/migrations, specific version for app containers
+6. Default pullPolicy: IfNotPresent for app containers, Always for jobs/migrations
+7. initContainers using well-known images (e.g., busybox:1.37) MAY use inline strings
+```
+
+<forbidden>
+- Flat string image values in new charts (use structured repository/tag/pullPolicy)
+- Templates that access .image.repository without kindIs guard
+- Hardcoded image tags in templates (always read from values)
+</forbidden>
+
+---
+
 ## Health Check Verification
 
 <cannot_skip>

--- a/dev-team/skills/dev-helm/SKILL.md
+++ b/dev-team/skills/dev-helm/SKILL.md
@@ -283,6 +283,7 @@ RUN in order:
 CHECK each item:
 
 [ ] Chart.yaml name has -helm suffix (unless exception)
+[ ] Image declarations use structured repository/tag/pullPolicy with kindIs guard ([pattern](../../docs/standards/helm/templates.md#image-declaration-pattern-mandatory))
 [ ] All values quoted in ConfigMap ({{ $value | quote }})
 [ ] No hardcoded credentials in values.yaml (use placeholders)
 [ ] Security context: runAsNonRoot: true, drop ALL capabilities
@@ -324,6 +325,7 @@ See [shared-patterns/shared-pressure-resistance.md](../shared-patterns/shared-pr
 | "One configmap for everything" | Sensitive data MUST be in Secrets, not ConfigMap | **Split per ConfigMap vs Secrets rule** |
 | "The chart works, so it's done" | Must validate against app env vars AND lint AND template render | **Run ALL validation steps** |
 | "initContainers are overkill" | Without dependency checks, pods crash before DB is ready | **Add wait-for-dependencies** |
+| "Just use a flat string for the image" | CI gitops-update can't target the tag independently; breaks automated deploys | **Use structured repository/tag/pullPolicy with kindIs guard** |
 
 ---
 


### PR DESCRIPTION
## Context

PR [helm#1105](https://github.com/LerianStudio/helm/pull/1105) exposed that our templates assumed image values are always maps (`repository/tag/pullPolicy`), but existing gitops values files may still use the old flat string format. CodeRabbit caught it, and the fix was a `kindIs` guard.

This PR codifies that pattern as a Lerian standard so all future charts follow it.

## Changes

### `dev-team/docs/standards/helm/templates.md`
- New section: **Image Declaration Pattern (MANDATORY)** — documents the structured `repository/tag/pullPolicy` values format plus the `kindIs "string"` backward-compat guard
- Includes: values.yaml structure, template pattern, rules, forbidden practices

### `dev-team/skills/dev-helm/SKILL.md`
- Added image pattern check to the manual validation checklist
- Added anti-rationalization entry for flat string image usage

## Pattern Summary

```yaml
{{- $img := .Values.{component}.image -}}
{{- if kindIs "string" $img }}
image: {{ $img | quote }}
imagePullPolicy: Always
{{- else }}
image: "{{ $img.repository | default "ghcr.io/lerianstudio/{service}" }}:{{ $img.tag | default "latest" }}"
imagePullPolicy: {{ $img.pullPolicy | default "IfNotPresent" }}
{{- end }}
```

Requested by @guilherme-rodrigues-lerian in [#pull-requests](https://lerianstudio.slack.com/archives/C08MDPHLHBM).