### PR TITLE
feat(default): add gandalf-webhook skill

### DIFF
--- a/default/skills/gandalf-webhook/SKILL.md
+++ b/default/skills/gandalf-webhook/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: ring:gandalf-webhook
+description: Send tasks to Gandalf (AI team member) via webhook and get responses back. Publish to Alfarrábio, ask for business context, trigger Slack messages, and more.
+user_invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+---
+
+# Gandalf Webhook
+
+Send tasks to Gandalf and get responses back. Gandalf is Lerian's AI team member running on a dedicated Mac mini with access to Slack, Google Workspace, GitHub, Jira, Alfarrábio (report server), and more.
+
+## When to Use
+
+- **Publish to Alfarrábio** — send analysis, reports, or HTML to be published on the report server
+- **Business context** — ask Gandalf about clients, deals, product decisions, team context
+- **Slack messages** — ask Gandalf to post something on a Slack channel
+- **Cross-tool tasks** — anything that needs tools you don't have (Google Docs, CRM, calendar, etc.)
+
+## Endpoint
+
+```
+POST http://gandalf.heron-justitia.ts.net:18792/task
+```
+
+Accessible only via Tailscale. No auth token needed — identity is resolved automatically from your Tailscale node.
+
+## Sending a Task
+
+```bash
+curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "your task description here",
+    "context": "optional context about what you are working on"
+  }'
+```
+
+**Fields:**
+| Field | Required | Description |
+|-------|----------|-------------|
+| `message` | Yes | What you want Gandalf to do. Be specific. |
+| `context` | No | What you're working on (repo, PR, feature). Helps Gandalf prioritize and contextualize. |
+
+**Response (202):**
+```json
+{
+  "ok": true,
+  "task_id": "a1b2c3d4",
+  "from": "Your Name",
+  "node": "your-machine",
+  "status": "processing",
+  "poll": "/task/a1b2c3d4"
+}
+```
+
+## Polling for Response
+
+```bash
+curl -s http://gandalf.heron-justitia.ts.net:18792/task/{task_id}
+```
+
+**While processing:**
+```json
+{
+  "task_id": "a1b2c3d4",
+  "status": "processing"
+}
+```
+
+**When done:**
+```json
+{
+  "task_id": "a1b2c3d4",
+  "status": "done",
+  "response": "Published at https://alfarrabio.lerian.net/your-report.html",
+  "completed_at": "2026-03-13T16:18:51-03:00"
+}
+```
+
+## Full Pattern (send + poll)
+
+```bash
+# Send task
+TASK_ID=$(curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{"message": "publish this analysis as an Alfarrábio report", "context": "PR #1900 lib-commons v4"}' \
+  | jq -r .task_id)
+
+# Poll until done (max ~2 min)
+for i in $(seq 1 24); do
+  RESULT=$(curl -s http://gandalf.heron-justitia.ts.net:18792/task/$TASK_ID)
+  STATUS=$(echo $RESULT | jq -r .status)
+  if [ "$STATUS" != "processing" ]; then
+    echo $RESULT | jq .
+    break
+  fi
+  sleep 5
+done
+```
+
+## Examples
+
+### Publish a report to Alfarrábio
+```bash
+curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Create an Alfarrábio report with this content:\n\n# API Coverage Analysis\n\n...(your content)...\n\nPublish it and return the URL.",
+    "context": "midaz API audit"
+  }'
+```
+
+### Ask for business context
+```bash
+curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "What is the current status of the Voluti integration? Any known issues?",
+    "context": "investigating INC-72"
+  }'
+```
+
+### Post to Slack
+```bash
+curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "message": "Post on #pull-requests: PR #1900 lib-commons v4 is ready for review. Migration guide included.",
+    "context": "lib-commons v4 task force"
+  }'
+```
+
+## Constraints
+
+- **Rate limit:** 10 requests/min per Tailscale node
+- **Timeout:** 120s per task
+- **One-way initiation:** you send, Gandalf processes. No streaming.
+- **Tailscale only:** not accessible from the public internet
+- **Identity:** your Tailscale node identity is attached automatically. No spoofing.
+
+## Health Check
+
+```bash
+curl -s http://gandalf.heron-justitia.ts.net:18792/health
+```


### PR DESCRIPTION
## What

Adds `ring:gandalf-webhook` skill to the default plugin. Enables any coding agent (Claude Code, Opencode, etc.) to send tasks to Gandalf via HTTP webhook and poll for responses.

## How it works

1. Coding agent sends `POST /task` with a message
2. Gandalf opens an OpenClaw session and processes the task
3. Coding agent polls `GET /task/{id}` for the response

## Identity

Zero-trust via Tailscale `whois` — no auth tokens needed. The webhook resolves the sender's identity from their Tailscale node automatically.

## Use cases

- Publish reports to Alfarrábio
- Ask for business/product context
- Trigger Slack messages
- Any cross-tool task the coding agent can't do directly

## Infrastructure

- Webhook service: `gandalf.heron-justitia.ts.net:18792`
- Tailscale-only (not public)
- Rate limit: 10 req/min per node
- LaunchAgent with auto-restart