### PR TITLE
fix(standards): add RABBITMQ_TLS to config and fix MULTI_TENANT_* count

### DIFF
--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -37,7 +37,7 @@ The only valid multi-tenant implementation uses:
 - `valkey.GetKeyContext` for Redis key prefixing (from `lib-commons/v4/commons/tenant-manager/valkey`)
 - `s3.GetS3KeyStorageContext` for S3 key prefixing (from `lib-commons/v4/commons/tenant-manager/s3`)
 - `tmrabbitmq.Manager` for RabbitMQ vhost isolation (from `lib-commons/v4/commons/tenant-manager/rabbitmq`)
-- The 13 canonical `MULTI_TENANT_*` environment variables with correct names and defaults
+- The 14 canonical `MULTI_TENANT_*` environment variables with correct names and defaults
 - `client.WithCircuitBreaker` on the Tenant Manager HTTP client
 - `client.WithServiceAPIKey` on the Tenant Manager HTTP client for `/settings` endpoint authentication
 - pgManager handles settings revalidation internally via `WithConnectionsCheckInterval` — PostgreSQL only, MongoDB excluded
@@ -55,7 +55,7 @@ These are the only files that require multi-tenant changes. The exact paths foll
 | File | Gate | What Changes |
 |------|------|-------------|
 | `go.mod` | 2 | lib-commons v4, lib-auth v2 |
-| `internal/bootstrap/config.go` | 3 | 13 canonical `MULTI_TENANT_*` env vars in Config struct |
+| `internal/bootstrap/config.go` | 3 | 14 canonical `MULTI_TENANT_*` env vars in Config struct |
 | `internal/bootstrap/service.go` (or equivalent init file) | 4 | Conditional initialization: Tenant Manager client, connection managers, middleware creation. Branch on `cfg.MultiTenantEnabled` |
 | `internal/bootstrap/routes.go` (or equivalent router file) | 4 | Per-route composition via `WhenEnabled(ttHandler)` — auth validates JWT before tenant resolves DB. Each project implements the `WhenEnabled` helper locally. See [Route-Level Auth-Before-Tenant Ordering](#route-level-auth-before-tenant-ordering-mandatory) |
 
@@ -161,6 +161,7 @@ go build ./...
 | `MULTI_TENANT_SERVICE_API_KEY` | API key for authenticating with tenant-manager `/settings` endpoint. Generated via service catalog. | - | If multi-tenant |
 | `MULTI_TENANT_CACHE_TTL_SEC` | In-memory cache TTL for tenant config. Passed to the tenant client. | `120` | Yes |
 | `MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC` | pgManager async settings revalidation interval (via `WithConnectionsCheckInterval`). | `30` | Yes |
+| `RABBITMQ_TLS` | Enable TLS/AMQPS connections for per-tenant RabbitMQ vhosts (AWS AmazonMQ, CloudAMQP) | `false` | No |
 
 
 **Example `.env` for multi-tenant:**
@@ -179,6 +180,7 @@ MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC=30
 MULTI_TENANT_SERVICE_API_KEY=your-service-api-key-here
 MULTI_TENANT_CACHE_TTL_SEC=120
 MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC=30
+RABBITMQ_TLS=false
 ```
 
 ### Configuration
@@ -203,6 +205,9 @@ type Config struct {
     MultiTenantServiceAPIKey            string `env:"MULTI_TENANT_SERVICE_API_KEY"`
     MultiTenantCacheTTLSec              int    `env:"MULTI_TENANT_CACHE_TTL_SEC" default:"120"`
     MultiTenantConnectionsCheckIntervalSec int    `env:"MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC" default:"30"`
+
+    // RabbitMQ TLS (for managed services like AWS AmazonMQ, CloudAMQP)
+    RabbitMQTLS                            bool   `env:"RABBITMQ_TLS" default:"false"`
 
     // PostgreSQL Primary (used as default connection in single-tenant mode)
     PrimaryDBHost     string `env:"DB_HOST"`
@@ -2166,7 +2171,7 @@ tenants/{env}/{tenantOrgID}/{applicationName}/m2m/{targetService}/credentials
 
 ### Environment Variables (M2M)
 
-In addition to the 13 canonical multi-tenant env vars, plugins MUST add:
+In addition to the 14 canonical multi-tenant env vars, plugins MUST add:
 
 | Env Var | Description | Default | Required |
 |---------|-------------|---------|----------|


### PR DESCRIPTION
## Summary
- Add `RABBITMQ_TLS` env var, Config struct field (`RabbitMQTLS bool`), and `.env` example so the bootstrap snippet referencing `cfg.RabbitMQTLS` compiles against the documented Config
- Fix stale canonical count from 13 to 14 `MULTI_TENANT_*` vars at lines 40, 58, and 2169 to match the actual env vars table (14 entries)

## Test plan
- [ ] Verify `grep -c "13 canonical" dev-team/docs/standards/golang/multi-tenant.md` returns 0
- [ ] Verify `grep -c "14 canonical" dev-team/docs/standards/golang/multi-tenant.md` returns 3
- [ ] Verify `RABBITMQ_TLS` appears in env vars table, Config struct, and `.env` example
- [ ] Verify `cfg.RabbitMQTLS` in bootstrap snippet matches the Config struct field
