### PR TITLE
feat(flowker-team): add plugin with provider and template scaffolding skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -138,7 +138,28 @@
         "agents",
         "content-quality"
       ]
+    },
+    {
+      "name": "ring-flowker-team",
+      "description": "Core four integration skills: scaffolds new providers (external HTTP services) and workflow templates in Core four (github.com/LerianStudio/flowker). 2 skills covering provider catalog registration with JSON Schema validation, auth wiring, unit tests, and workflow template creation with parameter validation and Build functions. Orchestrates ring:backend-engineer-golang, ring:dev-unit-testing, and ring:codereview for gate-based delivery.",
+      "version": "0.1.0",
+      "source": "./flowker-team",
+      "homepage": "https://github.com/lerianstudio/ring/tree/flowker-team",
+      "repository": "https://github.com/lerianstudio/ring/tree/flowker-team",
+      "license": "MIT",
+      "keywords": [
+        "flowker",
+        "workflow",
+        "orchestration",
+        "provider",
+        "template",
+        "scaffold",
+        "codegen",
+        "integration",
+        "catalog",
+        "golang"
+      ]
     }
   ],
-  "version": "0.334.0"
+  "version": "0.335.0"
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Proven engineering practices, enforced through skills.**
 
-Ring is a comprehensive skills library and workflow system for AI agents that transforms how AI assistants approach software development. Currently implemented as a **Claude Code plugin marketplace** with **6 active plugins** and **95 skills** (see `.claude-plugin/marketplace.json` for current versions), the skills themselves are agent-agnostic and can be used with any AI agent system. Ring provides battle-tested patterns, mandatory workflows, and systematic approaches across the entire software delivery value chain.
+Ring is a comprehensive skills library and workflow system for AI agents that transforms how AI assistants approach software development. Currently implemented as a **Claude Code plugin marketplace** with **7 active plugins** and **97 skills** (see `.claude-plugin/marketplace.json` for current versions), the skills themselves are agent-agnostic and can be used with any AI agent system. Ring provides battle-tested patterns, mandatory workflows, and systematic approaches across the entire software delivery value chain.
 
 ## ✨ Why Ring?
 
@@ -21,7 +21,7 @@ Without Ring, AI assistants often:
 Ring solves this by:
 
 - **Enforcing proven workflows** - Test-driven development, systematic debugging, proper planning
-- **Providing 95 specialized skills** (24 core + 33 dev-team + 16 product planning + 7 FinOps regulatory + 6 technical writing + 9 PMO)
+- **Providing 97 specialized skills** (24 core + 33 dev-team + 16 product planning + 7 FinOps regulatory + 6 technical writing + 9 PMO + 2 flowker-team)
 - **41 specialized agents** - 10 review/planning + 15 developer + 4 product research + 3 FinOps regulatory + 3 technical writing + 6 PMO
 - **Automating skill discovery** - Skills load automatically at session start
 - **Preventing common failures** - Built-in anti-patterns and mandatory checklists
@@ -292,7 +292,7 @@ Run command → Paste output → Then claim
 No "should work" → Only "does work" with proof
 ```
 
-## 📚 All 95 Skills (Across 6 Plugins)
+## 📚 All 97 Skills (Across 7 Plugins)
 
 ### Core Skills (ring-default plugin - 24 skills)
 
@@ -461,6 +461,15 @@ No "should work" → Only "does work" with proof
 - `ring:executive-summary` - Executive dashboards and board packages
 - `ring:portfolio-review` - Comprehensive portfolio review across projects
 
+### Core four Integration Skills (ring-flowker-team plugin - 2 skills)
+
+**Catalog Scaffolding:**
+
+- `ring:flowker-new-provider` - Scaffold a new Core four provider (HTTP-based external service) with executors, JSON Schema validation, auth wiring, and unit tests. 5 gates (interview → scaffold → schema → auth/InputBuilder → tests → review).
+- `ring:flowker-new-template` - Scaffold a new Core four workflow template (pre-built blueprint) with parameter schema, Build function, and unit tests. 4 gates (interview → scaffold → build+schema → tests → review).
+
+> These skills orchestrate `ring:backend-engineer-golang`, `ring:dev-unit-testing`, and `ring:codereview`. They target `github.com/LerianStudio/flowker` and depend on `ring-dev-team` plugin.
+
 ## 💡 Usage Examples
 
 ### Building a Feature
@@ -599,10 +608,14 @@ ring/                                  # Monorepo root
 │   │   └── delivery-reporter.md
 │   ├── skills/                       # 9 PMO skills
 │   └── hooks/                        # SessionStart hook
-└── tw-team/                         # Technical Writing plugin (ring-tw-team)
-    ├── skills/                      # 6 documentation skills
-    ├── agents/                      # 3 technical writing agents
-    └── hooks/                       # SessionStart hook
+├── tw-team/                         # Technical Writing plugin (ring-tw-team)
+│   ├── skills/                      # 6 documentation skills
+│   ├── agents/                      # 3 technical writing agents
+│   └── hooks/                       # SessionStart hook
+└── flowker-team/                    # Core four Integration plugin (ring-flowker-team)
+    └── skills/                      # 2 catalog scaffolding skills
+        ├── flowker-new-provider/   # Provider scaffold (5 gates)
+        └── flowker-new-template/   # Template scaffold (4 gates)
 ```
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -614,8 +614,8 @@ ring/                                  # Monorepo root
 │   └── hooks/                       # SessionStart hook
 └── flowker-team/                    # Core four Integration plugin (ring-flowker-team)
     └── skills/                      # 2 catalog scaffolding skills
-        ├── flowker-new-provider/   # Provider scaffold (5 gates)
-        └── flowker-new-template/   # Template scaffold (4 gates)
+        ├── flowker-new-provider/   # Provider scaffold (7 gates)
+        └── flowker-new-template/   # Template scaffold (6 gates)
 ```
 
 ## 🤝 Contributing

--- a/README.md
+++ b/README.md
@@ -465,8 +465,8 @@ No "should work" → Only "does work" with proof
 
 **Catalog Scaffolding:**
 
-- `ring:flowker-new-provider` - Scaffold a new Core four provider (HTTP-based external service) with executors, JSON Schema validation, auth wiring, and unit tests. 5 gates (interview → scaffold → schema → auth/InputBuilder → tests → review).
-- `ring:flowker-new-template` - Scaffold a new Core four workflow template (pre-built blueprint) with parameter schema, Build function, and unit tests. 4 gates (interview → scaffold → build+schema → tests → review).
+- `ring:flowker-new-provider` - Scaffold a new Core four provider (HTTP-based external service) with executors, JSON Schema validation, auth wiring, and unit tests. 7 gates (interview → scaffold → schema → auth/InputBuilder → tests → review → delivery).
+- `ring:flowker-new-template` - Scaffold a new Core four workflow template (pre-built blueprint) with parameter schema, Build function, and unit tests. 6 gates (interview → scaffold → build+schema → tests → review → delivery).
 
 > These skills orchestrate `ring:backend-engineer-golang`, `ring:dev-unit-testing`, and `ring:codereview`. They target `github.com/LerianStudio/flowker` and depend on `ring-dev-team` plugin.
 

--- a/flowker-team/CHANGELOG.md
+++ b/flowker-team/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Ring-flowker-team Changelog
+
+## [0.1.0](https://github.com/LerianStudio/ring/releases/tag/ring-flowker-team@0.1.0)
+
+- **Features**
+  - Initial release of `ring-flowker-team` plugin.
+  - Added `ring:flowker-new-provider` skill for scaffolding new Core four providers (HTTP-based external services) with executors, JSON schemas, auth wiring, and unit tests.
+  - Added `ring:flowker-new-template` skill for scaffolding new Core four workflow templates (pre-built blueprints with parameter validation and Build function).
+
+Contributors: @lffranca
+
+[Compare changes](https://github.com/LerianStudio/ring/releases/tag/ring-flowker-team@0.1.0)

--- a/flowker-team/CHANGELOG.md
+++ b/flowker-team/CHANGELOG.md
@@ -9,4 +9,4 @@
 
 Contributors: @lffranca
 
-[Compare changes](https://github.com/LerianStudio/ring/releases/tag/ring-flowker-team@0.1.0)
+[Release notes](https://github.com/LerianStudio/ring/releases/tag/ring-flowker-team@0.1.0)

--- a/flowker-team/skills/flowker-new-provider/SKILL.md
+++ b/flowker-team/skills/flowker-new-provider/SKILL.md
@@ -192,7 +192,7 @@ Custom InputBuilder needed?
   - true → ONLY when URL must change per-operation via template + provider config (Core one pattern)
 ```
 
-If user cannot answer, dispatch `ring:interviewing-user` to run a structured interview.
+If user cannot answer, dispatch `ring:interview-me` to run a structured interview.
 
 ## Gate 1 — Scaffold (Deterministic)
 

--- a/flowker-team/skills/flowker-new-provider/SKILL.md
+++ b/flowker-team/skills/flowker-new-provider/SKILL.md
@@ -67,6 +67,9 @@ output_schema:
     - name: "Verification Report"
       pattern: "^## Verification Report"
       required: true
+    - name: "Delivery"
+      pattern: "^## Delivery"
+      required: true
     - name: "Handoff"
       pattern: "^## Handoff"
       required: true
@@ -81,6 +84,15 @@ output_schema:
     - name: input_builder
       type: enum
       values: [default, custom, N/A]
+    - name: branch_name
+      type: string
+      description: "Must match ^feature/flowker-provider-[a-z][a-z0-9-]{0,19}$"
+    - name: pr_url
+      type: string
+      description: "https://github.com/LerianStudio/flowker/pull/<number>"
+    - name: pr_base
+      type: string
+      description: "Must equal 'develop'"
 
 verification:
   automated:
@@ -93,9 +105,16 @@ verification:
       description: "Provider registers in catalog"
     - command: "make lint"
       description: "Lint passes"
+    - command: "git rev-parse --abbrev-ref HEAD"
+      description: "On a branch matching feature/flowker-provider-*"
+      success_pattern: '^feature/flowker-provider-[a-z][a-z0-9-]+$'
+    - command: "gh pr view --json baseRefName -q .baseRefName"
+      description: "PR targets develop"
+      success_pattern: '^develop$'
   manual:
     - "curl http://localhost:8080/v1/catalog/providers returns new provider"
     - "Provider config schema validates example payload"
+    - "PR title matches: ^feature\\([a-z][a-z0-9-]{0,19}\\): add .+ provider with \\d+ executors?$"
 
 ---
 
@@ -484,6 +503,173 @@ Security reviewer MUST verify:
 - Auth config not exposed in ExecutionResult.Data
 - Path params sanitized against injection (`..`, `/`, query-string smuggling)
 
+## Gate 6 — Delivery (Branch + Commit + PR)
+
+**This gate is fully prescriptive. No interpretation allowed. Follow exact commands.**
+
+<cannot_skip>
+- Base branch is ALWAYS `develop`, NEVER `main`
+- Branch name pattern is FIXED: `feature/flowker-provider-<provider_id>`
+- Commit message format is ENFORCED by Core four's commit-msg hook (regex-validated)
+- PR target is `develop`; release PR (`develop → main`) is OUT OF SCOPE
+</cannot_skip>
+
+### Step 1 — Pre-flight verification
+
+Before branch creation, verify locally that everything passes. If any fails, go back and fix — do NOT bypass hooks.
+
+```bash
+cd <flowker_repo_root>
+go build ./...
+go test ./pkg/executors/<provider_id>/... -cover -covermode=atomic
+go test ./pkg/executors/ -run TestRegisterDefaults -v
+make lint
+```
+
+All four must exit 0. Paste output into the Handoff section.
+
+### Step 2 — Branch creation (exact pattern)
+
+**Pattern:** `feature/flowker-provider-<provider_id>`
+
+Where `<provider_id>` is the **literal kebab-case string from Gate 0**. No transformation, no prefix variation, no extra words.
+
+```bash
+git fetch origin
+git checkout -b feature/flowker-provider-<provider_id> origin/develop
+```
+
+#### Branch naming — correct vs. wrong
+
+| provider_id | ✅ Correct branch | ❌ Wrong branch |
+|---|---|---|
+| `stripe` | `feature/flowker-provider-stripe` | `feat/stripe-provider` |
+| `example-kyc` | `feature/flowker-provider-example-kyc` | `feature/add-example-kyc` |
+| `aml-vendor` | `feature/flowker-provider-aml-vendor` | `feature/flowker/provider/aml-vendor` |
+| `kyc` | `feature/flowker-provider-kyc` | `feature/new-provider-kyc` |
+
+### Step 3 — Commit (format enforced by hook)
+
+Core four's commit-msg hook enforces this regex (see Core four `CLAUDE.md` — "Commit Message Format"):
+
+- `type`: one of `feature|fix|refactor|style|test|docs|build`
+- `scope`: 1-20 characters, lowercase, kebab-case
+- `description`: 1-100 characters
+
+For a new provider, the values are **always**:
+
+- `type` = `feature`
+- `scope` = `<provider_id>` (if `> 20 chars`, use first 20 chars; document the truncation in PR body)
+- `description` = `add <provider_name> provider with <N> executors`
+
+#### Commit message — correct vs. wrong
+
+| Input | ✅ Correct commit | ❌ Wrong |
+|---|---|---|
+| id=`stripe`, name=`Stripe Payments`, N=2 | `feature(stripe): add Stripe Payments provider with 2 executors` | `feat: add stripe` |
+| id=`example-kyc`, name=`Example KYC`, N=2 | `feature(example-kyc): add Example KYC provider with 2 executors` | `feature(kyc): new provider` |
+| id=`aml-vendor`, name=`AML Vendor`, N=1 | `feature(aml-vendor): add AML Vendor provider with 1 executor` | `chore(aml): add vendor` |
+
+Note: use `1 executor` (singular) when N=1, `N executors` otherwise.
+
+#### Commit command
+
+```bash
+git add pkg/executors/<provider_id>/ pkg/executors/register.go pkg/executors/register_test.go
+git commit -m "feature(<provider_id>): add <provider_name> provider with <N> executors"
+```
+
+**DO NOT** use `--no-verify`. If the commit-msg hook rejects, fix the message — do not bypass.
+
+### Step 4 — Push
+
+```bash
+git push -u origin feature/flowker-provider-<provider_id>
+```
+
+### Step 5 — PR creation (target = `develop`)
+
+**PR title** MUST be identical to the commit message.
+
+**PR base** MUST be `develop` (not `main`). The `--base develop` flag is required.
+
+**PR body** MUST use the template below, with all placeholders filled.
+
+```bash
+gh pr create \
+  --base develop \
+  --title "feature(<provider_id>): add <provider_name> provider with <N> executors" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `<provider_name>` provider to Core four catalog at `pkg/executors/<provider_id>/`.
+- Registers <N> executors: <comma-separated list of ExecutorIDs, e.g., `example-kyc.verify-identity`, `example-kyc.get-result`>.
+- Auth: `<auth_type>`. InputBuilder: `<default|custom>`.
+
+## Files created
+
+| Path | Purpose |
+|---|---|
+| `pkg/executors/<provider_id>/provider.go` | Register + providerConfigSchema |
+| `pkg/executors/<provider_id>/<op>.go` × <N> | Executor per operation |
+| `pkg/executors/<provider_id>/input_builder.go` | Custom routing (if applicable; omit row otherwise) |
+| `pkg/executors/<provider_id>/<provider_id_no_hyphens>_test.go` | Unit tests |
+
+## Files modified
+
+| Path | Change |
+|---|---|
+| `pkg/executors/register.go` | `+` import, `+` `Register` call |
+| `pkg/executors/register_test.go` | `+` registration test |
+
+## Test plan
+
+- [x] `go test ./pkg/executors/<provider_id>/... -cover` — coverage ≥ 85%
+- [x] `go test ./pkg/executors/ -run TestRegisterDefaults -v` — passes
+- [x] `make lint` — clean
+- [ ] Manual: `curl /v1/catalog/providers | jq '.[].id'` lists `<provider_id>` (after `make up`)
+- [ ] Manual: create `provider_configuration` with real credentials and invoke one executor end-to-end
+
+## Scope note
+
+This PR adds the **catalog entry only**. It does not:
+- Create `provider_configurations` records (that is runtime data stored in MongoDB)
+- Reference this provider in any existing workflow
+- Modify authentication/authorization middleware
+- Change env vars or docker-compose
+
+## Out of scope
+
+Release PR (`develop → main`) is handled separately via `release/*` branches and is not part of this change.
+EOF
+)"
+```
+
+#### PR title — correct vs. wrong
+
+| ✅ Correct | ❌ Wrong |
+|---|---|
+| `feature(stripe): add Stripe Payments provider with 2 executors` | `Add stripe provider` |
+| `feature(example-kyc): add Example KYC provider with 2 executors` | `[KYC] New provider` |
+
+### Step 6 — Out of scope (DO NOT ATTEMPT)
+
+- **Do not merge the PR.** Merging requires human review per Core four's CODEOWNERS rules.
+- **Do not create a release PR** (`develop → main`). Core four handles releases via `release/*` branches in a separate workflow.
+- **Do not seed provider_configurations** in any environment — that is runtime data owned by operators.
+- **Do not create workflows that use the new provider** — that is a separate user action.
+- **Do not modify `.env`, `docker-compose.yml`, bootstrap DI, or Swagger** — provider registration does not require any of these.
+
+### Step 7 — Capture PR URL
+
+Extract the PR URL from `gh pr create` stdout and put it in the Handoff section:
+
+```text
+PR opened: https://github.com/LerianStudio/flowker/pull/<number>
+Base branch: develop
+Head branch: feature/flowker-provider-<provider_id>
+```
+
 ## Verification Commands (run from flowker repo root)
 
 ```bash
@@ -599,8 +785,16 @@ Emit this structured output when complete:
 [paste `curl /v1/catalog/providers/{{provider_id}}` output]
 ```
 
+## Delivery
+- **Branch:** `feature/flowker-provider-{{provider_id}}` (base: `develop`)
+- **Commit:** `feature({{provider_id}}): add {{provider_name}} provider with {{N}} executors`
+- **PR:** https://github.com/LerianStudio/flowker/pull/{{number}}
+- **PR base:** `develop`
+- **PR status:** OPEN (awaiting review; merge is out of this skill's scope)
+
 ## Handoff
 - Provider appears in catalog: YES
 - Ready for integration testing: YES
-- Next step: create provider config via `POST /v1/provider-configurations` with real credentials
+- Next step (post-merge): create provider config via `POST /v1/provider-configurations` with real credentials
+- Release PR (`develop → main`): out of scope — handled by Core four's release workflow
 ```

--- a/flowker-team/skills/flowker-new-provider/SKILL.md
+++ b/flowker-team/skills/flowker-new-provider/SKILL.md
@@ -86,7 +86,7 @@ output_schema:
       values: [default, custom, N/A]
     - name: branch_name
       type: string
-      description: "Must match ^feature/flowker-provider-[a-z][a-z0-9-]{0,19}$"
+      description: "Must match ^feature/flowker-provider-[a-z][a-z0-9-]+$ (literal provider_id, unbounded length)"
     - name: pr_url
       type: string
       description: "https://github.com/LerianStudio/flowker/pull/<number>"
@@ -238,13 +238,13 @@ func Register(catalog executor.Catalog) error {
 
 	registrations := []executor.ExecutorRegistration{}
 	{{#each operations}}
-	{{operation_name}}Exec, err := new{{OperationNameCamel}}Executor()
+	{{OperationNameCamel}}Exec, err := new{{OperationNameCamel}}Executor()
 	if err != nil {
 		return fmt.Errorf("failed to create %s %s executor: %w", Name, "{{operation_id}}", err)
 	}
 	registrations = append(registrations, executor.ExecutorRegistration{
-		Executor: {{operation_name}}Exec,
-		Runner:   http.NewRunner({{operation_name}}Exec.ID(), nil),
+		Executor: {{OperationNameCamel}}Exec,
+		Runner:   http.NewRunner({{OperationNameCamel}}Exec.ID(), nil),
 	})
 	{{/each}}
 
@@ -354,7 +354,7 @@ Add the import and call. Example diff:
 ```diff
  import (
      "github.com/LerianStudio/flowker/pkg/executor"
-+    "github.com/LerianStudio/flowker/pkg/executors/{{provider_id}}"
++    {{provider_id_no_hyphens}} "github.com/LerianStudio/flowker/pkg/executors/{{provider_id}}"
      "github.com/LerianStudio/flowker/pkg/executors/midaz"
      "github.com/LerianStudio/flowker/pkg/executors/tracer"
  )

--- a/flowker-team/skills/flowker-new-provider/SKILL.md
+++ b/flowker-team/skills/flowker-new-provider/SKILL.md
@@ -1,0 +1,606 @@
+---
+name: ring:flowker-new-provider
+description: |
+  Scaffolds a new Core four provider (HTTP-based external service integration) with
+  executors, JSON Schema validation, auth wiring, and unit tests. Use when adding
+  integrations like KYC, AML, payment gateways, or custom REST APIs to Core four.
+
+trigger: |
+  - User wants to add a new provider to Core four (e.g., "add provider", "integrate API X", "novo provider")
+  - Task requires creating a new entry in Core four's `pkg/executors/` catalog
+  - Working directory is the Core four repo (github.com/LerianStudio/flowker)
+
+skip_when: |
+  - Adding a new executor to an existing provider → modify the existing `pkg/executors/<name>/` directory directly
+  - Adding a new template (pre-built workflow blueprint) → use `ring:flowker-new-template` instead
+  - Adding a new trigger type (scheduled, Kafka, gRPC) → requires architectural refactor first, not templatable
+  - Not inside the Core four repository
+
+NOT_skip_when: |
+  - "It's just one HTTP call, I can do it manually" → Manual work misses `register.go` patch, tests, schema validation. Use the skill.
+  - "The existing HTTP provider is enough" → The generic `http` provider is not exposed publicly; each external service needs its own catalog entry.
+  - "I'll add the schema later" → Provider without schema fails `base.NewProvider()` at startup. Schema is mandatory.
+
+sequence:
+  before: [ring:dev-unit-testing, ring:codereview]
+
+related:
+  similar: [ring:flowker-new-template]
+  complementary: [ring:backend-engineer-golang, ring:dev-unit-testing, ring:codereview]
+
+input_schema:
+  required:
+    - name: provider_id
+      type: string
+      description: "Provider identifier in kebab-case (e.g., 'stripe', 'kyc-vendor'). Becomes `executor.ProviderID`."
+    - name: provider_name
+      type: string
+      description: "Human-readable name (e.g., 'Stripe Payments')."
+    - name: description
+      type: string
+      description: "Short description of what this provider integrates with."
+    - name: base_url_pattern
+      type: string
+      description: "How base URL(s) are structured (single URL? multi-region? env-specific?)."
+    - name: auth_type
+      type: string
+      enum: [none, api_key, bearer, basic, oidc_client_credentials, oidc_user]
+      description: "Auth mechanism supported by `pkg/executors/http/auth/factory.go`."
+    - name: operations
+      type: array
+      description: "List of operations. Each: { id (kebab-case), name, http_method, path_template, description }."
+  optional:
+    - name: custom_input_builder
+      type: boolean
+      default: false
+      description: "Set true when URL routing or auth translation cannot be handled by default HTTP runner (Core one-style)."
+
+output_schema:
+  format: markdown
+  required_sections:
+    - name: "Provider Summary"
+      pattern: "^## Provider Summary"
+      required: true
+    - name: "Files Created"
+      pattern: "^## Files Created"
+      required: true
+    - name: "Verification Report"
+      pattern: "^## Verification Report"
+      required: true
+    - name: "Handoff"
+      pattern: "^## Handoff"
+      required: true
+  metrics:
+    - name: result
+      type: enum
+      values: [PASS, FAIL]
+    - name: operations_created
+      type: integer
+    - name: test_coverage
+      type: float
+    - name: input_builder
+      type: enum
+      values: [default, custom, N/A]
+
+verification:
+  automated:
+    - command: "go build ./..."
+      description: "Code compiles"
+    - command: "go test ./pkg/executors/<provider_id>/... -cover"
+      description: "Unit tests pass with coverage"
+      success_pattern: 'coverage:.*[8-9][0-9].[0-9]%|100'
+    - command: "go test ./pkg/executors/ -run TestRegisterDefaults"
+      description: "Provider registers in catalog"
+    - command: "make lint"
+      description: "Lint passes"
+  manual:
+    - "curl http://localhost:8080/v1/catalog/providers returns new provider"
+    - "Provider config schema validates example payload"
+
+---
+
+# Core four New Provider
+
+## Overview
+
+Creates a new **static-catalog provider** in Core four with N executors, JSON Schema validation, auth wiring, and unit tests. Providers are stateless — they live in `pkg/executors/<name>/` and get registered in `pkg/executors/register.go` at bootstrap.
+
+**Core principle:** Each external HTTP service (KYC vendor, payment gateway, custom API) is one provider. Each operation on that service (`create_charge`, `refund`, etc.) is one executor.
+
+<block_condition>
+- Missing required input (provider_id, operations list, auth_type) = FAIL
+- Generated code does not compile = FAIL
+- Unit test coverage < 85% = FAIL
+- Provider does not appear in `GET /v1/catalog/providers` = FAIL
+</block_condition>
+
+## Prerequisites
+
+- Go 1.25.5 (Core four's language version)
+- Working directory = Core four repo root
+- Provider's external API docs (endpoints, auth, request/response shapes)
+- Decision made: does this provider need a custom `InputBuilder`? (default: no — only needed for Core one-style per-operation URL routing or nested auth translation)
+
+## Key Interfaces (file:line refs)
+
+The scaffolded code MUST satisfy these interfaces. Reference before generation:
+
+| Interface | Location | Purpose |
+|-----------|----------|---------|
+| `executor.Provider` | `pkg/executor/provider.go:13-29` | ID, Name, Description, Version, ConfigSchema |
+| `executor.Executor` | `pkg/executor/executor.go:15-36` | ID, Name, Category, Version, ProviderID, Schema, ValidateConfig |
+| `executor.Runner` | `pkg/executor/runner.go:11-18` | Execute(ctx, input) — reused from `pkg/executors/http/runner.go` |
+| `executor.InputBuilder` | `pkg/executor/input_builder.go:11-12` | OPTIONAL — only for custom URL/auth routing |
+| `base.NewProvider` | `pkg/executor/base/provider.go:18-78` | Factory that validates schema |
+| `base.NewExecutor` | `pkg/executor/base/base.go:20-83` | Factory with JSON Schema compilation |
+
+**Existing reference providers** (read before scaffolding):
+- Simple HTTP + API key auth: `pkg/executors/tracer/` (best template for new providers)
+- Complex OIDC + custom routing: `pkg/executors/midaz/` (template when `custom_input_builder: true`)
+
+## Gate 0 — Interview
+
+Gather ALL inputs before generating any file. If any required input is missing, STOP and ask.
+
+<cannot_skip>
+Must collect for EVERY operation: id, name, http_method, path_template, short description.
+Must decide: auth_type. Must decide: custom_input_builder (true only if Core one-like routing needed).
+</cannot_skip>
+
+Ask the user (or load from input_schema):
+
+```text
+Provider identity:
+  - provider_id (kebab-case, no dots): ____
+  - provider_name (human-readable): ____
+  - description: ____
+
+Base URL strategy:
+  - single base URL OR multi-endpoint (e.g., Core one has onboarding_base_url + transaction_base_url)?
+
+Authentication (choose ONE):
+  - none / api_key / bearer / basic / oidc_client_credentials / oidc_user
+
+Operations (REPEAT for each):
+  - operation_id (kebab-case, e.g., "create-charge"): ____
+  - operation_name: ____
+  - http_method (GET/POST/PUT/PATCH/DELETE): ____
+  - path_template (e.g., "/v1/charges", "/v1/accounts/{account_id}"): ____
+  - request body shape (inline JSON Schema properties): ____
+
+Custom InputBuilder needed?
+  - false (default) → HTTP runner handles routing using ExecutionInput.URL/Method
+  - true → ONLY when URL must change per-operation via template + provider config (Core one pattern)
+```
+
+If user cannot answer, dispatch `ring:interviewing-user` to run a structured interview.
+
+## Gate 1 — Scaffold (Deterministic)
+
+Create the directory and files below. All placeholders in `{{...}}` come from Gate 0 input.
+
+### File 1: `pkg/executors/{{provider_id}}/provider.go`
+
+```go
+package {{provider_id_no_hyphens}}
+
+import (
+	"fmt"
+
+	"github.com/LerianStudio/flowker/pkg/executor"
+	"github.com/LerianStudio/flowker/pkg/executor/base"
+	"github.com/LerianStudio/flowker/pkg/executors/http"
+)
+
+const (
+	// ProviderID is the catalog identifier for {{provider_name}}.
+	ProviderID executor.ProviderID = "{{provider_id}}"
+
+	// Name is the human-readable provider name.
+	Name = "{{provider_name}}"
+
+	// Description summarizes what this provider integrates with.
+	Description = "{{description}}"
+
+	// Version is the provider version. Bump on breaking schema changes.
+	Version = "v1"
+)
+
+// providerConfigSchema validates user-supplied provider configuration.
+// Filled in Gate 2 with real JSON Schema.
+const providerConfigSchema = `{{providerConfigSchema_placeholder}}`
+
+// Register wires the provider and its executors into the given catalog.
+func Register(catalog executor.Catalog) error {
+	provider, err := base.NewProvider(ProviderID, Name, Description, Version, providerConfigSchema)
+	if err != nil {
+		return fmt.Errorf("failed to register %s provider: %w", Name, err)
+	}
+
+	registrations := []executor.ExecutorRegistration{}
+	{{#each operations}}
+	{{operation_name}}Exec, err := new{{OperationNameCamel}}Executor()
+	if err != nil {
+		return fmt.Errorf("failed to create %s %s executor: %w", Name, "{{operation_id}}", err)
+	}
+	registrations = append(registrations, executor.ExecutorRegistration{
+		Executor: {{operation_name}}Exec,
+		Runner:   http.NewRunner({{operation_name}}Exec.ID(), nil),
+	})
+	{{/each}}
+
+	return catalog.RegisterProvider(provider, registrations)
+}
+```
+
+### File 2 (per operation): `pkg/executors/{{provider_id}}/{{operation_id_snake}}.go`
+
+```go
+package {{provider_id_no_hyphens}}
+
+import (
+	"fmt"
+
+	"github.com/LerianStudio/flowker/pkg/executor"
+	"github.com/LerianStudio/flowker/pkg/executor/base"
+)
+
+const (
+	// {{OperationNameCamel}}ID is the catalog ID for the {{operation_name}} operation.
+	{{OperationNameCamel}}ID executor.ID = "{{provider_id}}.{{operation_id}}"
+)
+
+// {{operation_id_lower}}Schema defines the JSON Schema for {{operation_name}} input.
+// Filled in Gate 2.
+const {{operation_id_lower}}Schema = `{{operationSchema_placeholder}}`
+
+func new{{OperationNameCamel}}Executor() (*base.Executor, error) {
+	exec, err := base.NewExecutor(
+		{{OperationNameCamel}}ID,
+		"{{operation_name}}",
+		"{{category}}",
+		Version,
+		ProviderID,
+		{{operation_id_lower}}Schema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new %s executor: %w", "{{operation_id}}", err)
+	}
+	return exec, nil
+}
+```
+
+### File 3: `pkg/executors/{{provider_id}}/{{provider_id_no_hyphens}}_test.go`
+
+```go
+package {{provider_id_no_hyphens}}_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	executorpkg "github.com/LerianStudio/flowker/pkg/executor"
+	{{provider_id_no_hyphens}} "github.com/LerianStudio/flowker/pkg/executors/{{provider_id}}"
+)
+
+func TestRegister_Success(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+
+	err := {{provider_id_no_hyphens}}.Register(catalog)
+	require.NoError(t, err)
+
+	provider, ok := catalog.GetProvider({{provider_id_no_hyphens}}.ProviderID)
+	require.True(t, ok)
+	require.Equal(t, {{provider_id_no_hyphens}}.Name, provider.Name())
+}
+
+{{#each operations}}
+func Test{{OperationNameCamel}}_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "{{http_method}}", r.Method)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true})
+	}))
+	defer server.Close()
+
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{provider_id_no_hyphens}}.Register(catalog))
+
+	runner, ok := catalog.GetRunner({{provider_id_no_hyphens}}.{{OperationNameCamel}}ID)
+	require.True(t, ok)
+
+	input := executorpkg.ExecutionInput{
+		Method:  "{{http_method}}",
+		URL:     server.URL + "{{path_template_resolved}}",
+		Headers: map[string]string{"Content-Type": "application/json"},
+	}
+
+	result, err := runner.Execute(context.Background(), input)
+	require.NoError(t, err)
+	require.Equal(t, executorpkg.ExecutionStatusSuccess, result.Status)
+}
+{{/each}}
+```
+
+### File 4 (patch): `pkg/executors/register.go`
+
+Add the import and call. Example diff:
+
+```diff
+ import (
+     "github.com/LerianStudio/flowker/pkg/executor"
++    "github.com/LerianStudio/flowker/pkg/executors/{{provider_id}}"
+     "github.com/LerianStudio/flowker/pkg/executors/midaz"
+     "github.com/LerianStudio/flowker/pkg/executors/tracer"
+ )
+
+ func RegisterDefaults(catalog executor.Catalog) error {
+     if err := midaz.Register(catalog); err != nil {
+         return err
+     }
+     if err := tracer.Register(catalog); err != nil {
+         return err
+     }
++    if err := {{provider_id_no_hyphens}}.Register(catalog); err != nil {
++        return err
++    }
+     return nil
+ }
+```
+
+### File 5 (patch): `pkg/executors/register_test.go`
+
+Add an assertion that the new provider appears after `RegisterDefaults`:
+
+```go
+func Test{{ProviderNameCamel}}ProviderRegistered(t *testing.T) {
+    catalog := executor.NewCatalog()
+    require.NoError(t, RegisterDefaults(catalog))
+
+    _, ok := catalog.GetProvider({{provider_id_no_hyphens}}.ProviderID)
+    require.True(t, ok, "{{provider_id}} provider must be registered")
+}
+```
+
+## Gate 2 — Schema Design (Judgment)
+
+Dispatch `ring:backend-engineer-golang` to fill `providerConfigSchema` and per-operation schemas.
+
+<dispatch_required agent="ring:backend-engineer-golang">
+Fill JSON Schema Draft 2020-12 content. Schemas must compile via jsonschema library.
+</dispatch_required>
+
+Prompt template:
+
+```yaml
+Task:
+  subagent_type: "ring:backend-engineer-golang"
+  description: "Fill JSON schemas for {{provider_id}} provider"
+  prompt: |
+    Fill the JSON Schema Draft 2020-12 strings in these files:
+    - pkg/executors/{{provider_id}}/provider.go → providerConfigSchema
+    - pkg/executors/{{provider_id}}/<op>.go → <op>Schema (one per operation)
+
+    ## Provider Config Schema Requirements
+    - Auth type: {{auth_type}}
+    - Auth fields required (reference pkg/executors/http/auth/factory.go:14-75 for accepted shapes):
+      - api_key: flat `api_key` string
+      - bearer: flat `token` string
+      - basic: `username` + `password`
+      - oidc_client_credentials: nested `auth` block with issuer_url/client_id/client_secret/scopes
+    - Base URL fields (based on base_url_pattern): single `base_url` OR multiple *_base_url
+    - All URL fields: "type": "string", "format": "uri"
+
+    ## Operation Schema Requirements (for each operation)
+    - Properties matching the operation's request body shape
+    - Required fields marked in "required" array
+    - Use "type", "format", "enum", "minLength", "pattern" as appropriate
+    - Do not use draft-04 syntax ($ref to external files) — keep inline
+
+    ## Output
+    - Modified .go files with filled schema constants
+    - Validation: `go build ./pkg/executors/{{provider_id}}/...` must pass
+    - Validation: provider must instantiate via `base.NewProvider` without error
+```
+
+## Gate 3 — Auth & InputBuilder Decision
+
+### Decision tree
+
+```text
+IF custom_input_builder == false:
+  → Skip this gate. HTTP runner handles routing via ExecutionInput.URL + Method
+  → Auth is handled by pkg/executors/http/auth/factory.go via provider config
+
+IF custom_input_builder == true:
+  → Create pkg/executors/{{provider_id}}/input_builder.go
+  → Dispatch ring:backend-engineer-golang to implement:
+      - type {{provider_id}}Provider struct wrapping base.Provider + InputBuilder
+      - executorRoutes map: executor.ID → {method, path_template}
+      - resolvePathParams() extracting from provider config / nodeData / requestBody
+      - buildAuth() translating provider-specific auth → http/auth factory format
+  → Reference pkg/executors/midaz/input_builder.go:1-126 as canonical example
+```
+
+### When is `custom_input_builder` required?
+
+| Condition | Custom InputBuilder? |
+|-----------|---------------------|
+| All operations use same base URL, only path differs | NO |
+| Method + URL known at executor definition time | NO |
+| Auth fits `http/auth/factory` types directly | NO |
+| Path contains `{variables}` resolved from provider config | **YES** |
+| Multiple base URLs per provider (e.g., onboarding vs transaction) | **YES** |
+| Auth has nested config block requiring translation | **YES** |
+
+## Gate 4 — Unit Tests
+
+Dispatch `ring:dev-unit-testing` with coverage threshold 85%.
+
+<dispatch_required skill="ring:dev-unit-testing">
+Run the full Gate 3 dev-cycle skill against the new provider package.
+</dispatch_required>
+
+Provide this input to `ring:dev-unit-testing`:
+
+```yaml
+unit_id: "{{provider_id}}-provider"
+language: "go"
+coverage_threshold: 85.0
+implementation_files:
+  - "pkg/executors/{{provider_id}}/provider.go"
+  - "pkg/executors/{{provider_id}}/<op>.go (per operation)"
+  - "pkg/executors/{{provider_id}}/input_builder.go (if custom)"
+acceptance_criteria:
+  - "Provider registers successfully via Register(catalog)"
+  - "Provider appears in catalog.GetProvider({{ProviderID}})"
+  - "Each executor appears in catalog.GetExecutor(<id>)"
+  - "Each runner is bound via catalog.GetRunner(<id>)"
+  - "providerConfigSchema validates a minimal valid config"
+  - "providerConfigSchema rejects config missing required fields"
+  - "Each operation schema validates a minimal valid input"
+  - "Each operation, invoked with httptest.NewServer, returns ExecutionStatusSuccess on 2xx"
+  - "Each operation returns ExecutionStatusFailure on 4xx/5xx"
+```
+
+## Gate 5 — Review
+
+Dispatch `ring:codereview` (parallel 6-reviewer pipeline).
+
+<dispatch_required skill="ring:codereview">
+Run the standard parallel review pipeline on all files created/modified.
+</dispatch_required>
+
+Reviewers that must PASS: code, business-logic, security, test, nil-safety, consequences.
+
+Security reviewer MUST verify:
+- No credentials logged or echoed in errors
+- Auth config not exposed in ExecutionResult.Data
+- Path params sanitized against injection (`..`, `/`, query-string smuggling)
+
+## Verification Commands (run from flowker repo root)
+
+```bash
+# 1. Code compiles
+go build ./...
+
+# 2. Unit tests pass with coverage
+go test ./pkg/executors/{{provider_id}}/... -cover -covermode=atomic
+
+# 3. Provider registers without error
+go test ./pkg/executors/ -run TestRegisterDefaults -v
+
+# 4. Lint clean
+make lint
+
+# 5. Runtime verification (requires local server)
+make up
+curl -s http://localhost:8080/v1/catalog/providers | jq '.[].id' | grep {{provider_id}}
+curl -s http://localhost:8080/v1/catalog/providers/{{provider_id}}/executors | jq '.[].id'
+```
+
+All commands must succeed. Paste actual output into the Verification Report section.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|--------------|----------------|------------------|
+| Adding env vars for provider config | Provider config is runtime data in `provider_configurations` collection, not static env | Define schema for runtime config; don't touch `.env.example` |
+| Creating MongoDB models or repositories | Providers are stateless catalog entries | Just register in `pkg/executors/<name>/provider.go` |
+| Modifying `internal/bootstrap/config.go` | `RegisterDefaults()` already runs at bootstrap, no new wiring | Only edit `pkg/executors/register.go` |
+| Adding Swagger annotations per provider | `GET /v1/catalog/providers` is a generic handler, reflects registered schema | No handler code needed |
+| Custom `InputBuilder` when default works | Core one-style complexity without Core one-style need = boilerplate tax | Default path: just set URL+Method in ExecutionInput; custom only when URLs vary per op |
+| Hardcoding credentials in schema examples | Examples get copy-pasted into prod configs | Use clearly fake placeholder values (`"api_key": "PLACEHOLDER_REPLACE_ME"`) |
+| Skipping `httptest.NewServer` for "we'll integration test" | Unit tests verify request shape cheaply; integration tests are separate | Test each operation with httptest mock |
+
+## Pressure Resistance
+
+| User Says | Your Response |
+|-----------|---------------|
+| "Just copy-paste tracer and rename" | "Copying without adapting schema and auth invites subtle bugs. Run Gates 1-4." |
+| "Skip tests, the external API is mocked in staging" | "Gate 4 unit tests verify code correctness, independent of staging. Write them." |
+| "I'll add the InputBuilder if we hit a problem later" | "InputBuilder decision is Gate 3 — based on objective criteria (per-op URLs, nested auth). Decide now, don't defer." |
+| "The schema is obvious, skip Gate 2" | "Missing `required` array or wrong types break runtime validation. Fill schema explicitly." |
+| "Why 85% coverage? It's boilerplate" | "Schema validation and auth edge cases are where bugs hide. 85% is the Ring floor." |
+
+## Example: Walkthrough — fictional `ExampleKYC` provider
+
+**Input (Gate 0):**
+- `provider_id`: `example-kyc`
+- `provider_name`: `Example KYC`
+- `description`: `Identity verification via Example KYC vendor`
+- `auth_type`: `api_key`
+- `operations`:
+  - `{id: "verify-identity", name: "Verify Identity", method: "POST", path: "/v1/verify"}`
+  - `{id: "get-result", name: "Get Result", method: "GET", path: "/v1/verifications/{verification_id}"}`
+- `custom_input_builder`: `true` (because `get-result` has path variable)
+
+**Output after Gate 1:**
+```
+pkg/executors/example-kyc/
+├── provider.go            (Register() + providerConfigSchema placeholder)
+├── verify_identity.go     (VerifyIdentityID + schema placeholder)
+├── get_result.go          (GetResultID + schema placeholder)
+├── input_builder.go       (route map + resolvePathParams)
+└── example_kyc_test.go    (3 tests: Register, VerifyIdentity, GetResult)
+pkg/executors/register.go  (+3 lines)
+pkg/executors/register_test.go (+1 test)
+```
+
+**After Gate 2 (schema filled):**
+- `providerConfigSchema` requires `{base_url, api_key}`
+- `verifyIdentitySchema` requires `{full_name, document_number, document_type}`
+- `getResultSchema` requires `{verification_id}`
+
+**After Gate 4:**
+- Coverage: 92%
+- All 3 tests pass
+
+**After Gate 5:**
+- Security reviewer: PASS (no api_key leak in errors)
+- Test reviewer: PASS (httptest covers 2xx + 4xx paths)
+
+## Handoff to Next Gate
+
+Emit this structured output when complete:
+
+```markdown
+## Provider Summary
+**Status:** PASS / FAIL
+**Provider ID:** {{provider_id}}
+**Operations:** {{count}}
+**InputBuilder:** default | custom
+**Test Coverage:** {{percent}}%
+
+## Files Created
+| Path | Purpose | Lines |
+|------|---------|-------|
+| pkg/executors/{{provider_id}}/provider.go | Register + schema | N |
+| pkg/executors/{{provider_id}}/<op>.go × {{count}} | Executor per operation | N |
+| pkg/executors/{{provider_id}}/input_builder.go | Custom routing (if applicable) | N |
+| pkg/executors/{{provider_id}}/{{provider_id_no_hyphens}}_test.go | Unit tests | N |
+
+## Files Modified
+| Path | Change |
+|------|--------|
+| pkg/executors/register.go | +import +Register call |
+| pkg/executors/register_test.go | +registration test |
+
+## Verification Report
+```
+[paste `go test -cover` output]
+[paste `make lint` output]
+[paste `curl /v1/catalog/providers/{{provider_id}}` output]
+```
+
+## Handoff
+- Provider appears in catalog: YES
+- Ready for integration testing: YES
+- Next step: create provider config via `POST /v1/provider-configurations` with real credentials
+```

--- a/flowker-team/skills/flowker-new-provider/SKILL.md
+++ b/flowker-team/skills/flowker-new-provider/SKILL.md
@@ -135,7 +135,7 @@ Creates a new **static-catalog provider** in Core four with N executors, JSON Sc
 
 ## Prerequisites
 
-- Go 1.25.5 (Core four's language version)
+- Go 1.25.8 (verify against Core four's `go.mod` at time of use)
 - Working directory = Core four repo root
 - Provider's external API docs (endpoints, auth, request/response shapes)
 - Decision made: does this provider need a custom `InputBuilder`? (default: no — only needed for Core one-style per-operation URL routing or nested auth translation)

--- a/flowker-team/skills/flowker-new-template/SKILL.md
+++ b/flowker-team/skills/flowker-new-template/SKILL.md
@@ -1,0 +1,585 @@
+---
+name: ring:flowker-new-template
+description: |
+  Scaffolds a new Core four workflow template — a pre-built workflow blueprint with
+  parameter validation and a Build function that emits `*model.CreateWorkflowInput`.
+  Use when codifying a recurring workflow pattern (e.g., KYC-AML check, payment-settlement).
+
+trigger: |
+  - User wants to add a new workflow template (e.g., "novo template", "workflow blueprint", "recurring workflow pattern")
+  - Task requires a new entry in Core four's `pkg/templates/` catalog
+  - Multiple users should be able to instantiate the same workflow shape with different parameters
+
+skip_when: |
+  - Adding a new provider (external service integration) → use `ring:flowker-new-provider`
+  - Adding a one-off workflow for a single user → just POST to `/v1/workflows`, no template needed
+  - Not inside the Core four repository
+
+NOT_skip_when: |
+  - "The workflow is too simple for a template" → Templates exist exactly to remove boilerplate for common shapes. Use it.
+  - "I'll write a script that generates the workflow JSON" → Templates are the built-in mechanism with schema validation. Use it.
+  - "I don't need parameter validation" → JSON Schema validation prevents broken workflows at creation time, not runtime. Do it.
+
+sequence:
+  before: [ring:codereview]
+
+related:
+  similar: [ring:flowker-new-provider]
+  complementary: [ring:backend-engineer-golang, ring:codereview]
+
+input_schema:
+  required:
+    - name: template_id
+      type: string
+      description: "Template identifier in kebab-case (e.g., 'kyc-aml-check'). Becomes `executor.TemplateID`."
+    - name: template_name
+      type: string
+      description: "Human-readable name."
+    - name: description
+      type: string
+      description: "Describes what workflow this template produces."
+    - name: category
+      type: string
+      description: "Grouping label (e.g., 'compliance', 'payments')."
+    - name: params
+      type: array
+      description: "Template parameters. Each: { name, type, required (bool), provider_config (nullable — if set, value must reference a provider config of that ProviderID) }."
+    - name: nodes
+      type: array
+      description: "Ordered workflow nodes. Each: { id, type (trigger|executor|conditional), reference (TriggerID or ExecutorID), data_mapping (param references) }."
+    - name: edges
+      type: array
+      description: "Workflow edges. Each: { source_node_id, target_node_id, condition (optional) }."
+
+output_schema:
+  format: markdown
+  required_sections:
+    - name: "Template Summary"
+      pattern: "^## Template Summary"
+      required: true
+    - name: "Files Created"
+      pattern: "^## Files Created"
+      required: true
+    - name: "Verification Report"
+      pattern: "^## Verification Report"
+      required: true
+    - name: "Handoff"
+      pattern: "^## Handoff"
+      required: true
+  metrics:
+    - name: result
+      type: enum
+      values: [PASS, FAIL]
+    - name: nodes_count
+      type: integer
+    - name: edges_count
+      type: integer
+    - name: test_coverage
+      type: float
+
+verification:
+  automated:
+    - command: "go build ./..."
+      description: "Code compiles"
+    - command: "go test ./pkg/templates/<template_id>/... -cover"
+      description: "Unit tests pass with coverage"
+      success_pattern: 'coverage:.*[8-9][0-9].[0-9]%|100'
+    - command: "go test ./pkg/templates/ -run TestRegisterDefaults"
+      description: "Template registers in catalog"
+    - command: "make lint"
+      description: "Lint passes"
+  manual:
+    - "curl http://localhost:8080/v1/catalog/templates returns new template"
+    - "curl -X POST /v1/workflows/from-template creates a valid workflow"
+
+---
+
+# Core four New Template
+
+## Overview
+
+Creates a new **workflow template** in Core four — a reusable blueprint that accepts parameters and emits a complete `*model.CreateWorkflowInput`. Templates live in `pkg/templates/<name>/` and get registered in `pkg/templates/register.go` at bootstrap.
+
+**Core principle:** Templates remove boilerplate for workflows users repeatedly construct (same nodes, same edges, different parameter values — like provider config IDs or workflow names).
+
+<block_condition>
+- Missing required input (template_id, nodes, edges, params) = FAIL
+- `build()` references an executor ID not present in the catalog = FAIL
+- Edge references a node_id that does not exist in nodes = FAIL
+- Unit test coverage < 85% = FAIL
+- Template does not appear in `GET /v1/catalog/templates` = FAIL
+</block_condition>
+
+## Prerequisites
+
+- Go 1.25.5
+- Working directory = Core four repo root
+- All executor IDs referenced in template nodes MUST already exist in the catalog (verify via `GET /v1/catalog/providers/<provider_id>/executors`)
+- All trigger IDs referenced MUST exist (currently only `webhook`)
+
+## Key Interfaces (file:line refs)
+
+| Interface / Type | Location | Purpose |
+|------------------|----------|---------|
+| `executor.Template` | `pkg/executor/template.go:23-52` | ID, Name, Description, Category, ParamSchema, ValidateParams, Build, ProviderConfigFields |
+| `base.NewTemplate` | `pkg/executor/base/template.go` | Factory with JSON Schema validation |
+| `executor.ProviderConfigField` | `pkg/executor/template.go` | Param→ProviderID binding for dynamic enrichment |
+| `model.CreateWorkflowInput` | `pkg/model/workflow.go` | Output shape that `build()` returns |
+| Consumer service | `internal/services/command/create_workflow_from_template.go` | What calls `Build()` at runtime |
+
+**Existing reference template** (read before scaffolding):
+- `pkg/templates/tracer_midaz/template.go` — canonical 4-node template (webhook → tracer validate → decision → midaz create-transaction)
+- `pkg/templates/tracer_midaz/template_test.go` — test patterns to replicate
+
+## Gate 0 — Interview
+
+Gather ALL inputs before generating any file. STOP if missing.
+
+<cannot_skip>
+Must collect: template_id, nodes (with types and references), edges (with source/target), params (with types and optional provider_config binding).
+Every executor ID and trigger ID in nodes MUST be verified to exist in the catalog.
+</cannot_skip>
+
+Ask the user:
+
+```text
+Template identity:
+  - template_id (kebab-case): ____
+  - template_name: ____
+  - description: ____
+  - category: ____
+
+Parameters:
+  REPEAT for each param:
+    - param_name: ____
+    - param_type: string | uuid | integer | boolean
+    - required: true | false
+    - provider_config_binding:
+        - NONE (regular param)
+        - provider_id (e.g., "midaz") → this param holds a provider_configuration UUID of that provider
+
+Workflow structure:
+  Nodes (ordered):
+    REPEAT for each node:
+      - node_id (unique within template): ____
+      - type: trigger | executor | conditional
+      - reference:
+          - trigger type: "webhook" (only option currently)
+          - executor type: ExecutorID (e.g., "tracer.validate-transaction") — VERIFY EXISTS
+          - conditional: N/A
+      - data_mapping:
+          - which template params feed into this node's data?
+
+  Edges:
+    REPEAT for each edge:
+      - source_node_id: ____
+      - target_node_id: ____
+      - condition (for edges out of conditional nodes): "true" | "false" | label | null
+```
+
+Before proceeding to Gate 1: VERIFY every executor ID in nodes exists:
+
+```bash
+for exec_id in <referenced_executor_ids>; do
+  curl -s http://localhost:8080/v1/catalog/providers/<provider>/executors | jq ".[] | select(.id == \"$exec_id\")"
+done
+```
+
+If any executor ID does not exist, STOP and ask the user to create the provider first (`ring:flowker-new-provider`).
+
+## Gate 1 — Scaffold (Deterministic)
+
+### File 1: `pkg/templates/{{template_id_snake}}/template.go`
+
+```go
+package {{template_id_snake}}
+
+import (
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/LerianStudio/flowker/pkg/executor"
+	"github.com/LerianStudio/flowker/pkg/executor/base"
+	"github.com/LerianStudio/flowker/pkg/model"
+)
+
+const (
+	// TemplateID is the catalog identifier for {{template_name}}.
+	TemplateID executor.TemplateID = "{{template_id}}"
+
+	// Name is the human-readable template name.
+	Name = "{{template_name}}"
+
+	// Description summarizes the workflow this template produces.
+	Description = "{{description}}"
+
+	// Category groups related templates.
+	Category = "{{category}}"
+
+	// Version is the template version. Bump on breaking param schema changes.
+	Version = "v1"
+)
+
+// paramSchema validates user-supplied template parameters.
+// Filled in Gate 2.
+const paramSchema = `{{paramSchema_placeholder}}`
+
+// Register wires the template into the given catalog.
+func Register(catalog executor.Catalog) error {
+	tmpl, err := base.NewTemplate(
+		TemplateID,
+		Name,
+		Description,
+		Version,
+		Category,
+		paramSchema,
+		build,
+		providerConfigFields(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to register %s template: %w", Name, err)
+	}
+	return catalog.RegisterTemplate(tmpl)
+}
+
+func providerConfigFields() []executor.ProviderConfigField {
+	return []executor.ProviderConfigField{
+		{{#each params_with_provider_binding}}
+		{ParamName: "{{param_name}}", ProviderID: "{{provider_id}}"},
+		{{/each}}
+	}
+}
+
+// build emits the workflow structure from validated params.
+// Filled in Gate 2.
+func build(params map[string]any) (any, error) {
+	return nil, fmt.Errorf("build not implemented")
+}
+```
+
+### File 2: `pkg/templates/{{template_id_snake}}/template_test.go`
+
+```go
+package {{template_id_snake}}_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	executorpkg "github.com/LerianStudio/flowker/pkg/executor"
+	{{template_id_snake}} "github.com/LerianStudio/flowker/pkg/templates/{{template_id_snake}}"
+)
+
+func TestRegister_Success(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{template_id_snake}}.Register(catalog))
+
+	tmpl, ok := catalog.GetTemplate({{template_id_snake}}.TemplateID)
+	require.True(t, ok)
+	require.Equal(t, {{template_id_snake}}.Name, tmpl.Name())
+}
+
+func TestRegister_Duplicate(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{template_id_snake}}.Register(catalog))
+
+	err := {{template_id_snake}}.Register(catalog)
+	require.Error(t, err, "duplicate registration must fail")
+}
+
+func TestValidateParams_Valid(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{template_id_snake}}.Register(catalog))
+	tmpl, _ := catalog.GetTemplate({{template_id_snake}}.TemplateID)
+
+	validParams := map[string]any{
+		{{#each params}}
+		"{{param_name}}": {{valid_example}},
+		{{/each}}
+	}
+	require.NoError(t, tmpl.ValidateParams(validParams))
+}
+
+func TestValidateParams_MissingRequired(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{template_id_snake}}.Register(catalog))
+	tmpl, _ := catalog.GetTemplate({{template_id_snake}}.TemplateID)
+
+	require.Error(t, tmpl.ValidateParams(map[string]any{}))
+}
+
+func TestBuild_ValidParams(t *testing.T) {
+	catalog := executorpkg.NewCatalog()
+	require.NoError(t, {{template_id_snake}}.Register(catalog))
+	tmpl, _ := catalog.GetTemplate({{template_id_snake}}.TemplateID)
+
+	params := map[string]any{
+		{{#each params}}
+		"{{param_name}}": {{valid_example}},
+		{{/each}}
+	}
+	out, err := tmpl.Build(params)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	// Verify output shape
+	workflow, ok := out.(*model.CreateWorkflowInput)
+	require.True(t, ok)
+	require.Len(t, workflow.Nodes, {{nodes_count}})
+	require.Len(t, workflow.Edges, {{edges_count}})
+}
+```
+
+### File 3 (patch): `pkg/templates/register.go`
+
+```diff
+ import (
+     "github.com/LerianStudio/flowker/pkg/executor"
++    "github.com/LerianStudio/flowker/pkg/templates/{{template_id_snake}}"
+     "github.com/LerianStudio/flowker/pkg/templates/tracer_midaz"
+ )
+
+ func RegisterDefaults(catalog executor.Catalog) error {
+     if err := tracer_midaz.Register(catalog); err != nil {
+         return err
+     }
++    if err := {{template_id_snake}}.Register(catalog); err != nil {
++        return err
++    }
+     return nil
+ }
+```
+
+## Gate 2 — Build Function & Param Schema (Judgment)
+
+Dispatch `ring:backend-engineer-golang` to fill two things: `paramSchema` (JSON Schema) and `build()` function body.
+
+<dispatch_required agent="ring:backend-engineer-golang">
+Fill paramSchema with JSON Schema Draft 2020-12 AND implement build() returning *model.CreateWorkflowInput.
+</dispatch_required>
+
+Prompt template:
+
+```yaml
+Task:
+  subagent_type: "ring:backend-engineer-golang"
+  description: "Implement build() and paramSchema for {{template_id}} template"
+  prompt: |
+    Fill the JSON Schema AND the build() function in:
+    pkg/templates/{{template_id_snake}}/template.go
+
+    ## paramSchema Requirements
+    - JSON Schema Draft 2020-12
+    - Properties matching each declared param:
+      - string params: {"type": "string", "minLength": 1}
+      - uuid params: {"type": "string", "format": "uuid"}
+      - integer: {"type": "integer"}
+      - boolean: {"type": "boolean"}
+    - Required params listed in "required" array
+    - Params with provider_config_binding MUST be uuid-formatted strings
+
+    ## build() Requirements
+    Implement `build(params map[string]any) (any, error)` that:
+    1. Extracts each param into typed variable
+    2. Constructs `[]model.Node` with:
+       - Unique node IDs (use uuid.New().String() or static readable IDs)
+       - NodeType = trigger | executor | conditional
+       - Reference = TriggerID or ExecutorID as declared
+       - Data = map[string]any derived from params (per data_mapping)
+    3. Constructs `[]model.Edge` with:
+       - Source and Target = node IDs from step 2
+       - Condition = as declared (nil for unconditional edges)
+    4. Returns &model.CreateWorkflowInput{
+           Name: params["workflow_name"].(string),
+           Description: Description,
+           Nodes: nodes,
+           Edges: edges,
+       }
+
+    ## Validation
+    - `go build ./pkg/templates/{{template_id_snake}}/...` must pass
+    - Returned `*model.CreateWorkflowInput` must have:
+      - Exactly {{nodes_count}} nodes
+      - Exactly {{edges_count}} edges
+      - First node must be of type `trigger`
+      - Every edge source_node_id and target_node_id must match an existing node ID
+
+    ## Reference
+    See `pkg/templates/tracer_midaz/template.go` as canonical example (4 nodes, 3 edges, webhook→validate→conditional→transaction).
+```
+
+## Gate 3 — Unit Tests
+
+Dispatch `ring:dev-unit-testing` with coverage threshold 85%.
+
+<dispatch_required skill="ring:dev-unit-testing">
+Run Gate 3 unit testing on the new template package.
+</dispatch_required>
+
+Provide this input:
+
+```yaml
+unit_id: "{{template_id}}-template"
+language: "go"
+coverage_threshold: 85.0
+implementation_files:
+  - "pkg/templates/{{template_id_snake}}/template.go"
+acceptance_criteria:
+  - "Register succeeds on fresh catalog"
+  - "Register fails on duplicate (second call returns error)"
+  - "ValidateParams passes on fully-populated valid param set"
+  - "ValidateParams fails on missing required params"
+  - "ValidateParams fails on wrong type (e.g., string where int expected)"
+  - "Build returns *model.CreateWorkflowInput with correct Nodes count"
+  - "Build returns *model.CreateWorkflowInput with correct Edges count"
+  - "Build returns error on param missing that ValidateParams would reject"
+  - "Build output: first node is trigger type"
+  - "Build output: every edge source/target references an existing node ID"
+```
+
+## Gate 4 — Review
+
+Dispatch `ring:codereview` (parallel 6-reviewer pipeline).
+
+<dispatch_required skill="ring:codereview">
+Run the standard parallel review pipeline on all files created/modified.
+</dispatch_required>
+
+Business-logic reviewer MUST verify:
+- Node graph is connected (no orphan nodes)
+- No cycles in edges (template workflows should be DAG)
+- ProviderConfigField bindings align with executor IDs used in nodes
+
+## Verification Commands (run from flowker repo root)
+
+```bash
+# 1. Code compiles
+go build ./...
+
+# 2. Unit tests pass with coverage
+go test ./pkg/templates/{{template_id_snake}}/... -cover -covermode=atomic
+
+# 3. Template registers without error
+go test ./pkg/templates/ -run TestRegisterDefaults -v
+
+# 4. Lint clean
+make lint
+
+# 5. Runtime verification (requires local server + existing provider configs)
+make up
+curl -s http://localhost:8080/v1/catalog/templates | jq '.[].id' | grep {{template_id}}
+curl -s http://localhost:8080/v1/catalog/templates/{{template_id}} | jq '.param_schema'
+
+# 6. Create a real workflow from the template
+curl -X POST http://localhost:8080/v1/workflows/from-template \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"template_id": "{{template_id}}", "params": {<your valid params>}}'
+```
+
+All commands must succeed. Paste actual output into the Verification Report section.
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It's Wrong | Correct Approach |
+|--------------|----------------|------------------|
+| Calling external APIs inside `build()` | `build()` must be pure and deterministic | All data comes from `params map[string]any`; fetch happens in runtime services |
+| Looking up provider configs inside `build()` | Provider config lookup is `CreateWorkflowFromTemplate` service's job | Declare `ProviderConfigField` bindings; param value is the UUID string |
+| Referencing an executor ID without verifying it exists | Broken at workflow-creation time, not at template registration | Gate 0 verifies catalog presence before scaffold |
+| Orphan nodes (not connected by any edge) | Workflow engine will never execute them | Every non-trigger node must have at least one incoming edge |
+| Using `model.Node` fields the catalog doesn't know | Workflow validation fails at creation | Use only documented `model.Node` fields; verify against `pkg/model/workflow.go` |
+| Randomizing UUIDs inside `build()` on every call | Breaks idempotency tests | Either accept deterministic seeds via params or document non-determinism |
+| Adding MongoDB collections or handlers | Templates are stateless catalog entries | Just `pkg/templates/<name>/template.go` and register |
+
+## Pressure Resistance
+
+| User Says | Your Response |
+|-----------|---------------|
+| "Skip ValidateParams, JSON Schema is overkill" | "Without validation, bad params reach `build()` and crash at runtime. Schema catches them at creation." |
+| "Let `build()` fetch live provider config" | "`build()` must be pure. Provider-config lookup is the consuming service's responsibility." |
+| "Templates are copy-paste, let me skip tests" | "Build() is where node/edge bugs hide. Tests prevent a broken template from registering." |
+| "Just hardcode node IDs to fixed UUIDs" | "Fixed UUIDs collide across workflows created from the same template. Generate per-Build call." |
+| "I'll wire up `ProviderConfigField` later" | "Without binding, the UI cannot offer a dropdown of valid provider configs. Declare it now." |
+
+## Example: Walkthrough — fictional `kyc-aml-check` template
+
+**Input (Gate 0):**
+- `template_id`: `kyc-aml-check`
+- `category`: `compliance`
+- Params:
+  - `workflow_name` (string, required)
+  - `kyc_provider_config_id` (uuid, required, binding: provider `example-kyc`)
+  - `aml_provider_config_id` (uuid, required, binding: provider `example-aml`)
+- Nodes:
+  1. `trigger_webhook` — type: trigger, ref: `webhook`
+  2. `kyc_verify` — type: executor, ref: `example-kyc.verify-identity`
+  3. `aml_check` — type: executor, ref: `example-aml.screen-entity`
+  4. `decision` — type: conditional
+  5. `approve` / `reject` — leaf nodes (executor or terminal)
+- Edges:
+  - `trigger_webhook → kyc_verify`
+  - `kyc_verify → aml_check`
+  - `aml_check → decision`
+  - `decision → approve` (condition: "true")
+  - `decision → reject` (condition: "false")
+
+**Output after Gate 1:**
+```
+pkg/templates/kyc_aml_check/
+├── template.go       (Register + paramSchema placeholder + build stub)
+└── template_test.go  (5 tests scaffolded)
+pkg/templates/register.go  (+3 lines)
+```
+
+**After Gate 2:**
+- `paramSchema` requires all three params
+- `build()` returns `*model.CreateWorkflowInput` with 5 nodes, 5 edges
+- First node is trigger, graph is acyclic, all executor IDs verified
+
+**After Gate 3:**
+- Coverage: 94%
+- All 5 tests pass
+
+**After Gate 4:**
+- Business-logic reviewer: PASS (graph connected, no cycles, ProviderConfigField matches executor provider)
+- Test reviewer: PASS
+
+## Handoff to Next Gate
+
+Emit this structured output when complete:
+
+```markdown
+## Template Summary
+**Status:** PASS / FAIL
+**Template ID:** {{template_id}}
+**Category:** {{category}}
+**Nodes:** {{count}}
+**Edges:** {{count}}
+**Test Coverage:** {{percent}}%
+
+## Files Created
+| Path | Purpose | Lines |
+|------|---------|-------|
+| pkg/templates/{{template_id_snake}}/template.go | Register + build + schema | N |
+| pkg/templates/{{template_id_snake}}/template_test.go | Unit tests | N |
+
+## Files Modified
+| Path | Change |
+|------|--------|
+| pkg/templates/register.go | +import +Register call |
+
+## Verification Report
+```
+[paste `go test -cover` output]
+[paste `make lint` output]
+[paste `curl /v1/catalog/templates/{{template_id}}` output]
+[paste `POST /v1/workflows/from-template` success output]
+```
+
+## Handoff
+- Template appears in catalog: YES
+- Workflow successfully created from template: YES
+- Next step: document template in project README / user-facing docs
+```

--- a/flowker-team/skills/flowker-new-template/SKILL.md
+++ b/flowker-team/skills/flowker-new-template/SKILL.md
@@ -21,7 +21,7 @@ NOT_skip_when: |
   - "I don't need parameter validation" → JSON Schema validation prevents broken workflows at creation time, not runtime. Do it.
 
 sequence:
-  before: [ring:codereview]
+  before: [ring:dev-unit-testing, ring:codereview]
 
 related:
   similar: [ring:flowker-new-provider]
@@ -131,7 +131,7 @@ Creates a new **workflow template** in Core four — a reusable blueprint that a
 
 ## Prerequisites
 
-- Go 1.25.5
+- Go 1.25.8 (verify against Core four's `go.mod` at time of use)
 - Working directory = Core four repo root
 - All executor IDs referenced in template nodes MUST already exist in the catalog (verify via `GET /v1/catalog/providers/<provider_id>/executors`)
 - All trigger IDs referenced MUST exist (currently only `webhook`)

--- a/flowker-team/skills/flowker-new-template/SKILL.md
+++ b/flowker-team/skills/flowker-new-template/SKILL.md
@@ -63,6 +63,9 @@ output_schema:
     - name: "Verification Report"
       pattern: "^## Verification Report"
       required: true
+    - name: "Delivery"
+      pattern: "^## Delivery"
+      required: true
     - name: "Handoff"
       pattern: "^## Handoff"
       required: true
@@ -76,6 +79,15 @@ output_schema:
       type: integer
     - name: test_coverage
       type: float
+    - name: branch_name
+      type: string
+      description: "Must match ^feature/flowker-template-[a-z][a-z0-9-]{0,19}$"
+    - name: pr_url
+      type: string
+      description: "https://github.com/LerianStudio/flowker/pull/<number>"
+    - name: pr_base
+      type: string
+      description: "Must equal 'develop'"
 
 verification:
   automated:
@@ -88,9 +100,16 @@ verification:
       description: "Template registers in catalog"
     - command: "make lint"
       description: "Lint passes"
+    - command: "git rev-parse --abbrev-ref HEAD"
+      description: "On a branch matching feature/flowker-template-*"
+      success_pattern: '^feature/flowker-template-[a-z][a-z0-9-]+$'
+    - command: "gh pr view --json baseRefName -q .baseRefName"
+      description: "PR targets develop"
+      success_pattern: '^develop$'
   manual:
     - "curl http://localhost:8080/v1/catalog/templates returns new template"
     - "curl -X POST /v1/workflows/from-template creates a valid workflow"
+    - "PR title matches: ^feature\\([a-z][a-z0-9-]{0,19}\\): add .+ workflow template$"
 
 ---
 
@@ -452,6 +471,167 @@ Business-logic reviewer MUST verify:
 - No cycles in edges (template workflows should be DAG)
 - ProviderConfigField bindings align with executor IDs used in nodes
 
+## Gate 5 — Delivery (Branch + Commit + PR)
+
+**This gate is fully prescriptive. No interpretation allowed. Follow exact commands.**
+
+<cannot_skip>
+- Base branch is ALWAYS `develop`, NEVER `main`
+- Branch name pattern is FIXED: `feature/flowker-template-<template_id>`
+- Commit message format is ENFORCED by Core four's commit-msg hook (regex-validated)
+- PR target is `develop`; release PR (`develop → main`) is OUT OF SCOPE
+</cannot_skip>
+
+### Step 1 — Pre-flight verification
+
+Before branch creation, all of these must exit 0:
+
+```bash
+cd <flowker_repo_root>
+go build ./...
+go test ./pkg/templates/<template_id_snake>/... -cover -covermode=atomic
+go test ./pkg/templates/ -run TestRegisterDefaults -v
+make lint
+```
+
+Paste output into Handoff section.
+
+### Step 2 — Branch creation (exact pattern)
+
+**Pattern:** `feature/flowker-template-<template_id>`
+
+Where `<template_id>` is the **literal kebab-case string from Gate 0**. No transformation.
+
+```bash
+git fetch origin
+git checkout -b feature/flowker-template-<template_id> origin/develop
+```
+
+#### Branch naming — correct vs. wrong
+
+| template_id | ✅ Correct branch | ❌ Wrong branch |
+|---|---|---|
+| `kyc-aml-check` | `feature/flowker-template-kyc-aml-check` | `feat/template-kyc` |
+| `payment-settlement` | `feature/flowker-template-payment-settlement` | `feature/add-payment-template` |
+| `onboarding` | `feature/flowker-template-onboarding` | `feature/flowker/template/onboarding` |
+
+### Step 3 — Commit (format enforced by hook)
+
+Core four's commit-msg hook enforces (see Core four `CLAUDE.md` — "Commit Message Format"):
+
+- `type`: one of `feature|fix|refactor|style|test|docs|build`
+- `scope`: 1-20 characters, lowercase, kebab-case
+- `description`: 1-100 characters
+
+For a new template, the values are **always**:
+
+- `type` = `feature`
+- `scope` = `<template_id>` (if `> 20 chars`, use first 20 chars; document the truncation in PR body)
+- `description` = `add <template_name> workflow template`
+
+#### Commit message — correct vs. wrong
+
+| Input | ✅ Correct commit | ❌ Wrong |
+|---|---|---|
+| id=`kyc-aml-check`, name=`KYC-AML Check` | `feature(kyc-aml-check): add KYC-AML Check workflow template` | `feat: add kyc template` |
+| id=`payment-settlement`, name=`Payment Settlement` | `feature(payment-settlement): add Payment Settlement workflow template` | `feature(template): add payment flow` |
+| id=`onboarding`, name=`Onboarding` | `feature(onboarding): add Onboarding workflow template` | `chore(onboarding): new template` |
+
+#### Commit command
+
+```bash
+git add pkg/templates/<template_id_snake>/ pkg/templates/register.go
+git commit -m "feature(<template_id>): add <template_name> workflow template"
+```
+
+**DO NOT** use `--no-verify`. If the commit-msg hook rejects, fix the message.
+
+### Step 4 — Push
+
+```bash
+git push -u origin feature/flowker-template-<template_id>
+```
+
+### Step 5 — PR creation (target = `develop`)
+
+**PR title** MUST be identical to the commit message.
+
+**PR base** MUST be `develop`.
+
+**PR body** MUST use the template below.
+
+```bash
+gh pr create \
+  --base develop \
+  --title "feature(<template_id>): add <template_name> workflow template" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `<template_name>` workflow template to Core four catalog at `pkg/templates/<template_id_snake>/`.
+- Produces `*model.CreateWorkflowInput` with <N> nodes and <M> edges.
+- Category: `<category>`.
+- Parameters: <comma-separated list of param names>.
+- Referenced executor IDs (must already exist in catalog): <comma-separated list>.
+
+## Files created
+
+| Path | Purpose |
+|---|---|
+| `pkg/templates/<template_id_snake>/template.go` | Register + paramSchema + build function |
+| `pkg/templates/<template_id_snake>/template_test.go` | Unit tests (registration, validation, build) |
+
+## Files modified
+
+| Path | Change |
+|---|---|
+| `pkg/templates/register.go` | `+` import, `+` `Register` call |
+
+## Workflow structure
+
+```
+<trigger_node> → <executor_node_1> → <executor_node_2> → <terminal_node>
+```
+
+(Replace with actual node/edge diagram of the generated workflow.)
+
+## Test plan
+
+- [x] `go test ./pkg/templates/<template_id_snake>/... -cover` — coverage ≥ 85%
+- [x] `go test ./pkg/templates/ -run TestRegisterDefaults -v` — passes
+- [x] `make lint` — clean
+- [ ] Manual: `curl /v1/catalog/templates | jq '.[].id'` lists `<template_id>` (after `make up`)
+- [ ] Manual: `POST /v1/workflows/from-template` with valid params creates a workflow
+
+## Scope note
+
+This PR adds the **catalog entry only**. It does not:
+- Create any `workflows` records (templates are instantiated on demand via `POST /v1/workflows/from-template`)
+- Create `provider_configurations` for the referenced providers
+- Modify handlers, services, or bootstrap wiring
+
+## Out of scope
+
+Release PR (`develop → main`) is handled separately via `release/*` branches.
+EOF
+)"
+```
+
+### Step 6 — Out of scope (DO NOT ATTEMPT)
+
+- **Do not merge the PR.** Requires human review per CODEOWNERS.
+- **Do not create a release PR** (`develop → main`).
+- **Do not seed workflows** using this template in any environment.
+- **Do not create provider_configurations** for the referenced providers.
+- **Do not modify existing templates** — each template is independent.
+
+### Step 7 — Capture PR URL
+
+```text
+PR opened: https://github.com/LerianStudio/flowker/pull/<number>
+Base branch: develop
+Head branch: feature/flowker-template-<template_id>
+```
+
 ## Verification Commands (run from flowker repo root)
 
 ```bash
@@ -578,8 +758,16 @@ Emit this structured output when complete:
 [paste `POST /v1/workflows/from-template` success output]
 ```
 
+## Delivery
+- **Branch:** `feature/flowker-template-{{template_id}}` (base: `develop`)
+- **Commit:** `feature({{template_id}}): add {{template_name}} workflow template`
+- **PR:** https://github.com/LerianStudio/flowker/pull/{{number}}
+- **PR base:** `develop`
+- **PR status:** OPEN (awaiting review; merge is out of this skill's scope)
+
 ## Handoff
 - Template appears in catalog: YES
-- Workflow successfully created from template: YES
-- Next step: document template in project README / user-facing docs
+- Workflow successfully created from template: YES (manual verification)
+- Next step (post-merge): document template in project README / user-facing docs
+- Release PR (`develop → main`): out of scope — handled by Core four's release workflow
 ```

--- a/flowker-team/skills/flowker-new-template/SKILL.md
+++ b/flowker-team/skills/flowker-new-template/SKILL.md
@@ -81,7 +81,7 @@ output_schema:
       type: float
     - name: branch_name
       type: string
-      description: "Must match ^feature/flowker-template-[a-z][a-z0-9-]{0,19}$"
+      description: "Must match ^feature/flowker-template-[a-z][a-z0-9-]+$ (literal template_id, unbounded length)"
     - name: pr_url
       type: string
       description: "https://github.com/LerianStudio/flowker/pull/<number>"
@@ -288,6 +288,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	executorpkg "github.com/LerianStudio/flowker/pkg/executor"
+	"github.com/LerianStudio/flowker/pkg/model"
 	{{template_id_snake}} "github.com/LerianStudio/flowker/pkg/templates/{{template_id_snake}}"
 )
 


### PR DESCRIPTION
## Summary

- **New plugin `ring-flowker-team`** targeting [github.com/LerianStudio/flowker](https://github.com/LerianStudio/flowker) — automates the creation of catalog entries (providers, templates) that today are manual boilerplate.
- **2 gate-based skills** that orchestrate `ring:backend-engineer-golang`, `ring:dev-unit-testing`, and `ring:codereview`:
  - `ring:flowker-new-provider` (7 gates: interview → scaffold → schema → auth/InputBuilder → tests → review → delivery): scaffolds a new static-catalog provider (HTTP external service) with executors, JSON Schema validation, auth wiring, optional custom `InputBuilder`, and `httptest.NewServer`-based unit tests. Includes a fully prescriptive delivery gate (branch `feature/flowker-provider-<id>` → commit `feature(<id>): ...` → PR against `develop`).
  - `ring:flowker-new-template` (6 gates: interview → scaffold → build+schema → tests → review → delivery): scaffolds a new workflow template (pre-built blueprint) with param schema, pure `Build()` emitting `*model.CreateWorkflowInput`, and unit tests covering registration/validation/build. Same prescriptive delivery gate.
- **Trigger creation deliberately excluded.** Adding new trigger types in Flowker today requires architectural refactor (extracting a `TriggerRuntime` abstraction to remove hardcoded `"webhook"` checks from 3+ lifecycle files). Once that refactor lands, a `ring:flowker-new-trigger` skill becomes viable; until then, it would be a skill that can't honestly promise determinism.

## Why this plugin

Flowker provider/template creation today is pure boilerplate: new directory under `pkg/executors/<name>/` or `pkg/templates/<name>/`, Register function, JSON Schema constants, patch `register.go`, write tests matching an established pattern. The pattern is so deterministic that 60-70% is pure codegen and 30-40% is judgment (schema fields, auth translation, Build-function node graph). These two skills encode the pattern plus explicit file:line references to the interfaces that must be satisfied.

## Files changed

| Path | Change |
|------|--------|
| `flowker-team/CHANGELOG.md` | New — 0.1.0 initial release notes |
| `flowker-team/skills/flowker-new-provider/SKILL.md` | New — 7-gate provider scaffold skill |
| `flowker-team/skills/flowker-new-template/SKILL.md` | New — 6-gate template scaffold skill |
| `.claude-plugin/marketplace.json` | Register `ring-flowker-team` plugin, bump marketplace version 0.334.0 → 0.335.0 |
| `README.md` | Plugin count 6→7, skill count 95→97, new plugin section, architecture tree entry |

## Skill structure

Both skills follow the Ring gated-skill format (same YAML frontmatter schema as `ring:dev-unit-testing`):

- YAML frontmatter: `name`, `description`, `trigger`, `skip_when`, `NOT_skip_when`, `sequence`, `related`, `input_schema`, `output_schema`, `verification`
- Sections: Overview, Prerequisites, Key Interfaces (file:line), Gate 0 Interview, Gates 1-N (including prescriptive Delivery), Verification Commands, Anti-Patterns, Pressure Resistance, Example walkthrough, Handoff

Skills are inline-only (per Ring convention — no `templates/`, `reference/`, or `examples/` subdirectories). Code templates are fenced code blocks inside each `SKILL.md`.

## Delivery gate (prescriptive)

Both skills include a fully prescriptive delivery gate with zero interpretation room:
- **Branch pattern (fixed):** `feature/flowker-provider-<provider_id>` / `feature/flowker-template-<template_id>`
- **Base branch:** `develop` (Flowker gitflow — never `main`)
- **Commit format:** enforced by Flowker's commit-msg hook regex (`type=feature`, `scope ≤ 20 chars`, `description ≤ 100 chars`)
- **PR body template:** with required Summary, Files, Test plan, Scope note, Out-of-scope sections
- **Out of scope (explicit):** merging PR, release PR (`develop → main`), seeding runtime data, modifying bootstrap/env vars

## Test plan

- [x] Skill frontmatter validates against Ring's canonical schema (compared with `dev-team/skills/dev-unit-testing/SKILL.md`)
- [x] `marketplace.json` loads: plugin entry parses, version bumped
- [x] README renders cleanly on GitHub (7 plugins, 97 skills, new section visible)
- [ ] End-to-end test with `ring:testing-skills-with-subagents`:
  - [ ] Run a RED scenario (ask subagent to add a provider without skill) → observe missed `register.go` patch or missing tests
  - [ ] Run GREEN scenario (same task, skill available) → verify full checklist completed
- [ ] Manual walkthrough: run `ring:flowker-new-provider` against Flowker repo with a fictional "stripe" provider, verify `go test ./pkg/executors/stripe/...` passes

## Dependencies

This plugin depends on `ring-dev-team` (for `ring:backend-engineer-golang`, `ring:dev-unit-testing`) and `ring-default` (for `ring:codereview`, `ring:interview-me`). Installation guidance is documented in the skill frontmatter (`related.complementary`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)