### PR TITLE
fix: correct JSON field naming from snake_case to camelCase

### DIFF
--- a/default/skills/production-readiness-audit/SKILL.md
+++ b/default/skills/production-readiness-audit/SKILL.md
@@ -2992,9 +2992,9 @@ Audit naming conventions across the codebase for production readiness.
 // Go struct with correct naming conventions
 type Account struct {
     ID          uuid.UUID `json:"id" gorm:"column:id"`
-    DisplayName string    `json:"display_name" gorm:"column:display_name"`  // camelCase JSON, snake_case DB
-    AccountType string    `json:"account_type" gorm:"column:account_type"`
-    CreatedAt   time.Time `json:"created_at" gorm:"column:created_at"`
+    DisplayName string    `json:"displayName" gorm:"column:display_name"`  // camelCase JSON, snake_case DB
+    AccountType string    `json:"accountType" gorm:"column:account_type"`
+    CreatedAt   time.Time `json:"createdAt" gorm:"column:created_at"`
 }
 
 // Query parameters use snake_case
@@ -3014,9 +3014,9 @@ type Account struct {
 // BAD: Inconsistent JSON naming
 type Account struct {
     ID          uuid.UUID `json:"id"`
-    DisplayName string    `json:"displayName"`    // camelCase instead of snake_case
-    AccountType string    `json:"account_type"`   // snake_case — inconsistent with above!
-    CreatedAt   time.Time `json:"CreatedAt"`      // PascalCase — wrong!
+    DisplayName string    `json:"display_name"`   // snake_case — WRONG for JSON body
+    AccountType string    `json:"account_type"`   // snake_case — WRONG for JSON body
+    CreatedAt   time.Time `json:"CreatedAt"`      // PascalCase — WRONG
 }
 
 // BAD: Mixed naming in query params
@@ -3025,7 +3025,7 @@ type Account struct {
 
 **Check Against Ring Standards For:**
 1. snake_case for database column names in migrations and GORM tags
-2. snake_case for JSON response body fields (json:"field_name")
+2. camelCase for JSON response body fields (json:"fieldName")
 3. snake_case for query parameters
 4. PascalCase for Go exported types and functions
 5. camelCase for Go unexported fields and variables
@@ -3043,7 +3043,7 @@ type Account struct {
 
 ### Summary
 - JSON fields audited: X
-- Using snake_case JSON: Y/X
+- Using camelCase JSON: Y/X
 - DB columns using snake_case: Y/Z
 - Query params using snake_case: Y/Z
 - Naming convention violations: N

--- a/dev-team/docs/standards/golang/messaging.md
+++ b/dev-team/docs/standards/golang/messaging.md
@@ -362,9 +362,9 @@ func (p *ProducerRepository) Publish(ctx context.Context, exchange, routingKey s
 
 ```go
 type QueueMessage struct {
-    OrganizationID uuid.UUID   `json:"organization_id"`
-    LedgerID       uuid.UUID   `json:"ledger_id"`
-    AuditID        uuid.UUID   `json:"audit_id"`
+    OrganizationID uuid.UUID   `json:"organizationId"`
+    LedgerID       uuid.UUID   `json:"ledgerId"`
+    AuditID        uuid.UUID   `json:"auditId"`
     Data           []QueueData `json:"data"`
 }
 

--- a/platforms/opencode/standards/golang.md
+++ b/platforms/opencode/standards/golang.md
@@ -2805,9 +2805,9 @@ func (p *ProducerRepository) Publish(ctx context.Context, exchange, routingKey s
 
 ```go
 type QueueMessage struct {
-    OrganizationID uuid.UUID   `json:"organization_id"`
-    LedgerID       uuid.UUID   `json:"ledger_id"`
-    AuditID        uuid.UUID   `json:"audit_id"`
+    OrganizationID uuid.UUID   `json:"organizationId"`
+    LedgerID       uuid.UUID   `json:"ledgerId"`
+    AuditID        uuid.UUID   `json:"auditId"`
     Data           []QueueData `json:"data"`
 }
 


### PR DESCRIPTION
## Problem

Three Ring files had code examples using `snake_case` for JSON struct tags, contradicting the mandatory `camelCase` convention defined in `dev-team/docs/standards/golang/api-patterns.md`.

This means agents using these files as reference would generate code with the wrong naming convention.

## Files Fixed

| File | Issue |
|------|-------|
| `platforms/opencode/standards/golang.md` | QueueMessage fields: `organization_id` → `organizationId` |
| `dev-team/docs/standards/golang/messaging.md` | Same QueueMessage copy |
| `default/skills/production-readiness-audit/SKILL.md` | GOOD/BAD reference examples were inverted — marked `snake_case` JSON as correct |

## Convention (per api-patterns.md)

| Context | Convention | Example |
|---------|-----------|---------|
| JSON body fields | camelCase | `organizationId`, `createdAt` |
| Query parameters | snake_case | `sort_order`, `start_date` |
| Database columns | snake_case | `organization_id`, `created_at` |

Reported by @alexgarzao