### PR TITLE
[codex] docs: require plural auth resources

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "ring-default",
       "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. Features parallel code review orchestration with 9 default reviewers plus triggered conditional specialists. 16 essential skills for software engineering excellence, including plan authoring and execution.",
-      "version": "1.33.2",
+      "version": "1.33.1",
       "source": "./default",
       "homepage": "https://github.com/lerianstudio/ring/tree/main/default",
       "repository": "https://github.com/lerianstudio/ring/tree/main/default",
@@ -30,7 +30,7 @@
     {
       "name": "ring-dev-team",
       "description": "24 specialized developer agents + 33 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
-      "version": "1.72.2",
+      "version": "1.72.1",
       "source": "./dev-team",
       "homepage": "https://github.com/lerianstudio/ring/tree/main/dev-team",
       "repository": "https://github.com/lerianstudio/ring/tree/main/dev-team",
@@ -104,5 +104,5 @@
       ]
     }
   ],
-  "version": "0.368.0"
+  "version": "0.367.0"
 }

--- a/default/.codex-plugin/plugin.json
+++ b/default/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-default",
-  "version": "1.33.2",
+  "version": "1.33.1",
   "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. Features parallel code review orchestration with 9 default reviewers plus triggered conditional specialists. 16 essential skills for software engineering excellence, including plan authoring and execution.",
   "author": {
     "name": "Lerian Studio",

--- a/default/.cursor-plugin/plugin.json
+++ b/default/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ring-default",
   "displayName": "Ring Default",
   "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. 16 essential skills for software engineering excellence, including plan authoring and execution.",
-  "version": "1.33.2",
+  "version": "1.33.1",
   "author": {
     "name": "Lerian Studio",
     "email": "fred@lerian.studio"

--- a/default/skills/production-readiness-audit/dimensions/structure.md
+++ b/default/skills/production-readiness-audit/dimensions/structure.md
@@ -96,6 +96,7 @@ return libHTTP.OK(c, pagination)
 ```
 ```
 
+
 ### Agent 2: Error Framework Auditor
 
 ```prompt
@@ -295,13 +296,16 @@ func NewHandler(deps ...interface{}) (*Handler, error) {
 2. (HARD GATE) Centralized route registration per module
 3. Handler constructors validate all dependencies
 4. Consistent URL patterns (v1, kebab-case, plural resources) per Ring conventions
-5. All routes use protected() wrapper (no public endpoints without explicit exemption)
-6. Clear separation: routes.go vs handlers.go per Ring directory structure
+5. Authorization resource names are plural and match the route collection (for example, `/v1/resources` -> `protected("resources", ...)`)
+6. Singular authorization resource names only appear for protected singleton/capability endpoints, with a local comment explaining the exception
+7. All routes use protected() wrapper (no public endpoints without explicit exemption)
+8. Clear separation: routes.go vs handlers.go per Ring directory structure
 
 **Severity Ratings:**
 - CRITICAL: Unprotected routes (missing auth middleware)
 - CRITICAL: HARD GATE violation — project does not follow hexagonal architecture per Ring standards
 - HIGH: Scattered route definitions
+- HIGH: Authorization resource name is singular for a collection route
 - MEDIUM: Handler accepts nil dependencies
 - LOW: Inconsistent URL naming conventions
 

--- a/dev-team/.codex-plugin/plugin.json
+++ b/dev-team/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-dev-team",
-  "version": "1.72.2",
+  "version": "1.72.1",
   "description": "24 specialized developer agents + 33 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists.",
   "author": {
     "name": "Lerian Studio",

--- a/dev-team/.cursor-plugin/plugin.json
+++ b/dev-team/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ring-dev-team",
   "displayName": "Ring Dev Team",
   "description": "24 specialized developer agents + 33 development skills. Backend (Go/TypeScript) and frontend (React/Next.js) dev cycles, DevOps, QA, SRE, and the parallel code-review pool.",
-  "version": "1.72.2",
+  "version": "1.72.1",
   "author": {
     "name": "Lerian Studio",
     "email": "fred@lerian.studio"

--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -1676,7 +1676,7 @@ MULTI_TENANT_ENABLED=true MULTI_TENANT_URL=http://dispatch layer:4003 go test ./
 ```go
 // ❌ WRONG: Tenant middleware runs before auth on ALL routes
 app.Use(tenantMid.WithTenantDB)  // Runs first — calls TM API before auth validates JWT
-app.Post("/v1/resources", auth.Authorize("app", "resource", "post"), handler.Create)
+app.Post("/v1/resources", auth.Authorize("app", "resources", "post"), handler.Create)
 ```
 
 In this pattern, `WithTenantDB` executes for **every request** before `auth.Authorize` validates the JWT. A request with a forged JWT containing `tenantId: "victim-tenant"` triggers a full Tenant Manager resolution — fetching credentials, opening connections — before auth rejects it.
@@ -1706,10 +1706,12 @@ func WhenEnabled(middleware fiber.Handler) fiber.Handler {
 ```go
 // ✅ CORRECT: Auth validates JWT FIRST, then tenant resolves DB
 // ttHandler is nil when MULTI_TENANT_ENABLED=false (single-tenant passthrough)
-f.Post("/v1/resources", auth.Authorize("app", "resource", "post"), WhenEnabled(ttHandler), handler.Create)
-f.Get("/v1/resources", auth.Authorize("app", "resource", "get"), WhenEnabled(ttHandler), handler.GetAll)
-f.Get("/v1/resources/:id", auth.Authorize("app", "resource", "get"), WhenEnabled(ttHandler), handler.GetByID)
+f.Post("/v1/resources", auth.Authorize("app", "resources", "post"), WhenEnabled(ttHandler), handler.Create)
+f.Get("/v1/resources", auth.Authorize("app", "resources", "get"), WhenEnabled(ttHandler), handler.GetAll)
+f.Get("/v1/resources/:id", auth.Authorize("app", "resources", "get"), WhenEnabled(ttHandler), handler.GetByID)
 ```
+
+`auth.Authorize(..., resource, ...)` MUST use the plural resource name that matches the collection route. Singular resources are allowed only for protected singleton/capability endpoints that are not collection routes, and the exception must be documented next to the route.
 
 **How it works:**
 1. `auth.Authorize(...)` is the first handler — validates JWT before anything else

--- a/dev-team/docs/standards/golang/security.md
+++ b/dev-team/docs/standards/golang/security.md
@@ -6,6 +6,7 @@ This module covers authentication, licensing, and secret protection.
 
 ---
 
+
 ## Table of Contents
 
 | # | Section | Description |
@@ -183,7 +184,7 @@ RBAC resource names **MUST** match the stable public route collection when the p
 
 Use singular resource names only for true singleton or non-collection surfaces whose route namespace is also singular, for example `/v1/admin/...` -> `"admin"`.
 
-**Forbidden:** protecting plural collection routes with singular RBAC resources such as `auth.Authorize(applicationName, "payment", "post")` for `POST /v1/payments`.
+**Forbidden:** protecting plural collection routes with singular RBAC resources such as `auth.Authorize(applicationName, "payments", "post")` for `POST /v1/payments`.
 
 ### Middleware Behavior
 
@@ -286,7 +287,10 @@ req.Header.Set("Authorization", "Bearer hardcoded-token-here")  // never
 f.Post("/v1/sensitive-data", handler.Create)  // Missing auth.Authorize
 
 // FORBIDDEN: Using wrong application name
-auth.Authorize("wrong-app-name", "resource", "post")  // Must match identity registration
+auth.Authorize("wrong-app-name", "resources", "post")  // Must match identity registration
+
+// FORBIDDEN: Singular resource for a collection route
+auth.Authorize(applicationName, "payment", "post")  // Route is /v1/payments, resource must be "payments"
 
 // FORBIDDEN: Singular RBAC resource for a plural route collection
 auth.Authorize(applicationName, "package", "post")  // /v1/packages requires "packages"


### PR DESCRIPTION
## What changed
- Require authorization resource names to be plural and match the REST collection route.
- Update Ring examples from `resource` to `resources` where the route is `/v1/resources`.
- Teach the production-readiness route organization audit to flag singular authorization resources on collection routes.

## Exception rule
Singular authorization resources are allowed only for protected singleton or capability endpoints that are not modeled as REST collections. Any exception must be documented next to the route registration and called out in the PR.

## Why
`plugin-br-payments` exposed the gap: routes use plural collections, but RBAC resources can drift to singular names like `payment` or `boleto`, creating mismatches with Access Manager grants.

## Validation
- `git diff --check`
- `rg` check for singular placeholder examples in the touched Ring docs

Requested by: @alexgarzao