### PR TITLE
feat(dev-team): add licensing skill and command

### DIFF
--- a/dev-team/commands/dev-license.md
+++ b/dev-team/commands/dev-license.md
@@ -1,0 +1,102 @@
+---
+name: ring:dev-license
+description: Apply or switch the license for the current repository
+argument-hint: "[apache|elv2|proprietary] [options]"
+---
+
+Apply or switch the license for the current repository.
+
+## Usage
+
+```
+/ring:dev-license [license-type] [options]
+```
+
+## Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `license-type` | No* | One of: `apache`, `elv2`, `proprietary` |
+
+*If omitted, the skill will detect the current license and ask which to apply.
+
+## Options
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `--dry-run` | Show what would change without modifying files | `--dry-run` |
+| `--year YEAR` | Override copyright year (default: current year) | `--year 2025` |
+| `--holder NAME` | Override copyright holder (default: Lerian Studio Ltd.) | `--holder "Lerian Studio Ltd."` |
+
+## License Types
+
+| Type | Full Name | SPDX | Use Case |
+|------|-----------|------|----------|
+| `apache` | Apache License 2.0 | `Apache-2.0` | Open source (e.g., Midaz core) |
+| `elv2` | Elastic License v2 | `Elastic-2.0` | Source-available Lerian products |
+| `proprietary` | Lerian Studio General License | `LicenseRef-Lerian-Proprietary` | Internal/closed repos |
+
+## Examples
+
+```bash
+# Apply Apache 2.0 license
+/ring:dev-license apache
+
+# Switch to ELv2
+/ring:dev-license elv2
+
+# Apply proprietary license with specific year
+/ring:dev-license proprietary --year 2024
+
+# Check what would change without modifying
+/ring:dev-license apache --dry-run
+
+# Detect current license (interactive)
+/ring:dev-license
+```
+
+## What It Does
+
+1. **Detects** current license (LICENSE file, source headers, SPDX identifiers)
+2. **Confirms** change with user (if switching from an existing license)
+3. **Writes** the LICENSE file with the full license text
+4. **Updates** all source file headers (.go, .ts, .js) to match
+5. **Updates** SPDX identifiers in go.mod/package.json (if present)
+6. **Updates** README.md license badge/section (if present)
+7. **Validates** all files have consistent headers
+
+## Related Commands
+
+| Command | Description |
+|---------|-------------|
+| `/ring:dev-cycle` | Development cycle (includes license check at Gate 0) |
+| `/ring:dev-refactor` | Codebase analysis (may detect license inconsistencies) |
+
+---
+
+## MANDATORY: Load Full Skill
+
+**This command MUST load the skill for complete workflow execution.**
+
+```
+Use Skill tool: ring:dev-licensing
+```
+
+The skill contains the complete 4-gate workflow with:
+- License detection and identification
+- User confirmation gate
+- Agent dispatch for header updates
+- Validation with consistency checks
+- Anti-rationalization tables
+- Pressure resistance scenarios
+
+## Execution Context
+
+Pass the following context to the skill:
+
+| Parameter | Value |
+|-----------|-------|
+| `license_type` | First argument: `apache`, `elv2`, or `proprietary` (if provided) |
+| `dry_run` | `true` if `--dry-run` flag present |
+| `copyright_year` | Value of `--year` option (default: current year) |
+| `copyright_holder` | Value of `--holder` option (default: `Lerian Studio Ltd.`) |

--- a/dev-team/docs/standards/golang/core.md
+++ b/dev-team/docs/standards/golang/core.md
@@ -844,23 +844,64 @@ grep -rn "CREATE TABLE\|ALTER TABLE\|DROP TABLE" --include="*.go" ./internal
 | Compliance audit failures | Audit-ready codebase          |
 | Inconsistent attribution  | Uniform legal protection      |
 
-### Required Format (Elastic License 2.0)
+### Important: License Is Per-Repository
+
+Lerian uses three license types, chosen per-app. The actual header text MUST match the LICENSE file in the repository root. Use the `/ring:dev-license` command (or the `ring:dev-licensing` skill) to apply or switch licenses consistently across a repository.
+
+| License | SPDX Identifier | When Used |
+| ------- | --------------- | --------- |
+| Apache 2.0 | `Apache-2.0` | Open source projects (e.g., Midaz core) |
+| Elastic License v2 | `Elastic-2.0` | Source-available Lerian products |
+| Proprietary | `LicenseRef-Lerian-Proprietary` | Internal/closed repositories |
+
+### Required Format: Apache 2.0
 
 ```go
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
+// Copyright (c) 2025 Lerian Studio Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yourpackage
+```
+
+### Required Format: Elastic License 2.0
+
+```go
+// Copyright (c) 2025 Lerian Studio Ltd.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package yourpackage
+```
+
+### Required Format: Proprietary (Lerian Studio General License)
+
+```go
+// Copyright (c) 2025 Lerian Studio Ltd. All rights reserved.
+// This source code is proprietary and confidential.
+// Unauthorized copying of this file is strictly prohibited.
 
 package yourpackage
 ```
 
 ### Header Components
 
-| Component         | Value                 | Notes                                     |
-| ----------------- | --------------------- | ----------------------------------------- |
-| Copyright holder  | `Elasticsearch B.V.`  | Fixed for all projects                    |
-| License reference | `Elastic License 2.0` | Or as specified in LICENSE file           |
-| LICENSE location  | Inline in header      | No separate LICENSE file reference needed |
+| Component         | Value                          | Notes                                              |
+| ----------------- | ------------------------------ | -------------------------------------------------- |
+| Copyright holder  | `Lerian Studio Ltd.`           | Default for all Lerian projects                    |
+| Copyright year    | Current year (e.g., `2025`)    | Update when making significant changes             |
+| License reference | Depends on repository LICENSE  | MUST match the LICENSE file in the repo root        |
+| LICENSE location  | Inline in header               | No separate LICENSE file reference needed           |
 
 ### Files That MUST Have Headers
 
@@ -883,9 +924,9 @@ package yourpackage
 ### Correct Examples
 
 ```go
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
+// Copyright (c) 2025 Lerian Studio Ltd.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
 
 package bootstrap
 
@@ -896,9 +937,9 @@ import (
 ```
 
 ```go
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
+// Copyright (c) 2025 Lerian Studio Ltd.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
 
 package bootstrap_test
 
@@ -916,18 +957,22 @@ package model
 import "time"
 
 // ❌ FORBIDDEN: Wrong format (missing full license text)
-// Copyright Elasticsearch B.V.
+// Copyright Lerian Studio
 // Licensed under Elastic License 2.0
 package model
 
 // ❌ FORBIDDEN: Header after package declaration
 package model
 
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License 2.0;
-// you may not use this file except in compliance with the Elastic License 2.0.
+// Copyright (c) 2025 Lerian Studio Ltd.
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
 
 import "time"
+
+// ❌ FORBIDDEN: Header from a different license than the repo LICENSE file
+// (e.g., Apache header in an ELv2 repo, or ELv2 header in an Apache repo)
+// Headers MUST match the LICENSE file in the repository root
 ```
 
 ### Verification Commands

--- a/dev-team/docs/standards/golang/core.md
+++ b/dev-team/docs/standards/golang/core.md
@@ -901,7 +901,7 @@ package yourpackage
 | Copyright holder  | `Lerian Studio Ltd.`           | Default for all Lerian projects                    |
 | Copyright year    | Current year (e.g., `2025`)    | Update when making significant changes             |
 | License reference | Depends on repository LICENSE  | MUST match the LICENSE file in the repo root        |
-| LICENSE location  | Inline in header               | No separate LICENSE file reference needed           |
+| LICENSE location  | Reference to LICENSE file       | Header points to LICENSE file in repo root (e.g., "that can be found in the LICENSE file") |
 
 ### Files That MUST Have Headers
 

--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -1834,6 +1834,28 @@ PM team task files often omit external_dependencies. If the codebase uses postgr
 Multi-tenant state is detected here and passed to Gate 0 (implementation) and Gate 0.5G (verification). See [multi-tenant.md](../../docs/standards/golang/multi-tenant.md) for the canonical model and compliance criteria.
 </auto_detect_reason>
 
+### License Detection (Advisory)
+
+Detect the repository license at cycle start. This check is advisory — it does not block Gate 0. If no license is found, prompt the user; if the user declines, log a warning and proceed.
+
+```text
+7. Detect repository license:
+   license_type = "unknown"
+
+   - ls LICENSE LICENSE.md LICENSE.txt 2>/dev/null
+   - If found:
+     - grep -l "Apache License" LICENSE* → license_type = "apache"
+     - grep -l "Elastic License" LICENSE* → license_type = "elv2"
+     - grep -l "All rights reserved.*Lerian" LICENSE* → license_type = "proprietary"
+   - If not found (no LICENSE file):
+     → Ask user: "No LICENSE file detected. Which license should this repository use? [apache|elv2|proprietary|skip]"
+     → If user selects a license: invoke Skill("ring:dev-licensing") with chosen type
+     → If user selects "skip": log "⚠️ WARNING: No LICENSE file. License headers may be inconsistent."
+
+   Store: state.license_type = license_type
+   Log: "License detected: {license_type}"
+```
+
 ---
 
 ## Step 2: Gate 0 - Implementation (Per Execution Unit)

--- a/dev-team/skills/dev-cycle/SKILL.md
+++ b/dev-team/skills/dev-cycle/SKILL.md
@@ -1849,8 +1849,8 @@ Detect the repository license at cycle start. This check is advisory — it does
      - grep -l "All rights reserved.*Lerian" LICENSE* → license_type = "proprietary"
    - If not found (no LICENSE file):
      → Ask user: "No LICENSE file detected. Which license should this repository use? [apache|elv2|proprietary|skip]"
-     → If user selects a license: invoke Skill("ring:dev-licensing") with chosen type
-     → If user selects "skip": log "⚠️ WARNING: No LICENSE file. License headers may be inconsistent."
+     → If user selects a license: set license_type = <chosen value>, invoke Skill("ring:dev-licensing") with chosen type
+     → If user selects "skip": set license_type = "skip", log "⚠️ WARNING: No LICENSE file. License headers may be inconsistent."
 
    Store: state.license_type = license_type
    Log: "License detected: {license_type}"

--- a/dev-team/skills/dev-licensing/SKILL.md
+++ b/dev-team/skills/dev-licensing/SKILL.md
@@ -1,0 +1,569 @@
+---
+name: ring:dev-licensing
+slug: dev-licensing
+version: 1.0.0
+type: skill
+description: |
+  Apply or switch the license for a Lerian service repository.
+  Supports three license types: Apache 2.0 (open source, like Midaz core),
+  Elastic License v2 (source-available, for Lerian products), and
+  Proprietary (Lerian Studio General License, all rights reserved).
+  Replaces/creates the LICENSE file, updates source file headers,
+  updates SPDX identifiers, and validates consistency across the codebase.
+  Licensing is per-app — decided case by case.
+
+trigger: |
+  - User requests to set, apply, or switch a license on a repository
+  - User runs /ring:dev-license command
+  - Scaffolding a new service from the boilerplate
+  - Task mentions "license", "licensing", "license header", "Apache 2.0", "ELv2", "proprietary"
+  - Gate 0 of dev-cycle when no LICENSE file exists or license is unknown
+
+skip_when: |
+  - Repository already has the requested license AND all source headers match AND SPDX identifiers are correct (verified, not assumed)
+  - Non-code repositories (documentation-only, design assets)
+
+prerequisite: |
+  - Repository with source files (Go, TypeScript, or similar)
+  - User has confirmed the desired license type
+
+related:
+  complementary: [ring:dev-cycle, ring:dev-implementation, ring:backend-engineer-golang, ring:backend-engineer-typescript]
+
+input_schema:
+  required:
+    - name: license_type
+      type: string
+      enum: [apache, elv2, proprietary]
+      description: "The license to apply: apache (Apache 2.0), elv2 (Elastic License v2), proprietary (Lerian Studio General License)"
+  optional:
+    - name: copyright_holder
+      type: string
+      default: "Lerian Studio Ltd."
+      description: "Copyright holder name for headers and LICENSE file"
+    - name: copyright_year
+      type: string
+      default: "current year"
+      description: "Copyright year (defaults to current year)"
+    - name: dry_run
+      type: boolean
+      default: false
+      description: "Report what would change without modifying files"
+    - name: source_dirs
+      type: array
+      items: string
+      default: ["cmd/", "internal/", "pkg/", "src/", "app/", "lib/"]
+      description: "Directories to scan for source files requiring headers"
+
+output_schema:
+  format: markdown
+  required_sections:
+    - name: "License Summary"
+      pattern: "^## License Summary"
+      required: true
+    - name: "Changes Applied"
+      pattern: "^## Changes Applied"
+      required: true
+    - name: "Validation Results"
+      pattern: "^## Validation Results"
+      required: true
+  metrics:
+    - name: result
+      type: enum
+      values: [PASS, FAIL]
+    - name: files_updated
+      type: integer
+    - name: files_skipped
+      type: integer
+    - name: inconsistencies_found
+      type: integer
+
+examples:
+  - name: "Apply Apache 2.0 license"
+    invocation: "/ring:dev-license apache"
+    expected_flow: |
+      1. Detect current license (if any)
+      2. Confirm change with user
+      3. Write LICENSE file
+      4. Update all .go source file headers
+      5. Update SPDX identifiers in go.mod/package.json
+      6. Update README.md badge/section
+      7. Validate all files have consistent headers
+  - name: "Switch from proprietary to ELv2"
+    invocation: "/ring:dev-license elv2"
+    expected_flow: |
+      1. Detect current proprietary license
+      2. Warn: switching from proprietary to source-available
+      3. Confirm with user
+      4. Replace LICENSE file
+      5. Update all source headers
+      6. Validate consistency
+---
+
+# License Management for Lerian Services
+
+<cannot_skip>
+
+## CRITICAL: This Skill ORCHESTRATES. Agents IMPLEMENT.
+
+| Who | Responsibility |
+|-----|----------------|
+| **This Skill** | Detect current license, determine changes, validate results |
+| **ring:backend-engineer-golang** | Update Go source file headers (when Go project) |
+| **ring:backend-engineer-typescript** | Update TypeScript source file headers (when TS project) |
+
+**CANNOT change license without user confirmation.**
+
+**FORBIDDEN: Applying a license that the user did not explicitly choose.**
+
+</cannot_skip>
+
+---
+
+## License Types
+
+Lerian uses three license types, chosen per-app:
+
+| License | SPDX Identifier | Use Case | Header Style |
+|---------|-----------------|----------|--------------|
+| **Apache 2.0** | `Apache-2.0` | Open source projects (e.g., Midaz core) | Copyright + Apache reference |
+| **Elastic License v2** | `Elastic-2.0` | Source-available Lerian products | Copyright + ELv2 reference |
+| **Proprietary** | `LicenseRef-Lerian-Proprietary` | Internal/closed repositories | Copyright + all rights reserved |
+
+### License Header Templates
+
+#### Apache 2.0 Header (for `.go` files)
+
+```go
+// Copyright (c) {YEAR} {COPYRIGHT_HOLDER}
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yourpackage
+```
+
+#### Elastic License v2 Header (for `.go` files)
+
+```go
+// Copyright (c) {YEAR} {COPYRIGHT_HOLDER}
+// Use of this source code is governed by the Elastic License 2.0
+// that can be found in the LICENSE file.
+
+package yourpackage
+```
+
+#### Proprietary Header (for `.go` files)
+
+```go
+// Copyright (c) {YEAR} {COPYRIGHT_HOLDER}. All rights reserved.
+// This source code is proprietary and confidential.
+// Unauthorized copying of this file is strictly prohibited.
+
+package yourpackage
+```
+
+### TypeScript/JavaScript Header Templates
+
+#### Apache 2.0 Header (for `.ts`/`.js` files)
+
+```typescript
+/**
+ * Copyright (c) {YEAR} {COPYRIGHT_HOLDER}
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+```
+
+#### Elastic License v2 Header (for `.ts`/`.js` files)
+
+```typescript
+/**
+ * Copyright (c) {YEAR} {COPYRIGHT_HOLDER}
+ * Use of this source code is governed by the Elastic License 2.0
+ * that can be found in the LICENSE file.
+ */
+```
+
+#### Proprietary Header (for `.ts`/`.js` files)
+
+```typescript
+/**
+ * Copyright (c) {YEAR} {COPYRIGHT_HOLDER}. All rights reserved.
+ * This source code is proprietary and confidential.
+ * Unauthorized copying of this file is strictly prohibited.
+ */
+```
+
+---
+
+## Gate 0: Detection
+
+**Orchestrator executes directly. No agent dispatch.**
+
+```text
+DETECT (run in parallel):
+
+1. LICENSE file:
+   - ls LICENSE LICENSE.md LICENSE.txt 2>/dev/null
+   - If found: read first 5 lines to identify type
+
+2. Identify license type from LICENSE content:
+   - grep -l "Apache License" LICENSE* → apache
+   - grep -l "Elastic License" LICENSE* → elv2
+   - grep -l "All rights reserved.*Lerian" LICENSE* → proprietary
+   - grep -l "All rights reserved" LICENSE* → unknown-proprietary
+   - No LICENSE file → none
+
+3. Current source headers:
+   - head -3 $(find . -name "*.go" -not -path "./vendor/*" -not -name "*.pb.go" | head -5)
+   - head -5 $(find . -name "*.ts" -not -path "./node_modules/*" | head -5)
+
+4. SPDX identifiers:
+   - grep -i "license" go.mod 2>/dev/null
+   - grep '"license"' package.json 2>/dev/null
+
+5. README license section:
+   - grep -i "license\|badge" README.md 2>/dev/null | head -10
+```
+
+**Output:**
+
+```text
+CURRENT LICENSE DETECTION:
+| Component        | Status              | Evidence           |
+|------------------|---------------------|--------------------|
+| LICENSE file     | {type} / none       | {file path}        |
+| Source headers   | {type} / mixed / none | {sample}         |
+| SPDX identifier  | {value} / none      | {file:line}        |
+| README section   | present / absent    | {line}             |
+```
+
+---
+
+## Gate 1: Confirmation
+
+**MUST confirm with user before making changes.**
+
+If current license matches requested license:
+
+```text
+"This repository already uses {license_type}. Checking for consistency..."
+→ Skip to Gate 3 (Validation only)
+```
+
+If current license differs from requested:
+
+```text
+"⚠️ LICENSE CHANGE DETECTED
+
+Current: {current_license}
+Requested: {requested_license}
+
+This will:
+- Replace LICENSE file
+- Update headers in {N} source files
+- Update SPDX identifiers
+
+Proceed? [y/N]"
+```
+
+If no current license:
+
+```text
+"No license detected. Will apply {requested_license}.
+
+This will:
+- Create LICENSE file
+- Add headers to {N} source files
+- Set SPDX identifiers
+
+Proceed? [y/N]"
+```
+
+**HARD GATE: MUST NOT proceed without explicit user confirmation.**
+
+---
+
+## Gate 2: Application
+
+**Dispatch the appropriate agent based on project language.**
+
+### Step 2.1: Write LICENSE File
+
+**Orchestrator writes the LICENSE file directly** (no agent needed for a single file write).
+
+Read the reference license text from `dev-team/skills/dev-licensing/references/`:
+
+| License Type | Reference File | Output File |
+|---|---|---|
+| apache | `references/apache-2.0.txt` | `LICENSE` |
+| elv2 | `references/elastic-v2.txt` | `LICENSE` |
+| proprietary | `references/proprietary.txt` | `LICENSE` |
+
+For **proprietary**, replace `{YEAR}` placeholder with the copyright year. For **apache**, the appendix contains `[yyyy]` and `[name of copyright owner]` — these are left as-is in the license body (the boilerplate notice at the bottom is informational). The actual copyright attribution goes in source file headers.
+
+MUST remove any old LICENSE.md or LICENSE.txt if the new file is named `LICENSE` (and vice versa). Only one license file should exist.
+
+### Step 2.2: Update Source File Headers
+
+**Dispatch agent to update headers in all source files.**
+
+For **Go projects**, dispatch `ring:backend-engineer-golang`:
+
+> TASK: Update license headers in all .go source files to match the {license_type} license.
+>
+> LICENSE TYPE: {license_type}
+> COPYRIGHT HOLDER: {copyright_holder}
+> COPYRIGHT YEAR: {copyright_year}
+>
+> HEADER TEMPLATE (use this exact text):
+> ```
+> {header_template from License Header Templates section above}
+> ```
+>
+> RULES:
+> 1. Header MUST be the FIRST content in every .go file (before package declaration)
+> 2. If an existing header exists (lines starting with `//` before `package`), REPLACE it entirely
+> 3. If no header exists, ADD the header before the package declaration
+> 4. Preserve a blank line between the header and the package declaration
+> 5. DO NOT modify generated files (*.pb.go, mock_*.go)
+> 6. DO NOT modify files in vendor/
+> 7. Process ALL .go files in: cmd/, internal/, pkg/, and any other source directories
+> 8. Include test files (*_test.go) — they are source code
+>
+> VERIFICATION: After updating, run:
+> ```bash
+> find . -name "*.go" -not -path "./vendor/*" -not -name "*.pb.go" -not -name "mock_*.go" \
+>     -exec sh -c 'head -1 "$1" | grep -q "^// Copyright" || echo "MISSING: $1"' _ {} \;
+> ```
+> This MUST return zero results.
+
+For **TypeScript projects**, dispatch `ring:backend-engineer-typescript`:
+
+> TASK: Update license headers in all .ts/.js source files to match the {license_type} license.
+>
+> (Same structure as Go dispatch, adapted for TS/JS header format and file patterns.)
+>
+> RULES:
+> 1. Header MUST be the FIRST content in every .ts/.js file (before imports)
+> 2. If an existing header block comment exists (`/** ... */` before first import), REPLACE it
+> 3. DO NOT modify files in node_modules/
+> 4. DO NOT modify generated files (*.d.ts in build output)
+> 5. Process ALL .ts/.js files in: src/, app/, lib/
+> 6. Include test files (*.test.ts, *.spec.ts)
+
+### Step 2.3: Update SPDX Identifiers
+
+**Orchestrator updates SPDX identifiers directly** (simple text replacements).
+
+| File | Field | Apache 2.0 | ELv2 | Proprietary |
+|------|-------|------------|------|-------------|
+| `go.mod` | (comment at top, if convention used) | `// SPDX-License-Identifier: Apache-2.0` | `// SPDX-License-Identifier: Elastic-2.0` | `// SPDX-License-Identifier: LicenseRef-Lerian-Proprietary` |
+| `package.json` | `"license"` | `"Apache-2.0"` | `"Elastic-2.0"` | `"SEE LICENSE IN LICENSE"` |
+
+If the file does not already have an SPDX field, add one only if the project convention supports it. Do not force SPDX into `go.mod` if no comment convention exists.
+
+### Step 2.4: Update README.md
+
+If README.md contains a license badge or section, update it:
+
+**Badge patterns to detect and replace:**
+
+```markdown
+<!-- Apache 2.0 -->
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+<!-- ELv2 -->
+[![License](https://img.shields.io/badge/License-Elastic_2.0-blue.svg)](https://www.elastic.co/licensing/elastic-license)
+
+<!-- Proprietary -->
+[![License](https://img.shields.io/badge/License-Proprietary-red.svg)](./LICENSE)
+```
+
+**License section pattern:**
+
+```markdown
+## License
+
+This project is licensed under the {LICENSE_NAME} — see the [LICENSE](./LICENSE) file for details.
+```
+
+| License Type | LICENSE_NAME |
+|---|---|
+| apache | Apache License 2.0 |
+| elv2 | Elastic License 2.0 (ELv2) |
+| proprietary | Lerian Studio General License |
+
+If no license section or badge exists in README.md, do NOT add one. Only update existing references.
+
+---
+
+## Gate 3: Validation
+
+**Orchestrator executes directly. MUST pass before reporting success.**
+
+```text
+VALIDATE (run in parallel):
+
+V1. LICENSE file exists and matches requested type:
+    - ls LICENSE && head -3 LICENSE
+    - Verify content matches reference
+
+V2. No duplicate license files:
+    - ls LICENSE LICENSE.md LICENSE.txt 2>/dev/null | wc -l
+    - MUST be exactly 1
+
+V3. Source headers consistent:
+    - For Go:
+      find . -name "*.go" -not -path "./vendor/*" -not -name "*.pb.go" -not -name "mock_*.go" \
+          -exec sh -c 'head -1 "$1" | grep -q "^// Copyright" || echo "MISSING: $1"' _ {} \;
+    - MUST return 0 results
+
+V4. No mixed headers (old license headers remaining):
+    - For apache: grep -rn "Elastic License" --include="*.go" --exclude-dir=vendor | grep -v "_test.go" → 0 results
+    - For elv2: grep -rn "Apache License" --include="*.go" --exclude-dir=vendor | grep -v "_test.go" → 0 results
+    - For proprietary: grep -rn "Apache License\|Elastic License" --include="*.go" --exclude-dir=vendor → 0 results
+
+V5. SPDX consistency (if identifiers exist):
+    - grep -i "license" go.mod package.json 2>/dev/null
+    - Verify matches requested type
+
+V6. Build verification:
+    - go build ./... (Go projects)
+    - npm run build / tsc --noEmit (TS projects)
+    - Headers MUST NOT break compilation
+```
+
+**Validation output:**
+
+```text
+VALIDATION RESULTS:
+| Check            | Status | Evidence |
+|------------------|--------|----------|
+| LICENSE file     | PASS/FAIL | {details} |
+| No duplicates    | PASS/FAIL | {count} |
+| Headers present  | PASS/FAIL | {missing count} |
+| No mixed headers | PASS/FAIL | {conflicts} |
+| SPDX identifiers | PASS/FAIL/N/A | {values} |
+| Build passes     | PASS/FAIL | {output} |
+```
+
+**HARD GATE: All checks MUST pass. If any check fails, report the specific failures and dispatch the appropriate agent to fix them. Re-validate after fixes.**
+
+---
+
+## Severity Calibration
+
+| Severity | Criteria | Examples |
+|----------|----------|----------|
+| **CRITICAL** | License mismatch between LICENSE file and source headers | Apache LICENSE with ELv2 headers, no LICENSE file at all |
+| **HIGH** | Missing headers in source files, duplicate license files | .go files without copyright, both LICENSE and LICENSE.md present |
+| **MEDIUM** | SPDX identifier mismatch, README badge outdated | go.mod says MIT but LICENSE is Apache |
+| **LOW** | Missing README license section, style inconsistencies | No badge, minor formatting differences in headers |
+
+---
+
+## Pressure Resistance
+
+| User Says | This Is | Response |
+|-----------|---------|----------|
+| "Just update the LICENSE file, skip headers" | SCOPE_REDUCTION | "CANNOT skip header updates. LICENSE file and source headers MUST match. Inconsistent headers create legal ambiguity." |
+| "Headers don't matter, the LICENSE file is what counts" | COMPLIANCE_BYPASS | "Per-file headers provide clear attribution when code is copied or distributed. MUST update both." |
+| "Skip validation, I trust it worked" | QUALITY_BYPASS | "MUST validate. Mixed headers from a previous license are common and only caught by automated scanning." |
+| "Use MIT instead" | SCOPE_CHANGE | "Lerian uses three license types: Apache 2.0, ELv2, or Proprietary. MIT is not in the approved set. Confirm with legal if MIT is required." |
+| "Don't touch test files" | SCOPE_REDUCTION | "Test files are source code. Same license headers apply. MUST include test files." |
+| "The boilerplate license is fine, don't change it" | COMPLIANCE_BYPASS | "If the boilerplate has a generic proprietary license but the app should be Apache or ELv2, MUST update. License is per-app." |
+
+---
+
+## Anti-Rationalization Table
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "LICENSE file is enough, headers are cosmetic" | Headers protect IP when files are extracted or redistributed. Legal requires both. | **Update both LICENSE and headers** |
+| "Only new files need headers" | All source files need consistent headers. Partial coverage = legal risk. | **Update all source files** |
+| "Generated files should get headers too" | Generated files are regenerated and headers would be overwritten. Exclude them. | **Skip *.pb.go, mock_*.go** |
+| "Current headers are close enough" | Close ≠ correct. Headers MUST match the chosen license exactly. | **Replace with exact template** |
+| "Small repo, licensing doesn't matter" | Size is irrelevant. Every Lerian repo needs clear licensing. | **Apply license to all repos** |
+| "I'll add headers later" | Later = never. License MUST be set when the repo is created or changed. | **Apply now** |
+
+---
+
+## Integration with dev-cycle
+
+### Pre-Gate-0 License Check
+
+When `ring:dev-cycle` starts on a repository, it SHOULD check license status:
+
+```text
+PRE-GATE-0 LICENSE CHECK:
+
+1. ls LICENSE LICENSE.md LICENSE.txt 2>/dev/null
+2. If no LICENSE file exists:
+   → Ask user: "No LICENSE file detected. Which license should this repository use? [apache|elv2|proprietary]"
+   → Invoke ring:dev-licensing with the chosen type
+3. If LICENSE file exists:
+   → Detect type (grep patterns from Gate 0)
+   → Log: "License detected: {type}"
+   → Continue to Gate 0
+
+This check is advisory — it does not block Gate 0 execution.
+If the user declines to set a license, log a warning and proceed.
+```
+
+### Scaffolding Integration
+
+When creating a new service from the boilerplate:
+
+1. The boilerplate ships with a generic proprietary LICENSE.md
+2. During initial setup, prompt: "What license should this service use? [apache|elv2|proprietary]"
+3. Invoke `ring:dev-licensing` with the chosen type
+4. This replaces the boilerplate LICENSE.md with the correct license
+
+---
+
+## When Implementation Is Not Needed
+
+Signs that licensing is already compliant:
+
+| Sign | Verification |
+|------|-------------|
+| LICENSE file matches requested type | `head -3 LICENSE` shows correct license |
+| All source files have correct headers | `find` + `grep` returns 0 missing files |
+| SPDX identifiers match (if present) | `grep` in go.mod/package.json matches |
+| README badge/section matches (if present) | Visual inspection or grep |
+| No mixed headers from previous license | Cross-license grep returns 0 results |
+
+**MUST verify all signs before concluding "not needed". Assumption is not verification.**
+
+---
+
+## Reference Files
+
+Full license texts are available at:
+
+- `dev-team/skills/dev-licensing/references/apache-2.0.txt` — Apache License 2.0
+- `dev-team/skills/dev-licensing/references/elastic-v2.txt` — Elastic License v2
+- `dev-team/skills/dev-licensing/references/proprietary.txt` — Lerian Studio General License (update year as needed)
+
+These files are the canonical source for LICENSE file content. MUST use these as-is (with year substitution for proprietary).

--- a/dev-team/skills/dev-licensing/SKILL.md
+++ b/dev-team/skills/dev-licensing/SKILL.md
@@ -31,12 +31,12 @@ related:
   complementary: [ring:dev-cycle, ring:dev-implementation, ring:backend-engineer-golang, ring:backend-engineer-typescript]
 
 input_schema:
-  required:
+  required: []
+  optional:
     - name: license_type
       type: string
       enum: [apache, elv2, proprietary]
-      description: "The license to apply: apache (Apache 2.0), elv2 (Elastic License v2), proprietary (Lerian Studio General License)"
-  optional:
+      description: "The license to apply. If omitted, the skill detects the current license from the repository or prompts the user interactively."
     - name: copyright_holder
       type: string
       default: "Lerian Studio Ltd."
@@ -257,6 +257,18 @@ CURRENT LICENSE DETECTION:
 | SPDX identifier  | {value} / none      | {file:line}        |
 | README section   | present / absent    | {line}             |
 ```
+
+### License Type Resolution
+
+If `license_type` was provided as input, use it directly.
+
+If `license_type` was NOT provided (interactive mode):
+1. Use the detected license from Gate 0 as the current state
+2. Ask the user: "Detected current license: {detected_type}. Which license should this repository use? [apache|elv2|proprietary]"
+3. Set `license_type` to the user's selection
+4. If no LICENSE file was detected AND no type provided: ask user to choose before proceeding
+
+**MUST have a resolved `license_type` before entering Gate 1.**
 
 ---
 

--- a/dev-team/skills/dev-licensing/references/apache-2.0.txt
+++ b/dev-team/skills/dev-licensing/references/apache-2.0.txt
@@ -1,0 +1,201 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. Please also get in touch with
+      the Apache Software Foundation to determine whether you need to
+      submit an Incubating or Contributor License Agreement.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/dev-team/skills/dev-licensing/references/elastic-v2.txt
+++ b/dev-team/skills/dev-licensing/references/elastic-v2.txt
@@ -1,0 +1,93 @@
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to the
+software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+**control** means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/dev-team/skills/dev-licensing/references/proprietary.txt
+++ b/dev-team/skills/dev-licensing/references/proprietary.txt
@@ -1,0 +1,24 @@
+Lerian Studio General License
+
+Copyright (c) 2025 Lerian Studio Ltd. All rights reserved.
+
+NOTICE: All information contained herein is, and remains the property of
+Lerian Studio Ltd. and its suppliers, if any. The intellectual and technical
+concepts contained herein are proprietary to Lerian Studio Ltd. and its
+suppliers and are protected by trade secret or copyright law.
+
+Dissemination of this information or reproduction of this material is strictly
+forbidden unless prior written permission is obtained from Lerian Studio Ltd.
+
+This software is provided by the copyright holders and contributors "as is"
+and any express or implied warranties, including, but not limited to, the
+implied warranties of merchantability and fitness for a particular purpose are
+disclaimed. In no event shall the copyright holder or contributors be liable
+for any direct, indirect, incidental, special, exemplary, or consequential
+damages (including, but not limited to, procurement of substitute goods or
+services; loss of use, data, or profits; or business interruption) however
+caused and on any theory of liability, whether in contract, strict liability,
+or tort (including negligence or otherwise) arising in any way out of the use
+of this software, even if advised of the possibility of such damage.
+
+For licensing inquiries, contact: legal@lerian.studio

--- a/dev-team/skills/dev-licensing/references/proprietary.txt
+++ b/dev-team/skills/dev-licensing/references/proprietary.txt
@@ -1,6 +1,6 @@
 Lerian Studio General License
 
-Copyright (c) 2025 Lerian Studio Ltd. All rights reserved.
+Copyright (c) {YEAR} {COPYRIGHT_HOLDER}. All rights reserved.
 
 NOTICE: All information contained herein is, and remains the property of
 Lerian Studio Ltd. and its suppliers, if any. The intellectual and technical


### PR DESCRIPTION
## Summary

Adds `ring:dev-licensing` skill and `/ring:dev-license` command for applying or switching licenses across Lerian repositories.

### Context

From [#tech-team discussion](https://lerianstudio.slack.com/archives/C06B6KAGBAS/p1775304577238629): the boilerplate had a generic proprietary license. Fred confirmed licensing is per-app — each repo gets the appropriate license (Apache 2.0, ELv2, or proprietary) case by case. Rather than a standalone agent, this is integrated as a step in the scaffolding flow.

### What's included

**New skill: `ring:dev-licensing`**
- 4-gate workflow: detect → confirm → apply → validate
- Replaces/creates LICENSE file with full license text
- Updates all source file headers (.go, .ts) to match
- Updates SPDX identifiers in go.mod/package.json
- Updates README license badge/section
- Validates consistency across codebase
- Supports dry-run mode

**New command: `/ring:dev-license [apache|elv2|proprietary]`**
- Standalone command to apply/switch license
- Interactive detection when no type specified
- `--dry-run`, `--year`, `--holder` options

**Reference license texts:**
- `references/apache-2.0.txt` — full Apache 2.0
- `references/elastic-v2.txt` — full Elastic License v2
- `references/proprietary.txt` — Lerian Studio General License

**Updated `core.md` License Headers section:**
- Replaced hardcoded Elasticsearch B.V. headers with Lerian-specific templates
- Added header templates for all three license types
- Updated Header Components table

**Updated `dev-cycle` SKILL.md:**
- Added advisory license detection at Gate 0 (pre-implementation)
- Non-blocking: prompts user if no LICENSE found, proceeds if skipped

### License types

| Type | SPDX | Use case |
|------|------|----------|
| `apache` | Apache-2.0 | Open source (e.g., Midaz core) |
| `elv2` | Elastic-2.0 | Source-available Lerian products |
| `proprietary` | LicenseRef-Lerian-Proprietary | Internal/closed repos |
