### PR TITLE
docs(multi-tenant): add RabbitMQ Manager initialization with WithTLS

### DIFF
--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -703,6 +703,44 @@ RabbitMQ multi-tenant requires **two complementary layers** — both are mandato
 
 **⛔ Layer 1 alone is incomplete.** Vhosts isolate but the `X-Tenant-ID` header is needed for log correlation, distributed tracing, and downstream context propagation across services.
 
+### RabbitMQ Manager Initialization
+
+The `tmrabbitmq.Manager` manages per-tenant vhost connections. Initialize it in the bootstrap with functional options:
+
+```go
+import tmrabbitmq "github.com/LerianStudio/lib-commons/v4/commons/tenant-manager/rabbitmq"
+
+rmqOpts := []tmrabbitmq.Option{
+    tmrabbitmq.WithModule(constant.ModuleManager),
+    tmrabbitmq.WithLogger(logger),
+    tmrabbitmq.WithMaxTenantPools(cfg.MultiTenantMaxTenantPools),
+    tmrabbitmq.WithIdleTimeout(time.Duration(cfg.MultiTenantIdleTimeoutSec) * time.Second),
+}
+
+// TLS for production environments (AWS AmazonMQ, CloudAMQP, etc.)
+if cfg.RabbitMQTLS {
+    rmqOpts = append(rmqOpts, tmrabbitmq.WithTLS())
+}
+
+rabbitMQManager := tmrabbitmq.NewManager(
+    tmClient,
+    cfg.ApplicationName,
+    rmqOpts...,
+)
+```
+
+**Available options:**
+
+| Option | Purpose | Required |
+|--------|---------|----------|
+| `WithModule(name)` | Module name for the manager | Yes |
+| `WithLogger(logger)` | Logger instance | Yes |
+| `WithMaxTenantPools(n)` | LRU soft limit for vhost connections | No (default: 100) |
+| `WithIdleTimeout(d)` | Idle timeout before connection eviction | No (default: 5min) |
+| `WithTLS()` | Enable TLS for AMQPS connections (required for AWS AmazonMQ, CloudAMQP, and production environments) | No (default: false) |
+
+**TLS configuration:** The `RABBITMQ_TLS` env var controls whether the manager uses AMQPS (TLS) connections to per-tenant vhosts. In production with managed RabbitMQ services (AWS AmazonMQ, CloudAMQP), TLS is typically required. The `WithTLS()` option configures the manager to use `amqps://` scheme and TLS dial for all tenant connections.
+
 ### RabbitMQ Multi-Tenant Producer
 
 ```go

--- a/dev-team/skills/shared-patterns/multi-tenant-analysis.md
+++ b/dev-team/skills/shared-patterns/multi-tenant-analysis.md
@@ -11,13 +11,13 @@ See [multi-tenant.md § Canonical Model Compliance](../../docs/standards/golang/
 1. WebFetch multi-tenant.md: https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/golang/multi-tenant.md
 2. **Detection:** Check if any multi-tenant code exists (`MULTI_TENANT_ENABLED`, `tenant-manager` in go.mod, `TenantMiddleware`)
 3. **If multi-tenant code exists → run compliance audit:**
-   - Config vars: MUST use the 7 canonical `MULTI_TENANT_*` names (not `TENANT_MANAGER_ADDRESS`, `TENANT_URL`, etc.)
+   - Config vars: MUST use the 14 canonical `MULTI_TENANT_*` names (not `TENANT_MANAGER_ADDRESS`, `TENANT_URL`, etc.) + `APPLICATION_NAME`
    - Middleware: MUST use `tmmiddleware.NewTenantMiddleware` with `WithPG`/`WithMB` options from lib-commons v4
    - Route ordering: Auth MUST run before tenant middleware — per-route via `WhenEnabled` (not global `app.Use`)
    - Repositories: MUST use `tmcore.GetPGContext`/`tmcore.GetMBContext` (not static connections)
    - Redis: MUST use `valkey.GetKeyContext` for every key operation (including Lua script KEYS[]/ARGV[])
    - S3: MUST use `s3.GetS3KeyStorageContext` for every object key
-   - RabbitMQ: MUST use `tmrabbitmq.Manager` (Layer 1 — vhost isolation) + `X-Tenant-ID` header (Layer 2 — audit)
+   - RabbitMQ: MUST use `tmrabbitmq.Manager` (Layer 1 — vhost isolation) + `X-Tenant-ID` header (Layer 2 — audit). Use `WithTLS()` for production (AWS AmazonMQ, CloudAMQP)
    - Circuit breaker: MUST have `client.WithCircuitBreaker` on Tenant Manager client
    - Backward compat: MUST have `TestMultiTenant_BackwardCompatibility` test
    - Non-canonical files: MUST NOT have custom tenant packages (`internal/tenant/`, `pkg/multitenancy/`, custom middleware). See [dev-multi-tenant SKILL.md § Phase 3](../dev-multi-tenant/SKILL.md#phase-3-non-canonical-file-detection-mandatory) for specific grep commands.


### PR DESCRIPTION
## Summary

- Add **RabbitMQ Manager Initialization** section to `multi-tenant.md` documenting `tmrabbitmq.NewManager` with functional options pattern
- Document `WithTLS()` option for production environments (AWS AmazonMQ, CloudAMQP) and the `RABBITMQ_TLS` env var
- Fix stale env var count in `multi-tenant-analysis.md` (7 → 14 `MULTI_TENANT_*` + `APPLICATION_NAME`)
- Add `WithTLS` to RabbitMQ compliance check in dev-refactor analysis

Pattern derived from [LerianStudio/reporter#630](https://github.com/LerianStudio/reporter/pull/630) which implements TLS support for multi-tenant RabbitMQ vhost connections.

## Test plan

- [ ] Verify `multi-tenant.md` RabbitMQ section shows correct initialization pattern with `WithTLS()`
- [ ] Verify `multi-tenant-analysis.md` env var count matches the standard (14 MULTI_TENANT_* + APPLICATION_NAME)
- [ ] Run `ring:dev-refactor` on a service with RabbitMQ multi-tenant and verify WithTLS is checked
