### PR TITLE
chore: replace pinned lib-commons v5.0.2 refs with dynamic latest-v5 resolution

### DIFF
--- a/default/skills/production-readiness-audit/SKILL.md
+++ b/default/skills/production-readiness-audit/SKILL.md
@@ -52,7 +52,7 @@ Use this skill when:
 | 3 | **Route Organization** | Hexagonal structure, handler construction, route registration |
 | 4 | **Bootstrap & Initialization** | Staged startup, cleanup handlers, graceful shutdown |
 | 5 | **Runtime Safety** | Panic recovery, production mode handling |
-| 28 | **Core Dependencies & Frameworks** | lib-commons v5, framework version minimums, no custom utility duplication |
+| 28 | **Core Dependencies & Frameworks** | lib-commons latest v5.x, framework version minimums, no custom utility duplication |
 | 29 | **Naming Conventions** | snake_case DB, camelCase JSON body, snake_case query params |
 | 30 | **Domain Modeling** | ToEntity/FromEntity, always-valid constructors, private fields + getters |
 | 35 | **Nil/Null Safety** | Type assertions, nil map/pointer/channel, null guards, API response consistency |
@@ -2916,7 +2916,7 @@ module github.com/company/project
 go 1.24
 
 require (
-    github.com/LerianStudio/lib-commons/v5 v5.0.2   // lib-commons present
+    github.com/LerianStudio/lib-commons/v5 v5.x.y   // lib-commons present (resolve latest v5.x tag)
     github.com/gofiber/fiber/v2 v2.52.x               // Fiber v2
     gorm.io/gorm v1.25.x                              // GORM
     github.com/go-playground/validator/v10 v10.x.x     // Validator

--- a/dev-team/agents/backend-engineer-golang.md
+++ b/dev-team/agents/backend-engineer-golang.md
@@ -228,7 +228,7 @@ See [shared-patterns/standards-compliance-detection.md](../skills/shared-pattern
 
 **Example sections from golang.md to check:**
 
-- Core Dependency (lib-commons v5)
+- Core Dependency (lib-commons latest v5.x)
 - Configuration Loading
 - Logger Initialization
 - Telemetry/OpenTelemetry

--- a/dev-team/agents/lib-commons-reviewer.md
+++ b/dev-team/agents/lib-commons-reviewer.md
@@ -514,8 +514,8 @@ Use the core output schema from [reviewer-output-schema-core.md](../../default/s
 **Recommendation:** [Specific fix]
 
 ### Version Consistency
-- `go.mod` version: `github.com/LerianStudio/lib-commons/v5 v5.0.2`
-- Organizational target: [from WebFetched skill frontmatter]
+- `go.mod` version: `github.com/LerianStudio/lib-commons/v5 <actual pinned version>`
+- Organizational target: latest v5.x (resolve via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`)
 - `replace` directives: [none / listed with severity]
 - Patch lag: [acceptable / flagged]
 
@@ -588,11 +588,11 @@ Diff reinvents connection-retry logic and uses deprecated v4 dispatch layer cont
 #### Deviation: dispatch layer/core.ContextWithTenantPG at internal/repo/account.go:45
 **Expected:** `tmcore.ContextWithPG(ctx, pg)` (v4.6.0+ variadic API)
 **Actual:** `tmcore.ContextWithTenantPG(ctx, pg)` (pre-v4.6.0, removed in v5)
-**Severity:** CRITICAL — will not compile on v5.0.2
+**Severity:** CRITICAL — will not compile on latest v5.x
 **Recommendation:** Replace with `tmcore.ContextWithPG(ctx, pg)`. For multi-module, use `tmcore.ContextWithPG(ctx, pg, "moduleName")`.
 
 ### Version Consistency
-- `go.mod` version: `github.com/LerianStudio/lib-commons/v5 v5.0.2` — MATCHES target
+- `go.mod` version: `github.com/LerianStudio/lib-commons/v5 <resolved latest v5.x>` — MATCHES target
 - No `replace` directives — OK
 
 ## Reinvented-Wheel Opportunities
@@ -640,7 +640,7 @@ Review failed: one deprecated API + two reinvented wheels. Skill loaded via WebF
 | Skill Loaded | PASS | Cache-miss → WebFetched `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/using-lib-commons/SKILL.md` |
 | API Usage Correctness | FAIL | `ContextWithTenantPG` is pre-v4.6.0 API |
 | Deprecated-API Freedom | FAIL | 1 deprecated API in `internal/repo/account.go:45` |
-| Version Consistency | PASS | `v5.0.2` matches target |
+| Version Consistency | PASS | `<resolved version>` matches latest v5.x target |
 | Opportunity Coverage | PASS | 2 opportunities detected (retry loop, bare goroutine) |
 | Initialization Order | PASS | Init sequence correct |
 | Financial-Path Escalation | PASS | Bare goroutine in financial path escalated to HIGH |

--- a/dev-team/agents/lib-commons-reviewer.md
+++ b/dev-team/agents/lib-commons-reviewer.md
@@ -67,6 +67,13 @@ The authoritative source of truth for lib-commons packages, APIs, and patterns i
 https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/skills/using-lib-commons/SKILL.md
 ```
 
+**Version Resolution:** Always resolve the actual latest v5.x tag at runtime using:
+```bash
+gh api repos/LerianStudio/lib-commons/releases/latest --jq '.tag_name'
+# or
+git ls-remote --tags https://github.com/LerianStudio/lib-commons.git 'v5.*' | sort -V | tail -1
+```
+
 **Resolution protocol (MUST follow in this order):**
 
 1. **Cache hit.** If the dispatch prompt contains a `<standards>` block with a `<standard>` entry whose `url` matches the URL above and whose `<content>` is populated, use that content as the authoritative reference. No WebFetch needed.

--- a/dev-team/docs/standards/golang/core.md
+++ b/dev-team/docs/standards/golang/core.md
@@ -31,7 +31,7 @@ This module covers the foundational requirements for all Go projects.
 
 ## Core Dependency: lib-commons (MANDATORY)
 
-All Lerian Studio Go projects **MUST** use `lib-commons/v5` as the foundation library. This ensures consistency across all services.
+All Lerian Studio Go projects **MUST** use the latest v5.x release of `lib-commons/v5` as the foundation library. This ensures consistency across all services.
 
 ### Required Import (lib-commons v5)
 
@@ -1279,7 +1279,7 @@ module github.com/LerianStudio/your-service
 go 1.24
 
 require (
-    github.com/LerianStudio/lib-commons/v5 v5.0.2
+    github.com/LerianStudio/lib-commons/v5 v5.x.y  // use latest v5.x tag
     github.com/gofiber/fiber/v2 v2.52.0
     github.com/jackc/pgx/v5 v5.5.0
 )

--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -108,7 +108,7 @@ Multi-tenant support requires **lib-commons v5** (`github.com/LerianStudio/lib-c
 | **v2** (`lib-commons/v2`) | Not available | N/A — no `dispatch layer` package |
 | **v3** (`lib-commons/v3`) | Legacy | Same sub-packages as v5 but without `dispatch layer/cache`. Upgrade to v5. |
 | **v4** (`lib-commons/v4`) | Legacy | Superseded by v5. Upgrade to v5. |
-| **v5** (`lib-commons/v5`) | Full support (current) | `github.com/LerianStudio/lib-commons/v5/commons/dispatch layer/...` (sub-packages: `core`, `client`, `cache`, `postgres`, `mongo`, `middleware`, `rabbitmq`, `consumer`, `valkey`, `s3`). The `middleware` sub-package contains `TenantMiddleware` with `WithPG`/`WithMB` variadic options that handle both single-module and multi-module services. Route-level composition uses a local `WhenEnabled` helper (not from lib-commons). |
+| **v5** (`lib-commons/v5`) | Full support (check latest tag) | `github.com/LerianStudio/lib-commons/v5/commons/dispatch layer/...` (sub-packages: `core`, `client`, `cache`, `postgres`, `mongo`, `middleware`, `rabbitmq`, `consumer`, `valkey`, `s3`). The `middleware` sub-package contains `TenantMiddleware` with `WithPG`/`WithMB` variadic options that handle both single-module and multi-module services. Route-level composition uses a local `WhenEnabled` helper (not from lib-commons). |
 
 **Migration to v5:**
 
@@ -123,7 +123,7 @@ Services on lib-commons v2, v3, or v4 MUST upgrade to v5 before implementing mul
 git ls-remote --tags https://github.com/LerianStudio/lib-commons.git | grep "v5" | sort -V | tail -1
 
 # Update go.mod
-go get github.com/LerianStudio/lib-commons/v5@v5.0.2
+go get github.com/LerianStudio/lib-commons/v5@latest
 
 # Update import paths across the codebase (portable — works on macOS and Linux)
 # From v2:

--- a/dev-team/skills/dev-systemplane-migration/SKILL.md
+++ b/dev-team/skills/dev-systemplane-migration/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ring:dev-systemplane-migration
 description: |
-  Systemplane migration orchestrator for Lerian Go services using lib-commons v5. Migrates services from
+  Systemplane migration orchestrator for Lerian Go services using lib-commons (latest v5.x). Migrates services from
   .env/YAML-based configuration of operational knobs (log levels, feature flags, rate limits, timeouts,
   worker intervals) to the v5 systemplane runtime config client — a database-backed, hot-reloadable plane
   using Postgres LISTEN/NOTIFY or MongoDB change streams. v5 API surface: systemplane.NewPostgres /
   NewMongoDB → Register keys → Start → Get*/OnChange → admin.Mount with custom authorizer. Detects v4
   residue (Supervisor, BundleFactory, ApplyBehavior, SYSTEMPLANE_* env vars — all DELETED in v5.0.0) and
-  fails hard until removed. Each implementation gate dispatches ring:backend-engineer-golang. Loads v5
-  systemplane package docs via WebFetch of lib-commons repo commons/systemplane/doc.go.
+  fails hard until removed. Each implementation gate dispatches ring:backend-engineer-golang. Loads latest
+  v5 systemplane package docs via WebFetch of lib-commons repo commons/systemplane/doc.go.
 
 trigger: |
   - User requests systemplane integration for a Go service
@@ -1310,7 +1310,7 @@ Save to `docs/ring-dev-systemplane-migration/current-cycle.json` for resume supp
 ```json
 {
   "cycle": "systemplane-migration",
-  "lib_commons_version": "v5.0.2",
+  "lib_commons_version": "<resolved at runtime via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`>",
   "backend": "postgres",
   "v4_residue_files_pending": 0,
   "keys_registered": 12,

--- a/dev-team/skills/using-assert/SKILL.md
+++ b/dev-team/skills/using-assert/SKILL.md
@@ -12,7 +12,7 @@ description: |
   identifies replacement opportunities with file:line precision, generates tasks compatible
   with ring:dev-cycle for batched fixes.
 
-  Reference Mode: Comprehensive catalog of commons/assert v5.0.2 — full API surface,
+  Reference Mode: Comprehensive catalog of commons/assert (latest v5.x) — full API surface,
   asserter lifecycle, instance method semantics, the complete domain predicate catalog
   (numeric, financial, transaction state machine, network, time), the observability trident
   (log + span event + metric), AssertionError unwrapping, decision tree for

--- a/dev-team/skills/using-assert/SKILL.md
+++ b/dev-team/skills/using-assert/SKILL.md
@@ -134,7 +134,7 @@ MANDATORY steps (orchestrator executes directly):
 
 1. **Read `go.mod`** at the target project root.
    - Extract the line matching `github.com/LerianStudio/lib-commons/vN`.
-   - Capture the exact pinned version (e.g., `v5.0.2`, `v4.2.0`).
+   - Capture the exact pinned version (e.g., `v5.1.0`, `v4.2.0`).
    - If the dependency is absent, STOP and report: "Target is not a lib-commons consumer.
      Assert sweep not applicable."
 
@@ -144,7 +144,7 @@ MANDATORY steps (orchestrator executes directly):
    https://api.github.com/repos/LerianStudio/lib-commons/releases/latest
    ```
 
-   Extract `tag_name` (e.g., `v5.0.2`) and `published_at`.
+   Extract `tag_name` (the latest v5.x release) and `published_at`.
 
 3. **Compare versions** and flag drift:
 
@@ -769,7 +769,7 @@ section even if empty (use "None detected" placeholders).
 | Field                    | Value             |
 | ------------------------ | ----------------- |
 | Pinned version           | <v5.0.0>          |
-| Latest stable            | <v5.0.2>          |
+| Latest stable            | <resolved at runtime> |
 | Drift classification     | <minor-drift>     |
 | Major upgrade required   | <yes / no>        |
 | Module path              | <.../v5>          |
@@ -897,12 +897,12 @@ array of tasks shaped for `ring:dev-cycle` consumption. The format matches what
 [
   {
     "id": "assert-sweep-001",
-    "title": "Upgrade lib-commons from v4.2.0 to v5.0.2",
+    "title": "Upgrade lib-commons from v4.2.0 to latest v5.x",
     "severity": "HIGH",
     "description": "Target service pins github.com/LerianStudio/lib-commons/v4 at v4.2.0. The commons/assert API surface is source-compatible across v4 → v5, but the module path bump requires updating all imports. All recommendations below assume v5 APIs are available. This task MUST complete before any other assert-sweep task lands.",
     "files_affected": ["go.mod", "go.sum", "<all Go files importing lib-commons/v4>"],
     "acceptance_criteria": [
-      "go.mod declares github.com/LerianStudio/lib-commons/v5 v5.0.2",
+      "go.mod declares github.com/LerianStudio/lib-commons/v5 at latest v5.x tag",
       "All imports updated from /v4 to /v5",
       "go build ./... passes",
       "go test ./... passes"
@@ -961,8 +961,9 @@ hand-rolled predicates) MUST be addressed before MEDIUM/LOW tiers.
 
 # REFERENCE MODE
 
-Sections 1–14 below catalog the `commons/assert` package at v5.0.2. Read the sections
-relevant to your current task. Sweep Mode explorers receive extracts from these sections
+Sections 1–14 below catalog the `commons/assert` package (latest v5.x). Resolve the
+actual version at runtime via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`.
+Read the sections relevant to your current task. Sweep Mode explorers receive extracts from these sections
 as context for their angle.
 
 ## 1. API Surface
@@ -1910,17 +1911,17 @@ tight loops, request handlers, and message consumers.
 
 ## 14. Breaking Changes
 
-### v4.x → v5.0.2 (commons/assert)
+### v4.x → v5.x (commons/assert)
 
-No API-breaking changes in `commons/assert` across v4.2.0 → v5.0.2. All method
+No API-breaking changes in `commons/assert` across v4.2.0 → v5.x. All method
 signatures, predicate signatures, and error types are source-compatible.
 
 The module path bump from `github.com/LerianStudio/lib-commons/v4/...` to
 `github.com/LerianStudio/lib-commons/v5/...` applies. See `ring:using-lib-commons`
 Section 15 for the full module-bump migration checklist.
 
-### v5.0.1 / v5.0.2
+### v5.0.1+
 
-Patch releases — no API changes to `commons/assert`.
+Patch releases — no API changes to `commons/assert`. Check the latest v5.x tag for current patch level.
 
 ---

--- a/dev-team/skills/using-dev-team/SKILL.md
+++ b/dev-team/skills/using-dev-team/SKILL.md
@@ -323,7 +323,7 @@ Remember:
 - ring:dev-dep-security-check (Audits dependency installations before execution)
 - ring:dev-llms-txt (Generates/audits llms.txt files per llmstxt.org spec)
 - ring:dev-licensing (Apply or switch license: Apache 2.0, Elastic v2, or Lerian Proprietary - updates LICENSE, SPDX headers, source files)
-- ring:using-lib-commons (Reference for lib-commons v5.0.2, Lerian shared Go library)
+- ring:using-lib-commons (Reference for lib-commons latest v5.x, Lerian shared Go library)
 - ring:using-runtime (Deep reference + 6-angle audit for commons/runtime: panic recovery, SafeGo, observability trident)
 - ring:using-assert (Deep reference + 6-angle audit for commons/assert: domain predicates, financial invariants, AssertionError patterns)
 

--- a/dev-team/skills/using-dev-team/SKILL.md
+++ b/dev-team/skills/using-dev-team/SKILL.md
@@ -23,6 +23,15 @@ skip_when: |
 
 related:
   similar: [ring:using-ring]
+
+## Runtime Version Resolution
+
+**IMPORTANT:** Always resolve lib-commons to the latest v5.x tag at runtime:
+```bash
+gh api repos/LerianStudio/lib-commons/releases/latest --jq '.tag_name'
+```
+
+Do NOT hardcode specific patch versions (v5.0.2, etc). This ensures your work uses the most current lib-commons features and fixes.
 ---
 
 # Using Ring Developer Specialists

--- a/dev-team/skills/using-lib-commons/SKILL.md
+++ b/dev-team/skills/using-lib-commons/SKILL.md
@@ -128,7 +128,7 @@ MANDATORY steps (orchestrator executes directly):
 1. **Read `go.mod`** at the target project root.
    - Extract the line matching `github.com/LerianStudio/lib-commons/vN` (or the
      unversioned module path if pre-v2).
-   - Capture the exact pinned version (e.g., `v5.0.2`, `v4.2.0`).
+   - Capture the exact pinned version (e.g., `v5.1.0`, `v4.2.0`).
    - If the dependency is absent, STOP and report: "Target is not a lib-commons consumer.
      Sweep not applicable."
 
@@ -138,7 +138,7 @@ MANDATORY steps (orchestrator executes directly):
    https://api.github.com/repos/LerianStudio/lib-commons/releases/latest
    ```
 
-   Extract `tag_name` (e.g., `v5.0.2`) and `published_at`.
+   Extract `tag_name` (the latest v5.x release) and `published_at`.
 
 3. **Compare versions** and flag drift:
 
@@ -1504,7 +1504,7 @@ section even if empty (use "None detected" placeholders).
 | Field                    | Value             |
 | ------------------------ | ----------------- |
 | Pinned version           | <v5.0.0>          |
-| Latest stable            | <v5.0.2>          |
+| Latest stable            | <resolved at runtime> |
 | Drift classification     | <minor-drift>     |
 | Major upgrade required   | <yes / no>        |
 | Module path              | <.../v5>          |
@@ -1628,12 +1628,12 @@ array of tasks shaped for `ring:dev-cycle` consumption. The format matches what
 [
   {
     "id": "libcommons-sweep-001",
-    "title": "Upgrade lib-commons from v4.2.0 to v5.0.2",
+    "title": "Upgrade lib-commons from v4.2.0 to latest v5.x",
     "severity": "HIGH",
-    "description": "Target service pins github.com/LerianStudio/lib-commons/v4 at v4.2.0. Latest stable is v5.0.2. Module path changes to v5 require go.mod update and import path rewrites. v5 introduces commons/webhook, commons/dlq, commons/certificate.Rotate, and tenant-manager subsystem — all unavailable in v4. This task MUST complete before any other sweep task lands (all recommendations below assume v5 APIs).",
+    "description": "Target service pins github.com/LerianStudio/lib-commons/v4 at v4.2.0. Resolve latest v5.x tag via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`. Module path changes to v5 require go.mod update and import path rewrites. v5 introduces commons/webhook, commons/dlq, commons/certificate.Rotate, and tenant-manager subsystem — all unavailable in v4. This task MUST complete before any other sweep task lands (all recommendations below assume v5 APIs).",
     "files_affected": ["go.mod", "go.sum", "<all Go files importing lib-commons>"],
     "acceptance_criteria": [
-      "go.mod declares github.com/LerianStudio/lib-commons/v5 v5.0.2",
+      "go.mod declares github.com/LerianStudio/lib-commons/v5 at latest v5.x tag",
       "All imports updated from /v4 to /v5",
       "go build ./... passes",
       "go test ./... passes",
@@ -1677,8 +1677,8 @@ before the HIGH/MEDIUM/LOW tier.
 
 # REFERENCE MODE
 
-Sections 1–15 below catalog lib-commons v5.0.2 packages, APIs, and initialization
-patterns. Read the sections relevant to your current task. Sweep Mode explorers receive
+Sections 1–15 below catalog lib-commons latest v5.x packages, APIs, and initialization
+patterns. Resolve the actual latest version at runtime via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`. Read the sections relevant to your current task. Sweep Mode explorers receive
 extracts from these sections as context for their angle.
 
 ## 1. Package Catalog (Quick Reference)
@@ -3521,7 +3521,7 @@ Patch release — no API changes. Internal test improvements and minor fixes.
 
 | Change | Migration |
 |---|---|
-| **Go module major version bump** | Replace all `github.com/LerianStudio/lib-commons/v4/...` imports with `github.com/LerianStudio/lib-commons/v5/...`. Update `go.mod` to require `v5.0.2` (or latest). Run `go mod tidy`. |
+| **Go module major version bump** | Replace all `github.com/LerianStudio/lib-commons/v4/...` imports with `github.com/LerianStudio/lib-commons/v5/...`. Update `go.mod` to require the latest v5.x tag (resolve via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`). Run `go mod tidy`. |
 | **Minimum Go version** | Now `go 1.25` — update your service's `go.mod` if it was on an older Go toolchain. |
 
 #### New Packages

--- a/dev-team/skills/using-lib-commons/SKILL.md
+++ b/dev-team/skills/using-lib-commons/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ring:using-lib-commons
 description: |
-  Dual-mode skill for github.com/LerianStudio/lib-commons v5.0.2 — Lerian's shared Go library.
+  Dual-mode skill for github.com/LerianStudio/lib-commons — latest v5.x release. Lerian's shared Go library.
 
   Sweep Mode (primary): Dispatches 22 parallel explorer subagents to sweep any Lerian Go
   codebase for DIY implementations that should use lib-commons. Detects version drift,
   identifies replacement opportunities with file:line precision, generates tasks compatible
   with ring:dev-cycle for batched fixes.
 
-  Reference Mode: Comprehensive catalog of lib-commons v5.0.2 packages — database
+  Reference Mode: Comprehensive catalog of lib-commons (latest v5.x) packages — database
   connections, messaging, multi-tenancy, observability, security, resilience, HTTP tooling,
   event-driven tenant discovery, webhook delivery, dead-letter queues, idempotency, TLS
   certificate management. Load for API discovery and initialization patterns.
@@ -91,7 +91,7 @@ relevant catalog entries for its angle so it knows the target API surface.
 | 12| Root Package & Utilities         | Reference | App lifecycle, context helpers, business errors, UUID, env vars           |
 | 13| Cross-Cutting Patterns           | Reference | Patterns shared across all packages                                       |
 | 14| Which Package Do I Need?         | Reference | Decision tree for package selection                                       |
-| 15| Breaking Changes                 | Reference | Migration notes for v4.2.0 through v5.0.2                                 |
+| 15| Breaking Changes                 | Reference | Migration notes from v4.2.0 through latest v5.x                          |
 
 ---
 

--- a/dev-team/skills/using-runtime/SKILL.md
+++ b/dev-team/skills/using-runtime/SKILL.md
@@ -140,7 +140,7 @@ MANDATORY steps (orchestrator executes directly):
 1. **Read `go.mod`** at the target project root.
    - Extract the line matching `github.com/LerianStudio/lib-commons/vN` (or the
      unversioned module path if pre-v2).
-   - Capture the exact pinned version (e.g., `v5.0.2`, `v4.2.0`).
+   - Capture the exact pinned version (e.g., `v5.1.0`, `v4.2.0`).
    - If the dependency is absent, STOP and report: "Target is not a lib-commons consumer.
      Sweep not applicable."
 
@@ -150,7 +150,7 @@ MANDATORY steps (orchestrator executes directly):
    https://api.github.com/repos/LerianStudio/lib-commons/releases/latest
    ```
 
-   Extract `tag_name` (e.g., `v5.0.2`) and `published_at`.
+   Extract `tag_name` (the latest v5.x release) and `published_at`.
 
 3. **Compare versions** and flag drift:
 
@@ -721,7 +721,7 @@ section even if empty (use "None detected" placeholders).
 | Field                    | Value             |
 | ------------------------ | ----------------- |
 | Pinned version           | <v5.0.0>          |
-| Latest stable            | <v5.0.2>          |
+| Latest stable            | <resolved at runtime> |
 | Drift classification     | <minor-drift>     |
 | Major upgrade required   | <yes / no>        |
 | Module path              | <.../v5>          |
@@ -912,7 +912,7 @@ explorers receive extracts from these sections as context for their angle.
 
 ## 1. API Surface
 
-Full catalog of exported symbols in `commons/runtime` (lib-commons v5.0.2).
+Full catalog of exported symbols in `commons/runtime` (lib-commons latest v5.x).
 
 ### Goroutine Launchers
 
@@ -1603,7 +1603,7 @@ in recovered panics because the underlying code is drifting from its invariants.
 
 ## 9. Breaking Changes
 
-No API-breaking changes in `commons/runtime` across v4.2.0 → v5.0.2. The Go module
+No API-breaking changes in `commons/runtime` across v4.2.0 → v5.x. The Go module
 major-version bump v4 → v5 applies — imports change from
 `github.com/LerianStudio/lib-commons/v4/commons/runtime` to
 `github.com/LerianStudio/lib-commons/v5/commons/runtime`, but function signatures,

--- a/dev-team/skills/using-runtime/SKILL.md
+++ b/dev-team/skills/using-runtime/SKILL.md
@@ -2,7 +2,7 @@
 name: ring:using-runtime
 description: |
   Dual-mode skill for commons/runtime — the panic observability trident inside
-  github.com/LerianStudio/lib-commons v5. Deep-dive companion to ring:using-lib-commons,
+  github.com/LerianStudio/lib-commons (latest v5.x). Deep-dive companion to ring:using-lib-commons,
   scoped entirely to the one package that turns silent goroutine deaths into
   observable production signal.
 

--- a/platforms/opencode/standards/golang.md
+++ b/platforms/opencode/standards/golang.md
@@ -54,7 +54,7 @@ This file defines the specific standards for Go development at Lerian Studio.
 
 ## Core Dependency: lib-commons (MANDATORY)
 
-All Lerian Studio Go projects **MUST** use `lib-commons/v5` as the foundation library. This ensures consistency across all services.
+All Lerian Studio Go projects **MUST** use the latest v5.x release of `lib-commons/v5` as the foundation library. This ensures consistency across all services. Resolve the actual latest tag using `gh api repos/LerianStudio/lib-commons/releases/latest --jq '.tag_name'` instead of hardcoding specific patch versions.
 
 ### Required Import (lib-commons v5)
 

--- a/platforms/opencode/standards/golang.md
+++ b/platforms/opencode/standards/golang.md
@@ -113,7 +113,7 @@ import (
 
 | Library | Minimum Version | Purpose |
 |---------|-----------------|---------|
-| `lib-commons` | v5.0.2 | Core infrastructure |
+| `lib-commons` | latest v5.x (resolve via `gh api repos/LerianStudio/lib-commons/releases/latest --jq .tag_name`) | Core infrastructure |
 | `fiber/v2` | v2.52.0 | HTTP framework |
 | `pgx/v5` | v5.7.0 | PostgreSQL driver |
 | `go.opentelemetry.io/otel` | v1.42.0 | Telemetry |


### PR DESCRIPTION
## Summary

All skills, agents, and standards docs now reference **latest v5.x** instead of hardcoding v5.0.2. Agents are instructed to resolve the actual latest tag at runtime.

### What changed
- Version references updated from pinned v5.0.2 to dynamic latest-v5 across 11 files
- Added runtime version resolution instructions where skills check versions
- Go module path (lib-commons/v5) preserved — that is the major version path, not a pin
- v4→v5 migration instructions updated to use latest v5 targets

### Why
Every lib-commons patch release required a Ring bump PR. Now Ring automatically picks up the latest.

### Files modified
- default/skills/production-readiness-audit/SKILL.md
- dev-team/agents/backend-engineer-golang.md
- dev-team/agents/lib-commons-reviewer.md
- dev-team/docs/standards/golang/core.md
- dev-team/docs/standards/golang/multi-tenant.md
- dev-team/skills/dev-systemplane-migration/SKILL.md
- dev-team/skills/using-assert/SKILL.md
- dev-team/skills/using-dev-team/SKILL.md
- dev-team/skills/using-lib-commons/SKILL.md
- dev-team/skills/using-runtime/SKILL.md
- platforms/opencode/standards/golang.md

Requested by: @jeffersonrodrigues92