### PR TITLE
feat(opencode): add gate progression validator (soft block)

### DIFF
--- a/dev-team/hooks/validate-gate-progression.sh
+++ b/dev-team/hooks/validate-gate-progression.sh
@@ -299,21 +299,63 @@ fi
 # ─── Decision ───
 
 if [[ ${#errors[@]} -gt 0 ]]; then
-  # Build error list as JSON array, then format reason as single escaped string
+  # Build error list as JSON array
   ERROR_JSON_ARRAY=$(printf '%s\n' "${errors[@]}" | jq -R . | jq -sc .)
+
+  # Build recovery instructions based on which gates failed
+  recovery_steps=()
+  for err in "${errors[@]}"; do
+    case "$err" in
+      *"Gate 0:"*)   recovery_steps+=("Gate 0: Load Skill(ring:dev-implementation), dispatch backend-engineer agent with TDD cycle") ;;
+      *"Gate 0.5:"*) recovery_steps+=("Gate 0.5: Load Skill(ring:dev-delivery-verification), verify all requirements delivered") ;;
+      *"Gate 1"*)    recovery_steps+=("Gate 1: Load Skill(ring:dev-devops), dispatch ring:devops-engineer") ;;
+      *"Gate 2"*)    recovery_steps+=("Gate 2: Load Skill(ring:dev-sre), dispatch ring:sre") ;;
+      *"Gate 3"*)    recovery_steps+=("Gate 3: Load Skill(ring:dev-unit-testing), dispatch ring:qa-analyst (test_mode=unit, coverage >= 85%)") ;;
+      *"Gate 4"*)    recovery_steps+=("Gate 4: Load Skill(ring:dev-fuzz-testing), dispatch ring:qa-analyst (test_mode=fuzz, corpus >= 5)") ;;
+      *"Gate 5"*)    recovery_steps+=("Gate 5: Load Skill(ring:dev-property-testing), dispatch ring:qa-analyst (test_mode=property)") ;;
+      *"Gate 6"*)    recovery_steps+=("Gate 6: Load Skill(ring:dev-integration-testing), dispatch ring:qa-analyst (test_mode=integration, write only)") ;;
+      *"Gate 7"*)    recovery_steps+=("Gate 7: Load Skill(ring:dev-chaos-testing), dispatch ring:qa-analyst (test_mode=chaos, write only)") ;;
+      *"Gate 8"*)    recovery_steps+=("Gate 8: Load Skill(ring:codereview), dispatch ALL 8 reviewers in parallel") ;;
+    esac
+  done
+
+  # Deduplicate recovery steps
+  RECOVERY_JSON_ARRAY=$(printf '%s\n' "${recovery_steps[@]}" | sort -u | jq -R . | jq -sc .)
+
+  # Extract task context for recovery instructions
+  TASK_TITLE=$(echo "$NEW_STATE" | jq -r ".tasks[$CURRENT_TASK_INDEX].title // empty")
+  TASK_FILE=$(echo "$NEW_STATE" | jq -r ".tasks[$CURRENT_TASK_INDEX].subtasks[0].file // .source_file // empty")
+  LAST_COMPLETED_GATE=$(echo "$TASK_GATES" | jq -r '[
+    if .implementation.tdd_green.status == "completed" then "0" else empty end,
+    if .delivery_verification.status == "completed" then "0.5" else empty end,
+    if .devops.status == "completed" then "1" else empty end,
+    if .sre.status == "completed" then "2" else empty end,
+    if .unit_testing.status == "completed" then "3" else empty end,
+    if .fuzz_testing.status == "completed" then "4" else empty end,
+    if .property_testing.status == "completed" then "5" else empty end,
+    if .integration_testing.status == "completed" then "6" else empty end,
+    if .chaos_testing.status == "completed" then "7" else empty end,
+    if .review.status == "completed" then "8" else empty end
+  ] | last // "none"')
 
   jq -n \
     --arg task "$TASK_ID" \
+    --arg title "$TASK_TITLE" \
     --arg gate "$TARGET_GATE" \
+    --arg lastGate "$LAST_COMPLETED_GATE" \
     --argjson errs "$ERROR_JSON_ARRAY" \
+    --argjson recovery "$RECOVERY_JSON_ARRAY" \
     '{
       hookSpecificOutput: {
         hookEventName: "PreToolUse",
         permissionDecision: "deny",
         permissionDecisionReason: (
-          "GATE PROGRESSION BLOCKED for " + $task + " (target: Gate " + $gate + "): " +
-          ($errs | join("; ")) +
-          ". Complete all prerequisite gates before progressing."
+          "GATE PROGRESSION BLOCKED for " + $task +
+          (if $title != "" then " (" + $title + ")" else "" end) +
+          " — target: Gate " + $gate + ", last completed: Gate " + $lastGate + ". " +
+          "Issues: " + ($errs | join("; ")) + ". " +
+          "RECOVERY for " + $task + " — Resume from Gate " + $lastGate + ", execute in order: " +
+          ($recovery | join("; "))
         )
       }
     }'

--- a/dev-team/hooks/validate-gate-progression.sh
+++ b/dev-team/hooks/validate-gate-progression.sh
@@ -319,24 +319,31 @@ if [[ ${#errors[@]} -gt 0 ]]; then
     esac
   done
 
-  # Deduplicate recovery steps
-  RECOVERY_JSON_ARRAY=$(printf '%s\n' "${recovery_steps[@]}" | sort -u | jq -R . | jq -sc .)
+  # Deduplicate recovery steps (preserve gate order — sort -u would reorder)
+  RECOVERY_JSON_ARRAY=$(printf '%s\n' "${recovery_steps[@]}" | awk '!seen[$0]++' | jq -R . | jq -sc .)
 
   # Extract task context for recovery instructions
   TASK_TITLE=$(echo "$NEW_STATE" | jq -r ".tasks[$CURRENT_TASK_INDEX].title // empty")
-  TASK_FILE=$(echo "$NEW_STATE" | jq -r ".tasks[$CURRENT_TASK_INDEX].subtasks[0].file // .source_file // empty")
-  LAST_COMPLETED_GATE=$(echo "$TASK_GATES" | jq -r '[
-    if .implementation.tdd_green.status == "completed" then "0" else empty end,
-    if .delivery_verification.status == "completed" then "0.5" else empty end,
-    if .devops.status == "completed" then "1" else empty end,
-    if .sre.status == "completed" then "2" else empty end,
-    if .unit_testing.status == "completed" then "3" else empty end,
-    if .fuzz_testing.status == "completed" then "4" else empty end,
-    if .property_testing.status == "completed" then "5" else empty end,
-    if .integration_testing.status == "completed" then "6" else empty end,
-    if .chaos_testing.status == "completed" then "7" else empty end,
-    if .review.status == "completed" then "8" else empty end
-  ] | last // "none"')
+  # Derive last contiguously valid gate using the SAME predicates as the validators
+  # (not just status == completed — also checks evidence thresholds)
+  LAST_COMPLETED_GATE=$(echo "$TASK_GATES" | jq -r '
+    if (.implementation.tdd_red.status != "completed") or (.implementation.tdd_green.status != "completed") then "none"
+    elif .delivery_verification.status != "completed" then "0"
+    elif (.delivery_verification.requirements_total // 0) > 0 and (.delivery_verification.requirements_delivered // 0) < (.delivery_verification.requirements_total // 0) then "0"
+    elif .devops.status != "completed" then "0.5"
+    elif .sre.status != "completed" then "1"
+    elif .unit_testing.status != "completed" then "2"
+    elif (.unit_testing.coverage_actual // 0) < 85 then "2"
+    elif .fuzz_testing.status != "completed" then "3"
+    elif (.fuzz_testing.corpus_entries // 0) < 5 then "3"
+    elif .property_testing.status != "completed" then "4"
+    elif (.property_testing.properties_tested // 0) < 1 then "4"
+    elif .integration_testing.status != "completed" then "5"
+    elif .chaos_testing.status != "completed" then "6"
+    elif .review.status != "completed" then "7"
+    else "8"
+    end
+  ')
 
   jq -n \
     --arg task "$TASK_ID" \

--- a/platforms/opencode/installer.sh
+++ b/platforms/opencode/installer.sh
@@ -476,6 +476,15 @@ if [[ -d "$SCRIPT_DIR/plugin" ]]; then
   echo "  Installed plugin/"
 fi
 
+# Gate progression validator hook (shell script used by plugin)
+GATE_VALIDATOR="$RING_ROOT/dev-team/hooks/validate-gate-progression.sh"
+if [[ -f "$GATE_VALIDATOR" ]]; then
+  mkdir -p "$TARGET_ROOT/hooks"
+  cp "$GATE_VALIDATOR" "$TARGET_ROOT/hooks/validate-gate-progression.sh"
+  chmod +x "$TARGET_ROOT/hooks/validate-gate-progression.sh"
+  echo "  Installed hooks/validate-gate-progression.sh"
+fi
+
 # Prompts (session-start, context-injection)
 if [[ -d "$SCRIPT_DIR/prompts" ]]; then
   mkdir -p "$TARGET_ROOT/prompts"

--- a/platforms/opencode/installer.sh
+++ b/platforms/opencode/installer.sh
@@ -480,6 +480,10 @@ fi
 GATE_VALIDATOR="$RING_ROOT/dev-team/hooks/validate-gate-progression.sh"
 if [[ -f "$GATE_VALIDATOR" ]]; then
   mkdir -p "$TARGET_ROOT/hooks"
+  if [[ -f "$TARGET_ROOT/hooks/validate-gate-progression.sh" ]]; then
+    mkdir -p "$BACKUP_DIR/hooks"
+    cp "$TARGET_ROOT/hooks/validate-gate-progression.sh" "$BACKUP_DIR/hooks/validate-gate-progression.sh"
+  fi
   cp "$GATE_VALIDATOR" "$TARGET_ROOT/hooks/validate-gate-progression.sh"
   chmod +x "$TARGET_ROOT/hooks/validate-gate-progression.sh"
   echo "  Installed hooks/validate-gate-progression.sh"

--- a/platforms/opencode/plugin/hooks/factories/gate-validator.ts
+++ b/platforms/opencode/plugin/hooks/factories/gate-validator.ts
@@ -20,8 +20,21 @@ import { execSync } from "node:child_process"
 /** Per-call state: tracks files we need to validate after write */
 const pendingValidations = new Map<
   string,
-  { filePath: string; previousContent: string | null }
+  { filePath: string; previousContent: string | null; timestamp: number }
 >()
+
+/** Max age for pending entries (5 minutes) — prevents leaks on tool timeouts */
+const PENDING_TTL_MS = 5 * 60 * 1000
+
+/** Evict stale entries on each before hook call */
+function evictStale(): void {
+  const now = Date.now()
+  for (const [key, entry] of pendingValidations) {
+    if (now - entry.timestamp > PENDING_TTL_MS) {
+      pendingValidations.delete(key)
+    }
+  }
+}
 
 /**
  * Resolve the validate-gate-progression.sh script path.
@@ -29,13 +42,10 @@ const pendingValidations = new Map<
 function findValidatorScript(projectRoot: string): string | null {
   const candidates = [
     path.join(projectRoot, "dev-team", "hooks", "validate-gate-progression.sh"),
-    path.join(
-      process.env.HOME ?? "~",
-      ".config",
-      "opencode",
-      "hooks",
-      "validate-gate-progression.sh",
-    ),
+    // HOME-based path (skip if HOME undefined — literal "~" won't resolve)
+    ...(process.env.HOME
+      ? [path.join(process.env.HOME, ".config", "opencode", "hooks", "validate-gate-progression.sh")]
+      : []),
     path.join(projectRoot, ".ring", "hooks", "validate-gate-progression.sh"),
   ]
 
@@ -111,7 +121,8 @@ export function createToolExecuteBefore(projectRoot: string) {
       }
     }
 
-    pendingValidations.set(input.callID, { filePath: absPath, previousContent })
+    evictStale()
+    pendingValidations.set(input.callID, { filePath: absPath, previousContent, timestamp: Date.now() })
   }
 }
 
@@ -147,6 +158,8 @@ export function createToolExecuteAfter(projectRoot: string) {
 
     // Temporarily restore previous state so the script's regression check
     // compares against the ORIGINAL state, not the already-written content.
+    // NOTE: Non-atomic window between restore and re-write. Acceptable in
+    // single-agent usage; concurrent file access could read reverted state.
     if (pending.previousContent !== null) {
       fs.writeFileSync(pending.filePath, pending.previousContent, "utf-8")
     } else {

--- a/platforms/opencode/plugin/hooks/factories/gate-validator.ts
+++ b/platforms/opencode/plugin/hooks/factories/gate-validator.ts
@@ -1,0 +1,188 @@
+/**
+ * Gate Progression Validator — OpenCode Integration
+ *
+ * Soft block for OpenCode's tool.execute.before/after hooks.
+ * OpenCode SDK doesn't support hard blocks (deny), so this uses
+ * detect-and-revert:
+ *
+ * 1. tool.execute.before: Save backup of current-cycle.json
+ * 2. tool.execute.after: Validate written state via the same shell
+ *    script used by Claude Code. If invalid → revert file + replace
+ *    tool output with block message.
+ *
+ * Reuses: dev-team/hooks/validate-gate-progression.sh (single source of truth)
+ */
+
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { execSync } from "node:child_process"
+
+/** Per-call state: tracks files we need to validate after write */
+const pendingValidations = new Map<
+  string,
+  { filePath: string; previousContent: string | null }
+>()
+
+/**
+ * Resolve the validate-gate-progression.sh script path.
+ */
+function findValidatorScript(projectRoot: string): string | null {
+  const candidates = [
+    path.join(projectRoot, "dev-team", "hooks", "validate-gate-progression.sh"),
+    path.join(
+      process.env.HOME ?? "~",
+      ".config",
+      "opencode",
+      "hooks",
+      "validate-gate-progression.sh",
+    ),
+    path.join(projectRoot, ".ring", "hooks", "validate-gate-progression.sh"),
+  ]
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) return candidate
+  }
+  return null
+}
+
+/**
+ * Run the shell validator script and return the result.
+ */
+function runValidator(
+  scriptPath: string,
+  toolInput: { file_path: string; content: string },
+): { allowed: boolean; reason?: string } {
+  const hookInput = JSON.stringify({
+    tool_name: "Write",
+    tool_input: {
+      file_path: toolInput.file_path,
+      content: toolInput.content,
+    },
+  })
+
+  try {
+    const result = execSync(`bash "${scriptPath}"`, {
+      input: hookInput,
+      encoding: "utf-8",
+      timeout: 5000,
+    })
+
+    if (!result.trim()) return { allowed: true }
+
+    const parsed = JSON.parse(result)
+    if (parsed?.hookSpecificOutput?.permissionDecision === "deny") {
+      return {
+        allowed: false,
+        reason:
+          parsed.hookSpecificOutput.permissionDecisionReason ??
+          "Gate progression validation failed",
+      }
+    }
+
+    return { allowed: true }
+  } catch {
+    return { allowed: true } // Fail open
+  }
+}
+
+/**
+ * Hook for tool.execute.before — saves backup if writing current-cycle.json.
+ */
+export function createToolExecuteBefore(projectRoot: string) {
+  return async (
+    input: { tool: string; sessionID: string; callID: string },
+    output: { args: any },
+  ): Promise<void> => {
+    const toolName = input.tool?.toLowerCase() ?? ""
+    if (toolName !== "file_write" && toolName !== "write") return
+
+    const filePath: string =
+      output.args?.file_path ?? output.args?.filePath ?? output.args?.path ?? ""
+    if (!filePath.endsWith("current-cycle.json")) return
+
+    const absPath = path.isAbsolute(filePath) ? filePath : path.resolve(projectRoot, filePath)
+
+    let previousContent: string | null = null
+    if (fs.existsSync(absPath)) {
+      try {
+        previousContent = fs.readFileSync(absPath, "utf-8")
+      } catch {
+        /* proceed without backup */
+      }
+    }
+
+    pendingValidations.set(input.callID, { filePath: absPath, previousContent })
+  }
+}
+
+/**
+ * Hook for tool.execute.after — validates and reverts if invalid.
+ */
+export function createToolExecuteAfter(projectRoot: string) {
+  const validatorScript = findValidatorScript(projectRoot)
+  const debug = process.env.RING_DEBUG === "true"
+
+  if (!validatorScript) {
+    if (debug) console.debug("[ring:gate-validator] Validator script not found — disabled")
+    return async () => {}
+  }
+
+  if (debug) console.debug(`[ring:gate-validator] Active: ${validatorScript}`)
+
+  return async (
+    input: { tool: string; sessionID: string; callID: string; args: any },
+    output: { title: string; output: string; metadata: any },
+  ): Promise<void> => {
+    const pending = pendingValidations.get(input.callID)
+    if (!pending) return
+
+    pendingValidations.delete(input.callID)
+
+    let writtenContent: string
+    try {
+      writtenContent = fs.readFileSync(pending.filePath, "utf-8")
+    } catch {
+      return
+    }
+
+    // Temporarily restore previous state so the script's regression check
+    // compares against the ORIGINAL state, not the already-written content.
+    if (pending.previousContent !== null) {
+      fs.writeFileSync(pending.filePath, pending.previousContent, "utf-8")
+    } else {
+      try {
+        fs.unlinkSync(pending.filePath)
+      } catch {
+        /* ignore */
+      }
+    }
+
+    const result = runValidator(validatorScript, {
+      file_path: pending.filePath,
+      content: writtenContent,
+    })
+
+    if (result.allowed) {
+      // Valid — restore the new content
+      fs.writeFileSync(pending.filePath, writtenContent, "utf-8")
+      return
+    }
+
+    // BLOCKED — file stays reverted, replace tool output
+    if (debug) console.debug(`[ring:gate-validator] BLOCKED: ${result.reason}`)
+
+    // Previous content was already restored above. If there was no previous
+    // file, it was already unlinked. No additional revert needed.
+
+    output.title = "⛔ GATE PROGRESSION BLOCKED"
+    output.output = [
+      "⛔ GATE PROGRESSION BLOCKED — File reverted.",
+      "",
+      result.reason,
+      "",
+      "The state file has been reverted to its previous state.",
+      "Complete all prerequisite gates before progressing.",
+      "Gates execute in order: 0 → 0.5 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9.",
+    ].join("\n")
+  }
+}

--- a/platforms/opencode/plugin/ring-unified.ts
+++ b/platforms/opencode/plugin/ring-unified.ts
@@ -14,6 +14,8 @@
 
 import type { Plugin, PluginInput } from "@opencode-ai/plugin"
 import type { Config as OpenCodeSdkConfig } from "@opencode-ai/sdk"
+// Gate validator (soft block via detect-and-revert)
+import { createToolExecuteAfter, createToolExecuteBefore } from "./hooks/factories/gate-validator.js"
 import type { RingConfig } from "./config/index.js"
 // Config
 import { createConfigHandler, loadConfig } from "./config/index.js"
@@ -103,6 +105,10 @@ export const RingUnifiedPlugin: Plugin = async (ctx: PluginInput) => {
   const sessionId = getSessionId()
   const ringTools = createRingTools(directory)
 
+  // Gate progression validator
+  const gateValidatorBefore = createToolExecuteBefore(directory)
+  const gateValidatorAfter = createToolExecuteAfter(directory)
+
   return {
     // Register Ring tools
     tool: ringTools,
@@ -155,6 +161,10 @@ export const RingUnifiedPlugin: Plugin = async (ctx: PluginInput) => {
         await hookRegistry.executeLifecycle("session.error", hookCtx, output)
       }
     },
+
+    // Gate progression validation (soft block — OpenCode lacks hard deny)
+    "tool.execute.before": gateValidatorBefore,
+    "tool.execute.after": gateValidatorAfter,
 
     // System prompt transformation
     "experimental.chat.system.transform": async (


### PR DESCRIPTION
## Context

Follow-up to #354 (Claude Code hard block via PreToolUse). This adds the same gate progression validation to OpenCode.

## Problem

OpenCode SDK's `tool.execute.before` doesn't support `block`/`deny` like Claude Code's `PreToolUse`. A direct port isn't possible.

## Solution: Detect-and-Revert

Two-phase soft block using OpenCode's existing hook points:

1. **`tool.execute.before`** — When a write targets `current-cycle.json`, saves backup of current file content
2. **`tool.execute.after`** — Runs the same `validate-gate-progression.sh` script. If invalid:
   - Reverts file to previous state
   - Replaces tool output with `⛔ GATE PROGRESSION BLOCKED` message
   - Agent sees the error instead of "Wrote file successfully"

### Key design decision

The `after` hook temporarily restores the previous file content before running the validator. This is necessary because the validator's regression check (`target_gate <= existing_gate → allow`) would see the already-written invalid state and treat it as a same-gate write.

## Tested

Live OpenCode session with `RING_DEBUG=true`:
- Agent attempted to write `current-cycle.json` with `current_gate: 8` while testing gates were `pending`
- Hook detected the write, ran validator, got `deny`
- File reverted (deleted, since no prior state existed)
- Agent received: `⛔ GATE PROGRESSION BLOCKED — File reverted. Gate 3 (Unit Testing): not completed...`

## Files

- `platforms/opencode/plugin/hooks/factories/gate-validator.ts` — new hook module
- `platforms/opencode/plugin/ring-unified.ts` — wired `tool.execute.before/after`
- `platforms/opencode/installer.sh` — copies shell script to `~/.config/opencode/hooks/`

## Platform comparison

| Platform | Mechanism | Block Type |
|----------|-----------|-----------|
| Claude Code | `PreToolUse` → `permissionDecision: deny` | **Hard** (write prevented) |
| OpenCode | `tool.execute.after` → revert + output replace | **Soft** (write reverted) |

Both use the same `validate-gate-progression.sh` — single validation source.

Requested by: @jeff-music-city