### PR TITLE
feat(gandalf-webhook): v3 — fast paths + full agent

### DIFF
--- a/default/skills/gandalf-webhook/SKILL.md
+++ b/default/skills/gandalf-webhook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ring:gandalf-webhook
-description: Send tasks to Gandalf (AI team member) via webhook and get responses back. Publish to Alfarrábio, ask for business context, trigger Slack messages, and more.
+description: Send tasks to Gandalf (AI team member) via webhook and get responses back. Publish to Alfarrábio, send Slack notifications, ask for business context, and more.
 user_invocable: true
 allowed-tools:
   - Bash
@@ -12,86 +12,73 @@ allowed-tools:
 
 Send tasks to Gandalf and get responses back. Gandalf is Lerian's AI team member running on a dedicated Mac mini with access to Slack, Google Workspace, GitHub, Jira, Alfarrábio (report server), and more.
 
-## When to Use
-
-- **Publish to Alfarrábio** — send analysis, reports, or HTML to be published on the report server
-- **Business context** — ask Gandalf about clients, deals, product decisions, team context
-- **Slack messages** — ask Gandalf to post something on a Slack channel
-- **Cross-tool tasks** — anything that needs tools you don't have (Google Docs, CRM, calendar, etc.)
-
 ## Endpoint
 
 ```
 POST http://gandalf.heron-justitia.ts.net:18792/task
 ```
 
-Accessible only via Tailscale. No auth token needed — identity is resolved automatically from your Tailscale node.
+Tailscale only. No auth token — identity resolved from your Tailscale node.
 
-## Sending a Task
+## Actions
+
+### `publish` — instant (<1s)
+
+Write content directly to Alfarrábio and get the URL back. No agent bootstrap.
 
 ```bash
 curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
   -H "Content-Type: application/json" \
   -d '{
-    "message": "your task description here",
-    "context": "optional context about what you are working on"
+    "action": "publish",
+    "message": "My Report Title",
+    "content": "<html>...full report...</html>",
+    "context": "optional context"
   }'
 ```
 
-**Fields:**
-| Field | Required | Description |
-|-------|----------|-------------|
-| `message` | Yes | What you want Gandalf to do. Be specific. |
-| `context` | No | What you're working on (repo, PR, feature). Helps Gandalf prioritize and contextualize. |
-| `content` | No | Inline content (HTML, markdown, text) for Gandalf to process. Max 5MB. Use this instead of file uploads. |
-
-**Response (202):**
+Response (synchronous):
 ```json
 {
   "ok": true,
   "task_id": "a1b2c3d4",
-  "from": "Your Name",
-  "node": "your-machine",
-  "status": "processing",
-  "poll": "/task/a1b2c3d4"
+  "status": "done",
+  "response": "https://alfarrabio.lerian.net/my-report-title.html"
 }
 ```
 
-## Polling for Response
+### `notify` — instant (<1s)
+
+Send a Slack message. Prefix with `#channel:` to target a specific channel.
 
 ```bash
-curl -s http://gandalf.heron-justitia.ts.net:18792/task/{task_id}
+curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "action": "notify",
+    "message": "#pull-requests: PR #1900 lib-commons v4 ready for review"
+  }'
 ```
 
-**While processing:**
-```json
-{
-  "task_id": "a1b2c3d4",
-  "status": "processing"
-}
-```
+Without `#channel:` prefix, sends to #gandalf-notifications.
 
-**When done:**
-```json
-{
-  "task_id": "a1b2c3d4",
-  "status": "done",
-  "response": "Published at https://alfarrabio.lerian.net/your-report.html",
-  "completed_at": "2026-03-13T16:18:51-03:00"
-}
-```
+### `ask` — full agent (~30-60s)
 
-## Full Pattern (send + poll)
+Open a full OpenClaw agent session. Use for anything that needs intelligence: business context, analysis, cross-tool tasks. This is the default when `action` is omitted.
 
 ```bash
 # Send task
-TASK_ID=$(curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
+RESP=$(curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
   -H "Content-Type: application/json" \
-  -d '{"message": "publish this analysis as an Alfarrábio report", "context": "PR #1900 lib-commons v4"}' \
-  | jq -r .task_id)
+  -d '{
+    "action": "ask",
+    "message": "What is the current status of the Voluti integration?",
+    "context": "investigating INC-72"
+  }')
+TASK_ID=$(echo $RESP | jq -r .task_id)
 
-# Poll until done (max ~2 min)
-for i in $(seq 1 24); do
+# Poll until done
+for i in $(seq 1 60); do
   RESULT=$(curl -s http://gandalf.heron-justitia.ts.net:18792/task/$TASK_ID)
   STATUS=$(echo $RESULT | jq -r .status)
   if [ "$STATUS" != "processing" ]; then
@@ -102,63 +89,40 @@ for i in $(seq 1 24); do
 done
 ```
 
-## Examples
+## Fields
 
-### Publish a report to Alfarrábio
-```bash
-# Build your HTML/markdown content, then send inline via `content` field
-CONTENT=$(cat my-report.html)
-curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
-  -H "Content-Type: application/json" \
-  --data-binary @- << EOF
-{
-  "message": "Publish this as an Alfarrábio report titled 'API Coverage Analysis'. Return the URL.",
-  "context": "midaz API audit",
-  "content": $(echo "$CONTENT" | jq -Rs .)
-}
-EOF
+| Field | Required | Description |
+|-------|----------|-------------|
+| `message` | Yes | What to do. For `publish`, this becomes the report title. |
+| `action` | No | `publish` (instant), `notify` (instant), `ask` (full agent). Default: `ask`. |
+| `content` | No | Inline content (HTML, markdown, text). Required for `publish`. Max 5MB. |
+| `context` | No | What you're working on (repo, PR, feature). |
+
+## Polling (for `ask` only)
+
+```
+GET http://gandalf.heron-justitia.ts.net:18792/task/{task_id}
 ```
 
-### Publish markdown (Gandalf converts to HTML)
-```bash
-curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Convert this markdown to a styled Alfarrábio report and publish it. Return the URL.",
-    "context": "PR #1900 analysis",
-    "content": "# Analysis\n\n## Findings\n\n- Point 1\n- Point 2\n\n## Conclusion\n\nAll good."
-  }'
-```
+`publish` and `notify` return the result synchronously — no polling needed.
 
-### Ask for business context
-```bash
-curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "What is the current status of the Voluti integration? Any known issues?",
-    "context": "investigating INC-72"
-  }'
-```
+## When to Use What
 
-### Post to Slack
-```bash
-curl -s -X POST http://gandalf.heron-justitia.ts.net:18792/task \
-  -H "Content-Type: application/json" \
-  -d '{
-    "message": "Post on #pull-requests: PR #1900 lib-commons v4 is ready for review. Migration guide included.",
-    "context": "lib-commons v4 task force"
-  }'
-```
+| Need | Action | Speed |
+|------|--------|-------|
+| Publish HTML/markdown report | `publish` | <1s |
+| Send Slack notification | `notify` | <1s |
+| Ask business/product question | `ask` | 30-60s |
+| Complex cross-tool task | `ask` | 30-300s |
+| Anything without `action` field | `ask` | 30-300s |
 
 ## Constraints
 
 - **Rate limit:** 10 requests/min per Tailscale node
-- **Timeout:** 120s per task
-- **Content limit:** 5MB inline (use `content` field, not file uploads)
-- **One-way initiation:** you send, Gandalf processes. No streaming.
+- **Content limit:** 5MB inline
+- **Agent timeout:** 300s (for `ask` actions)
 - **Tailscale only:** not accessible from the public internet
-- **Identity:** your Tailscale node identity is attached automatically. No spoofing.
-- **No file uploads:** send content inline as JSON string. Safer, simpler.
+- **No file uploads:** send content inline as JSON string
 
 ## Health Check
 


### PR DESCRIPTION
## v3 — Three-tier action system

### Fast paths (no agent, <1s):
- **`action=publish`** — writes content to Alfarrábio, returns URL synchronously
- **`action=notify`** — sends Slack message, returns synchronously

### Slow path (full agent, 30-300s):
- **`action=ask`** (default) — opens full OpenClaw agent session with polling

### Why
v2 routed everything through a full agent session (~40K token bootstrap). Publishing a 56KB HTML report timed out at 120s. Fast paths bypass the agent entirely for well-defined operations.

Follows #270 and #272.