### PR TITLE
fix(dev-team): make standards-workflow.md accessible via FetchUrl

### DIFF
--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -250,7 +250,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the index.md above first, then load required modules based on task type.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -414,7 +420,7 @@ I have loaded golang.md standards via WebFetch.
 
 **If this acknowledgment is missing → Implementation is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## MANDATORY Instrumentation (NON-NEGOTIABLE)
 
@@ -547,7 +553,7 @@ I have loaded golang.md standards via WebFetch.
 
 **⛔ If this acknowledgment is missing for new projects → Implementation is INVALID and REJECTED.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Application Type Detection (MANDATORY)
 
@@ -728,7 +734,7 @@ ok      myapp/auth    0.015s
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/backend-engineer-typescript.md
+++ b/dev-team/agents/backend-engineer-typescript.md
@@ -338,7 +338,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any implementation work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -469,7 +475,7 @@ I have loaded typescript.md standards via WebFetch.
 
 **If this acknowledgment is missing → Implementation is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## MANDATORY Instrumentation (NON-NEGOTIABLE)
 
@@ -594,7 +600,7 @@ I have loaded typescript.md standards via WebFetch.
 
 **⛔ If this acknowledgment is missing for new projects → Implementation is INVALID and REJECTED.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ### TypeScript Standards Verification (HARD GATE)
 
@@ -750,7 +756,7 @@ Test Suites: 1 passed, 1 total
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/devops-engineer.md
+++ b/dev-team/agents/devops-engineer.md
@@ -223,7 +223,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any implementation work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -348,11 +354,11 @@ I have loaded devops.md standards via WebFetch.
 
 **If this acknowledgment is missing → Implementation is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/frontend-bff-engineer-typescript.md
+++ b/dev-team/agents/frontend-bff-engineer-typescript.md
@@ -456,7 +456,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any implementation work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -621,7 +627,7 @@ I have loaded typescript.md standards via WebFetch.
 
 **If this acknowledgment is missing → Implementation is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Architecture Patterns
 
@@ -802,7 +808,7 @@ Test Suites: 1 passed, 1 total
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/frontend-designer.md
+++ b/dev-team/agents/frontend-designer.md
@@ -876,7 +876,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any design work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -1010,7 +1016,7 @@ I have loaded frontend.md standards via WebFetch.
 
 **If this acknowledgment is missing → Specification is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Anti-Patterns (Never Do These)
 
@@ -1029,7 +1035,7 @@ See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/frontend-engineer.md
+++ b/dev-team/agents/frontend-engineer.md
@@ -157,7 +157,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any implementation work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -355,7 +361,7 @@ I have loaded frontend.md standards via WebFetch.
 
 **If this acknowledgment is missing → Implementation is INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Project Standards Integration
 
@@ -816,7 +822,7 @@ You have deep expertise in accessibility. Apply WCAG 2.1 AA standards.
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/helm-engineer.md
+++ b/dev-team/agents/helm-engineer.md
@@ -113,7 +113,13 @@ MUST WebFetch the index above before any implementation work. Index contains URL
 - **worker-patterns.md** — Dual-mode KEDA/Deployment
 - **compliance.md** — Standards compliance output format
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules

--- a/dev-team/agents/qa-analyst-frontend.md
+++ b/dev-team/agents/qa-analyst-frontend.md
@@ -312,7 +312,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 WebFetch the URL above before any testing work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -1374,11 +1380,11 @@ I have loaded frontend.md standards via WebFetch.
 
 **If this acknowledgment is missing, tests are INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/qa-analyst.md
+++ b/dev-team/agents/qa-analyst.md
@@ -482,7 +482,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 WebFetch the appropriate URL based on project language before any test work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
@@ -1073,11 +1079,11 @@ I have loaded [golang.md|typescript.md] standards via WebFetch.
 
 **If this acknowledgment is missing → Tests are INVALID.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+Refer to standards-workflow.md (loaded via WebFetch above) for complete loading process.
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/sre.md
+++ b/dev-team/agents/sre.md
@@ -163,7 +163,11 @@ I will search for all patterns above using Grep tool.
 **Result:** ❌ FAIL - N FORBIDDEN patterns found
 ```
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for complete loading process.
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
 
 **OUT OF SCOPE - Do not validate:**
 
@@ -325,7 +329,7 @@ See [shared-patterns/standards-compliance-detection.md](../skills/shared-pattern
 
 **⛔ CRITICAL: You CANNOT proceed without successfully loading standards via WebFetch.**
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - **If WebFetch fails → STOP IMMEDIATELY** (see workflow for error format)
@@ -403,7 +407,7 @@ _After rendering: if no row has Decision = "PROJECT_RULES (override)", append "N
 ```
 
 <gate>
-**Precedence Rules:** See [standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for Ring vs PROJECT_RULES precedence semantics.
+**Precedence Rules:** Refer to standards-workflow.md (loaded via WebFetch above) for Ring vs PROJECT_RULES precedence semantics.
 
 STOP and ask user when neither Ring nor PROJECT_RULES covers the topic.
 </gate>
@@ -412,7 +416,7 @@ STOP and ask user when neither Ring nor PROJECT_RULES covers the topic.
 
 ## Handling Ambiguous Requirements
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+Refer to standards-workflow.md (loaded via WebFetch above) for:
 
 - Missing PROJECT_RULES.md handling (HARD BLOCK)
 - Non-compliant existing code handling

--- a/dev-team/agents/ui-engineer.md
+++ b/dev-team/agents/ui-engineer.md
@@ -99,7 +99,13 @@ https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards
 
 MUST WebFetch the URL above before any implementation work.
 
-See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
+<fetch_required>
+https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
+</fetch_required>
+
+MUST WebFetch the standards-workflow.md above. It defines the full loading process (PROJECT_RULES.md + WebFetch), precedence rules, missing/non-compliant handling, and anti-rationalization table.
+
+This covers:
 - Full loading process (PROJECT_RULES.md + WebFetch)
 - Precedence rules
 - Missing/non-compliant handling


### PR DESCRIPTION
## Problem

All 11 dev-team agents reference `standards-workflow.md` via relative markdown links:

```markdown
See [shared-patterns/standards-workflow.md](../skills/shared-patterns/standards-workflow.md) for:
- Full loading process (PROJECT_RULES.md + WebFetch)
- Precedence rules
- Missing/non-compliant handling
```

**These links are unreachable at runtime** through all three installation methods:

1. **Symlinks (`install-symlinks.sh`)**: The `link_skills()` function explicitly skips `shared-patterns/` directories (`[[ "$name" == "shared-patterns" ]] && continue`)
2. **Plugin install (`install-ring.sh`)**: Agents are installed as flat `.md` files where relative paths do not resolve
3. **Factory install**: Same as plugin — agents land in `~/.factory/droids/` as standalone files

**Impact**: The `standards-workflow.md` file contains critical enforcement logic — precedence rules between Ring Standards and `PROJECT_RULES.md`, hard block scenarios, and anti-rationalization tables — but this content **never enters the agent context window**. Agents see the instruction to load it but cannot follow the link.

This was identified as the root cause for agents not consistently following `PROJECT_RULES.md` during dev-cycle execution.

## Solution

Replace broken relative markdown links with `<fetch_required>` tags using the raw GitHub URL — the **same pattern** already used for `golang.md`, `typescript.md`, `frontend.md`, and other standards files.

**First occurrence** in each agent gets a full `<fetch_required>` block:
```markdown
<fetch_required>
https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/shared-patterns/standards-workflow.md
</fetch_required>

MUST WebFetch the standards-workflow.md above. It defines the full loading process...
```

**Subsequent occurrences** become short back-references:
```markdown
Refer to standards-workflow.md (loaded via WebFetch above) for:
```

## Files Changed

11 agent files in `dev-team/agents/`:

| Agent | Refs Fixed |
|-------|-----------|
| `backend-engineer-golang.md` | 4 |
| `backend-engineer-typescript.md` | 4 |
| `sre.md` | 4 |
| `devops-engineer.md` | 3 |
| `frontend-bff-engineer-typescript.md` | 3 |
| `frontend-designer.md` | 3 |
| `frontend-engineer.md` | 3 |
| `qa-analyst-frontend.md` | 3 |
| `qa-analyst.md` | 3 |
| `helm-engineer.md` | 1 |
| `ui-engineer.md` | 1 |

## Out of Scope

- No changes to `standards-workflow.md` content itself
- No changes to `install-symlinks.sh` (the `shared-patterns` skip is intentional)
- No changes to skills or orchestrator files (only agents that generate code)