### PR TITLE
fix(standards): add bootstrap-only comments to panic() examples

### DIFF
--- a/dev-team/docs/standards/golang/bootstrap.md
+++ b/dev-team/docs/standards/golang/bootstrap.md
@@ -367,6 +367,7 @@ headers := libOpentelemetry.PrepareQueueHeaders(ctx, map[string]any{
 func InitServers() *Service {
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 
@@ -666,6 +667,7 @@ func InitServers() *Service {
     // All environment variables are loaded into the Config struct
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 

--- a/dev-team/docs/standards/golang/core.md
+++ b/dev-team/docs/standards/golang/core.md
@@ -392,11 +392,13 @@ func InitServers() *Service {
 
     // Load all environment variables into config struct
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 
     // Validate required fields
     if cfg.PrimaryDBHost == "" || cfg.PrimaryDBName == "" {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic("DB_HOST and DB_NAME must be configured")
     }
 

--- a/dev-team/docs/standards/golang/security.md
+++ b/dev-team/docs/standards/golang/security.md
@@ -99,6 +99,7 @@ type Config struct {
 func InitServers() *Service {
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 
@@ -370,6 +371,7 @@ import (
 func InitServers() *Service {
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 

--- a/dev-team/docs/standards/sre.md
+++ b/dev-team/docs/standards/sre.md
@@ -303,6 +303,7 @@ import (
 func InitServers() *Service {
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 

--- a/platforms/opencode/standards/sre.md
+++ b/platforms/opencode/standards/sre.md
@@ -303,6 +303,7 @@ import (
 func InitServers() *Service {
     cfg := &Config{}
     if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+        // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
         panic(err)
     }
 

--- a/pm-team/skills/shared-patterns/code-example-standards.md
+++ b/pm-team/skills/shared-patterns/code-example-standards.md
@@ -106,6 +106,7 @@ type Config struct {
 
 cfg := &Config{}
 if err := libCommons.SetConfigFromEnvVars(cfg); err != nil {
+    // bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
     panic(err)
 }
 ```


### PR DESCRIPTION
## Problem

Garzão reportou no #the-ring-feedbacks que Ring agents ainda estavam gerando código com `panic()` em business logic.

**Root cause:** Os code examples nos standards usam `panic(err)` em contexto de bootstrap (que é correto em Go), mas sem nenhum comentário explícito. Agents copiam o padrão do exemplo literalmente, ignorando a regra abstrata do `backend-engineer-golang.md` que proíbe panic em business logic.

## Fix

Adicionei comentário explícito em todas as ocorrências de `panic()` nos code examples:

```go
// bootstrap-only: panic is acceptable in main/init; NEVER use panic in business logic
panic(err)
```

### Files changed (6):
- `pm-team/skills/shared-patterns/code-example-standards.md` — exemplo marcado como '✅ CORRECT' agora tem o comentário
- `dev-team/docs/standards/sre.md` — bootstrap example
- `dev-team/docs/standards/golang/bootstrap.md` — 2 bootstrap examples
- `dev-team/docs/standards/golang/core.md` — bootstrap + validation examples
- `dev-team/docs/standards/golang/security.md` — 2 bootstrap examples
- `platforms/opencode/standards/sre.md` — synced with dev-team source

**Nota do Fred:** `platforms/opencode/standards/sre.md` deriva do `dev-team/docs/standards/sre.md` — mantive ambos em sync.

## Why comments instead of replacing panic

`panic()` em bootstrap/init IS the correct Go idiom — a aplicação não pode funcionar sem config. O problema não é o panic em si, é que os agents não distinguem bootstrap de business logic. O comentário inline resolve isso porque agents copiam o comentário junto com o código.