### PR TITLE
feat(dev-cycle): add gate progression validator hook

### DIFF
--- a/dev-team/hooks/hooks.json
+++ b/dev-team/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Write(*current-cycle.json)",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/validate-gate-progression.sh"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup|resume",

--- a/dev-team/hooks/validate-gate-progression.sh
+++ b/dev-team/hooks/validate-gate-progression.sh
@@ -7,6 +7,9 @@
 # Returns permissionDecision: "deny" if gate progression is invalid.
 # Returns exit 0 (allow) if progression is valid or file is not a cycle state file.
 #
+# Note: Gate 9 (Validation) requires explicit user approval per SKILL.md
+# and cannot be programmatically validated — intentionally omitted.
+#
 # Install: add to hooks.json under PreToolUse with matcher "Write"
 # and if condition "Write(*current-cycle.json)"
 
@@ -115,6 +118,12 @@ validate_gate_3() {
     (if .unit_testing.status == "completed" then 85 else 0 end)
   ')
 
+  # Ensure coverage is numeric (guards against null/malformed values)
+  if ! [[ "$coverage" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+    errors+=("Gate 3 (Unit Testing): invalid coverage value: $coverage")
+    return
+  fi
+
   if [[ "$status" != "completed" ]]; then
     errors+=("Gate 3 (Unit Testing): not completed (status: $status)")
   else
@@ -207,13 +216,30 @@ gate_to_num() {
     7)   echo 8 ;;
     8)   echo 9 ;;
     9)   echo 10 ;;
-    *)   echo 0 ;;
+    *)   echo -1 ;;
   esac
 }
 
 TARGET_NUM=$(gate_to_num "$TARGET_GATE")
 
+# Reject unrecognized gate values
+if [[ "$TARGET_NUM" -eq -1 ]]; then
+  jq -n --arg gate "$TARGET_GATE" '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("Invalid gate value: " + $gate + ". Expected: 0, 0.5, 1-9.")
+    }
+  }'
+  exit 0
+fi
+
 # ─── Read existing state to detect regression (allowed) vs progression ───
+# Normalize FILE_PATH to absolute (tool_input may provide relative paths)
+if [[ "$FILE_PATH" != /* ]]; then
+  FILE_PATH="${PWD}/${FILE_PATH}"
+fi
+
 # If the state file exists, check if this is a regression (going back) — always allow
 if [[ -f "$FILE_PATH" ]]; then
   EXISTING_GATE=$(jq -r '.current_gate // 0' "$FILE_PATH" 2>/dev/null || echo "0")
@@ -267,6 +293,8 @@ fi
 if [[ "$TARGET_NUM" -ge 10 ]]; then
   validate_gate_8
 fi
+
+# Note: Gate 9 (Validation) is user approval — cannot be automated
 
 # ─── Decision ───
 

--- a/dev-team/hooks/validate-gate-progression.sh
+++ b/dev-team/hooks/validate-gate-progression.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# validate-gate-progression.sh
+# PreToolUse hook for ring:dev-cycle — enforces gate ordering and completion
+# evidence before allowing state file progression.
+#
+# Receives Claude Code PreToolUse JSON on stdin.
+# Returns permissionDecision: "deny" if gate progression is invalid.
+# Returns exit 0 (allow) if progression is valid or file is not a cycle state file.
+#
+# Install: add to hooks.json under PreToolUse with matcher "Write"
+# and if condition "Write(*current-cycle.json)"
+
+set -euo pipefail
+
+# Read the PreToolUse input from stdin
+INPUT=$(cat)
+
+# Extract the file path and content from tool_input
+FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty')
+CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // empty')
+
+# Only validate current-cycle.json writes
+if [[ "$FILE_PATH" != *"current-cycle.json" ]]; then
+  exit 0
+fi
+
+# If no content, allow (might be a read or other operation)
+if [[ -z "$CONTENT" ]]; then
+  exit 0
+fi
+
+# Parse the new state being written
+NEW_STATE="$CONTENT"
+
+# Validate JSON
+if ! echo "$NEW_STATE" | jq empty 2>/dev/null; then
+  jq -n '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: "Invalid JSON in current-cycle.json write"
+    }
+  }'
+  exit 0
+fi
+
+# ─── Gate ordering map ───
+# Maps gate index to the gate_progress field name and required evidence checks
+# Gate order: 0 → 0.5 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9
+
+# Extract current task being progressed
+CURRENT_TASK_INDEX=$(echo "$NEW_STATE" | jq -r '.current_task_index // 0')
+TARGET_GATE=$(echo "$NEW_STATE" | jq -r '.current_gate // 0')
+
+# Get the task's gate_progress
+TASK_GATES=$(echo "$NEW_STATE" | jq -c ".tasks[$CURRENT_TASK_INDEX].gate_progress // empty")
+
+if [[ -z "$TASK_GATES" ]]; then
+  exit 0  # No gate_progress yet, allow initial writes
+fi
+
+TASK_ID=$(echo "$NEW_STATE" | jq -r ".tasks[$CURRENT_TASK_INDEX].id // \"T-???\"")
+
+# ─── Validation functions ───
+
+errors=()
+
+validate_gate_0() {
+  local tdd_red tdd_green
+  tdd_red=$(echo "$TASK_GATES" | jq -r '.implementation.tdd_red.status // "pending"')
+  tdd_green=$(echo "$TASK_GATES" | jq -r '.implementation.tdd_green.status // "pending"')
+
+  if [[ "$tdd_red" != "completed" ]]; then
+    errors+=("Gate 0: TDD-RED not completed (status: $tdd_red)")
+  fi
+  if [[ "$tdd_green" != "completed" ]]; then
+    errors+=("Gate 0: TDD-GREEN not completed (status: $tdd_green)")
+  fi
+}
+
+validate_gate_05() {
+  local status total delivered
+  status=$(echo "$TASK_GATES" | jq -r '.delivery_verification.status // "pending"')
+  total=$(echo "$TASK_GATES" | jq -r '.delivery_verification.requirements_total // 0')
+  delivered=$(echo "$TASK_GATES" | jq -r '.delivery_verification.requirements_delivered // 0')
+
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 0.5: Delivery verification not completed (status: $status)")
+  elif [[ "$total" -gt 0 && "$delivered" -lt "$total" ]]; then
+    errors+=("Gate 0.5: Requirements gap — delivered $delivered/$total")
+  fi
+}
+
+validate_gate_1() {
+  local status
+  status=$(echo "$TASK_GATES" | jq -r '.devops.status // "pending"')
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 1 (DevOps): not completed (status: $status)")
+  fi
+}
+
+validate_gate_2() {
+  local status
+  status=$(echo "$TASK_GATES" | jq -r '.sre.status // "pending"')
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 2 (SRE): not completed (status: $status)")
+  fi
+}
+
+validate_gate_3() {
+  local status coverage
+  status=$(echo "$TASK_GATES" | jq -r '.unit_testing.status // "pending"')
+  coverage=$(echo "$TASK_GATES" | jq -r '
+    .unit_testing.coverage_actual //
+    (if .unit_testing.status == "completed" then 85 else 0 end)
+  ')
+
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 3 (Unit Testing): not completed (status: $status)")
+  else
+    # Compare coverage using awk for float comparison
+    if awk "BEGIN {exit !($coverage < 85)}"; then
+      errors+=("Gate 3 (Unit Testing): coverage $coverage% < 85% threshold")
+    fi
+  fi
+}
+
+validate_gate_4() {
+  local status corpus
+  status=$(echo "$TASK_GATES" | jq -r '.fuzz_testing.status // "pending"')
+  corpus=$(echo "$TASK_GATES" | jq -r '.fuzz_testing.corpus_entries // 0')
+
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 4 (Fuzz Testing): not completed (status: $status)")
+  elif [[ "$corpus" -lt 5 ]]; then
+    errors+=("Gate 4 (Fuzz Testing): corpus_entries=$corpus < 5 minimum")
+  fi
+}
+
+validate_gate_5() {
+  local status props
+  status=$(echo "$TASK_GATES" | jq -r '.property_testing.status // "pending"')
+  props=$(echo "$TASK_GATES" | jq -r '.property_testing.properties_tested // 0')
+
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 5 (Property Testing): not completed (status: $status)")
+  elif [[ "$props" -lt 1 ]]; then
+    errors+=("Gate 5 (Property Testing): properties_tested=$props < 1 minimum")
+  fi
+}
+
+validate_gate_6() {
+  local status
+  status=$(echo "$TASK_GATES" | jq -r '.integration_testing.status // "pending"')
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 6 (Integration Testing): not completed (status: $status)")
+  fi
+}
+
+validate_gate_7() {
+  local status
+  status=$(echo "$TASK_GATES" | jq -r '.chaos_testing.status // "pending"')
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 7 (Chaos Testing): not completed (status: $status)")
+  fi
+}
+
+validate_gate_8() {
+  local status
+  status=$(echo "$TASK_GATES" | jq -r '.review.status // "pending"')
+  if [[ "$status" != "completed" ]]; then
+    errors+=("Gate 8 (Review): not completed (status: $status)")
+  fi
+
+  # Check all 8 reviewers have verdicts
+  local reviewers=("code_reviewer" "business_logic_reviewer" "security_reviewer"
+                   "nil_safety_reviewer" "test_reviewer" "consequences_reviewer"
+                   "dead_code_reviewer" "performance_reviewer")
+
+  local reviewer_count=0
+  for reviewer in "${reviewers[@]}"; do
+    local verdict
+    verdict=$(echo "$TASK_GATES" | jq -r ".review.$reviewer.verdict // empty")
+    if [[ -n "$verdict" ]]; then
+      ((reviewer_count++))
+    fi
+  done
+
+  if [[ "$reviewer_count" -lt 8 && "$status" == "completed" ]]; then
+    errors+=("Gate 8 (Review): only $reviewer_count/8 reviewers have verdicts — all 8 required")
+  fi
+}
+
+# ─── Gate numeric mapping ───
+# Convert current_gate to a comparable number (0.5 → 05 for ordering)
+gate_to_num() {
+  local g="$1"
+  case "$g" in
+    0)   echo 0 ;;
+    0.5) echo 1 ;;
+    1)   echo 2 ;;
+    2)   echo 3 ;;
+    3)   echo 4 ;;
+    4)   echo 5 ;;
+    5)   echo 6 ;;
+    6)   echo 7 ;;
+    7)   echo 8 ;;
+    8)   echo 9 ;;
+    9)   echo 10 ;;
+    *)   echo 0 ;;
+  esac
+}
+
+TARGET_NUM=$(gate_to_num "$TARGET_GATE")
+
+# ─── Read existing state to detect regression (allowed) vs progression ───
+# If the state file exists, check if this is a regression (going back) — always allow
+if [[ -f "$FILE_PATH" ]]; then
+  EXISTING_GATE=$(jq -r '.current_gate // 0' "$FILE_PATH" 2>/dev/null || echo "0")
+  EXISTING_NUM=$(gate_to_num "$EXISTING_GATE")
+
+  if [[ "$TARGET_NUM" -le "$EXISTING_NUM" ]]; then
+    # Regression or same gate — always allowed (e.g., going back to fix)
+    exit 0
+  fi
+fi
+
+# ─── Progressive validation ───
+# Validate all gates that should be completed before TARGET_GATE
+
+if [[ "$TARGET_NUM" -ge 1 ]]; then
+  validate_gate_0
+fi
+
+if [[ "$TARGET_NUM" -ge 2 ]]; then
+  validate_gate_05
+fi
+
+if [[ "$TARGET_NUM" -ge 3 ]]; then
+  validate_gate_1
+fi
+
+if [[ "$TARGET_NUM" -ge 4 ]]; then
+  validate_gate_2
+fi
+
+if [[ "$TARGET_NUM" -ge 5 ]]; then
+  validate_gate_3
+fi
+
+if [[ "$TARGET_NUM" -ge 6 ]]; then
+  validate_gate_4
+fi
+
+if [[ "$TARGET_NUM" -ge 7 ]]; then
+  validate_gate_5
+fi
+
+if [[ "$TARGET_NUM" -ge 8 ]]; then
+  validate_gate_6
+fi
+
+if [[ "$TARGET_NUM" -ge 9 ]]; then
+  validate_gate_7
+fi
+
+if [[ "$TARGET_NUM" -ge 10 ]]; then
+  validate_gate_8
+fi
+
+# ─── Decision ───
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  # Build error list as JSON array, then format reason as single escaped string
+  ERROR_JSON_ARRAY=$(printf '%s\n' "${errors[@]}" | jq -R . | jq -sc .)
+
+  jq -n \
+    --arg task "$TASK_ID" \
+    --arg gate "$TARGET_GATE" \
+    --argjson errs "$ERROR_JSON_ARRAY" \
+    '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: (
+          "GATE PROGRESSION BLOCKED for " + $task + " (target: Gate " + $gate + "): " +
+          ($errs | join("; ")) +
+          ". Complete all prerequisite gates before progressing."
+        )
+      }
+    }'
+  exit 0
+fi
+
+# All validations passed — allow the write
+exit 0


### PR DESCRIPTION
## Problem

Under parallel task execution with context saturation, the dev-cycle orchestrator can rationalize skipping testing gates (3-7). The gate enforcement is entirely prompt-based — when the context window fills with implementation artifacts from multiple tasks, the gate rules fall out of the attention window.

This was identified during pressure testing: a dev-cycle session running 5 parallel tasks (Garzão/IKA on Payments) skipped testing gates despite the SKILL.md having explicit anti-rationalization tables and HARD GATE markers.

## Root Cause Analysis

Two RED phase tests were run to reproduce the failure:
1. **RED v1** (clean context) — agent followed all gates correctly
2. **RED v2** (saturated context with 5 tasks' artifacts) — agent still followed gates

Both tests asked the agent to *plan* execution. The actual failure happens during *real execution* where hundreds of tool calls push the SKILL.md rules out of the context window. The skill text works when visible; the vulnerability is architectural.

## Solution

External programmatic validator (`PreToolUse` hook) that intercepts writes to `current-cycle.json` and blocks invalid gate progressions regardless of what the agent "remembers".

### What it validates

Every gate transition — not just the Gate 8 boundary. When the agent writes `current_gate: N`, all gates 0 through N-1 must have status `completed` with evidence:

| Gate | Evidence Required |
|------|------------------|
| 0 | TDD-RED + TDD-GREEN completed |
| 0.5 | Delivery verification: delivered = total |
| 1 | DevOps completed |
| 2 | SRE completed |
| 3 | Unit testing completed + coverage ≥ 85% |
| 4 | Fuzz testing completed + corpus ≥ 5 entries |
| 5 | Property testing completed + properties ≥ 1 |
| 6 | Integration testing write completed |
| 7 | Chaos testing write completed |
| 8 | Review completed + all 8 reviewer verdicts |

### Behavior
- **Progression blocked** → returns `permissionDecision: deny` with specific error listing which gates/evidence are missing
- **Regression allowed** → going back to fix gates is always permitted
- **Non-cycle files** → ignored (no false positives)

### Platform support
- **Claude Code**: `hooks.json` PreToolUse with `Write(*current-cycle.json)` matcher
- **OpenCode**: same shell script callable from `tool.before` hook via plugin wrapper

## Test Results

10/10 scenarios passing:

```
✓ Non-cycle file → allow
✓ Gate 0→0.5 (TDD done) → allow
✓ Skip to Gate 8 → deny
✓ Coverage 72% → deny
✓ Coverage 87.5% → allow
✓ Corpus 3 → deny
✓ Full chain Gate 8 → allow
✓ Middle skip (G3 pending → G5) → deny
✓ Requirements gap 3/5 → deny
✓ 5/8 reviewers → G9 deny
```

## Files Changed

- `dev-team/hooks/validate-gate-progression.sh` — validator script (new)
- `dev-team/hooks/hooks.json` — added PreToolUse hook entry

## Complementary Measures

This hook is the programmatic safety net. Complementary measures for context drift prevention:
- **RTK** (rtk-ai/rtk) for token compression — reduces context saturation rate
- **claude-md-reminder.sh** (existing UserPromptSubmit hook) — periodically re-injects instruction files

Requested by: @jeff-music-city