### PR TITLE
docs(multi-tenant): add MULTI_TENANT_REDIS_CA_CERT to §28

### DIFF
--- a/default/skills/shared-patterns/consolidated-report-template.md
+++ b/default/skills/shared-patterns/consolidated-report-template.md
@@ -732,6 +732,7 @@ MultiTenantRedisHost                   string `env:"MULTI_TENANT_REDIS_HOST"`
 MultiTenantRedisPort                   string `env:"MULTI_TENANT_REDIS_PORT" default:"6379"`
 MultiTenantRedisPassword               string `env:"MULTI_TENANT_REDIS_PASSWORD"`
 MultiTenantRedisTLS                    bool   `env:"MULTI_TENANT_REDIS_TLS"`
+MultiTenantRedisCACert                 string `env:"MULTI_TENANT_REDIS_CA_CERT"` // OPTIONAL base64-encoded PEM; required when MULTI_TENANT_REDIS_TLS=true and the cluster CA isn't in system trust
 MultiTenantMaxTenantPools              int    `env:"MULTI_TENANT_MAX_TENANT_POOLS" default:"100"`
 MultiTenantIdleTimeoutSec              int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC" default:"300"`
 MultiTenantTimeout                     int    `env:"MULTI_TENANT_TIMEOUT" default:"30"`
@@ -886,7 +887,7 @@ WARNINGS (does not zero the score, but flagged as HIGH):
 5. (WARNING) Non-canonical source implementation files detected: custom tenant resolvers, manual pool managers, or wrapper middleware in source paths (internal/, pkg/, cmd/) outside canonical lib-commons integration paths. Excludes docs, tests, fixtures, vendored code.
 
 Canonical Environment Variables:
-6. APPLICATION_NAME always required (used for Tenant Manager settings resolution regardless of mode). When MULTI_TENANT_ENABLED=true, all 14 MULTI_TENANT_* env vars must also be declared in the config struct with exact names: MULTI_TENANT_ENABLED, MULTI_TENANT_URL, MULTI_TENANT_REDIS_HOST, MULTI_TENANT_REDIS_PORT, MULTI_TENANT_REDIS_PASSWORD, MULTI_TENANT_REDIS_TLS, MULTI_TENANT_MAX_TENANT_POOLS, MULTI_TENANT_IDLE_TIMEOUT_SEC, MULTI_TENANT_TIMEOUT, MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD, MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC, MULTI_TENANT_SERVICE_API_KEY, MULTI_TENANT_CACHE_TTL_SEC, MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC. Single-tenant mode (MULTI_TENANT_ENABLED=false or absent) must work without any MULTI_TENANT_* vars set.
+6. APPLICATION_NAME always required (used for Tenant Manager settings resolution regardless of mode). When MULTI_TENANT_ENABLED=true, all 14 required MULTI_TENANT_* env vars must also be declared in the config struct with exact names: MULTI_TENANT_ENABLED, MULTI_TENANT_URL, MULTI_TENANT_REDIS_HOST, MULTI_TENANT_REDIS_PORT, MULTI_TENANT_REDIS_PASSWORD, MULTI_TENANT_REDIS_TLS, MULTI_TENANT_MAX_TENANT_POOLS, MULTI_TENANT_IDLE_TIMEOUT_SEC, MULTI_TENANT_TIMEOUT, MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD, MULTI_TENANT_CIRCUIT_BREAKER_TIMEOUT_SEC, MULTI_TENANT_SERVICE_API_KEY, MULTI_TENANT_CACHE_TTL_SEC, MULTI_TENANT_CONNECTIONS_CHECK_INTERVAL_SEC. A 15th OPTIONAL env var, MULTI_TENANT_REDIS_CA_CERT (base64-encoded PEM bundle threaded through `TenantPubSubRedisConfig.CACertBase64`), is required when MULTI_TENANT_REDIS_TLS=true AND the tenant Pub/Sub Redis cluster's CA isn't in the runtime image's system trust pool (managed AWS/GCP/Azure issuers, macOS dev workstations) — see multi-tenant.md §28 §`MULTI_TENANT_REDIS_CA_CERT`. Single-tenant mode (MULTI_TENANT_ENABLED=false or absent) must work without any MULTI_TENANT_* vars set.
 7. No non-canonical env var names for tenant configuration (e.g., TENANT_MANAGER_URL, TENANT_ENABLED, MULTI_TENANT_ENVIRONMENT are violations — APPLICATION_NAME is valid)
 
 Middleware & Routing:

--- a/dev-team/agents/lib-systemplane-reviewer.md
+++ b/dev-team/agents/lib-systemplane-reviewer.md
@@ -40,14 +40,18 @@ Include verified standards, sections checked, and violations with file:line evid
 | missing `Close()` in lifecycle owner | shutdown through service lifecycle |
 | tenant ID parsed manually for config read paths | `GetForTenant` / tenant-aware APIs |
 | `SYSTEMPLANE_*`, `Supervisor`, `BundleFactory`, `lib-commons/v4` residue | lib-systemplane client migration |
+| `systemplane.SchemaSQL()` / `DefaultSeedSQL()` at boot, `runSchema` hook, `CREATE TABLE systemplane_entries` outside `migrations/` | `make systemplane-ddl` generator (multi-tenant.md §27 "Cold-tenant resolution") |
+| missing `cmd/generate-systemplane-ddl/`, `migrations/systemplane_ddl_manifest.json`, or `make systemplane-ddl` / `check-systemplane-ddl-drift` while systemplane is wired | scaffold the generator per multi-tenant.md §27 |
+| hand-edited `migrations/NNN_systemplane_*.sql` | re-run `make systemplane-ddl`; the generator is the only writer |
+| bootstrap seam diverges from `SystemplaneSeedEntries() ([]SystemplaneSeedEntry, error)` | align to the canonical signature — the generator depends on it |
 
 ## Severity
 
 | Severity | Examples |
 |----------|----------|
-| **CRITICAL** | v4 systemplane import, silent tenant fallback to global, admin mount without required authorizer, DIY pgx/Mongo config feed. |
-| **HIGH** | Reads before start, missing close, SIGHUP/fsnotify/viper watcher still wired for runtime knobs. |
-| **MEDIUM** | Bootstrap-only setting incorrectly moved to systemplane, missing validator/debounce on mutable numeric knob. |
+| **CRITICAL** | v4 systemplane import, silent tenant fallback to global, admin mount without required authorizer, DIY pgx/Mongo config feed, runtime DDL provisioning (`SchemaSQL()` at boot or `CREATE TABLE systemplane_entries` outside `migrations/`). |
+| **HIGH** | Reads before start, missing close, SIGHUP/fsnotify/viper watcher still wired for runtime knobs, missing `cmd/generate-systemplane-ddl/` + manifest + Make targets while systemplane is wired. |
+| **MEDIUM** | Bootstrap-only setting incorrectly moved to systemplane, missing validator/debounce on mutable numeric knob, hand-edited generated `migrations/NNN_systemplane_*.sql`. |
 | **LOW** | Missing descriptions, namespace naming drift, logger/telemetry option omitted when otherwise available. |
 
 ## Output Format

--- a/dev-team/docs/standards/golang/multi-tenant.md
+++ b/dev-team/docs/standards/golang/multi-tenant.md
@@ -158,6 +158,7 @@ go build ./...
 | `MULTI_TENANT_REDIS_PORT` | Redis port for Pub/Sub | `6379` | If multi-tenant |
 | `MULTI_TENANT_REDIS_PASSWORD` | Redis password for Pub/Sub | - | If multi-tenant |
 | `MULTI_TENANT_REDIS_TLS` | Enable TLS for Pub/Sub Redis connection (AWS ElastiCache/Valkey) | `false` | If multi-tenant |
+| `MULTI_TENANT_REDIS_CA_CERT` | Base64-encoded PEM bundle for the tenant Pub/Sub Redis cluster CA. Threaded through `TenantPubSubRedisConfig.CACertBase64`. Required when `MULTI_TENANT_REDIS_TLS=true` AND the cluster's CA is not in the runtime image's system trust pool (managed AWS/GCP/Azure issuers, macOS dev workstations). See §[`MULTI_TENANT_REDIS_CA_CERT`](#multi_tenant_redis_ca_cert--required-for-tls-enabled-per-tenant-pubsub-redis). | - | No (optional; required when `MULTI_TENANT_REDIS_TLS=true` and CA isn't in system trust) |
 | `MULTI_TENANT_MAX_TENANT_POOLS` | Soft limit for tenant connection pools (LRU eviction) | `100` | No |
 | `MULTI_TENANT_IDLE_TIMEOUT_SEC` | Seconds before idle tenant connection is eviction-eligible | `300` | No |
 | `MULTI_TENANT_TIMEOUT` | HTTP client timeout for dispatch layer API calls (seconds). Passed to `tmclient.WithTimeout`. | `30` | No |
@@ -176,6 +177,7 @@ MULTI_TENANT_REDIS_HOST=redis
 MULTI_TENANT_REDIS_PORT=6379
 MULTI_TENANT_REDIS_PASSWORD=
 MULTI_TENANT_REDIS_TLS=false
+# MULTI_TENANT_REDIS_CA_CERT=  # base64-encoded PEM bundle; set when MULTI_TENANT_REDIS_TLS=true and the cluster CA isn't in system trust
 MULTI_TENANT_MAX_TENANT_POOLS=100
 MULTI_TENANT_IDLE_TIMEOUT_SEC=300
 MULTI_TENANT_TIMEOUT=30
@@ -200,6 +202,7 @@ type Config struct {
     MultiTenantRedisPort                string `env:"MULTI_TENANT_REDIS_PORT" default:"6379"`
     MultiTenantRedisPassword            string `env:"MULTI_TENANT_REDIS_PASSWORD"`
     MultiTenantRedisTLS                 bool   `env:"MULTI_TENANT_REDIS_TLS"`
+    MultiTenantRedisCACert              string `env:"MULTI_TENANT_REDIS_CA_CERT"` // base64-encoded PEM; optional, required when MULTI_TENANT_REDIS_TLS=true and CA isn't in system trust
     MultiTenantMaxTenantPools           int    `env:"MULTI_TENANT_MAX_TENANT_POOLS" default:"100"`
     MultiTenantIdleTimeoutSec           int    `env:"MULTI_TENANT_IDLE_TIMEOUT_SEC" default:"300"`
     MultiTenantTimeout                  int    `env:"MULTI_TENANT_TIMEOUT" default:"30"`
@@ -1593,6 +1596,7 @@ MULTI_TENANT_ENABLED=true MULTI_TENANT_URL=http://dispatch layer:4003 go test ./
 - [ ] `MULTI_TENANT_REDIS_PORT` in config struct (default: `6379`)
 - [ ] `MULTI_TENANT_REDIS_PASSWORD` in config struct
 - [ ] `MULTI_TENANT_REDIS_TLS` in config struct (default: `false`)
+- [ ] `MULTI_TENANT_REDIS_CA_CERT` in config struct (OPTIONAL; required when `MULTI_TENANT_REDIS_TLS=true` and the cluster CA isn't in system trust — see §28)
 - [ ] `MULTI_TENANT_MAX_TENANT_POOLS` in config struct (default: `100`)
 - [ ] `MULTI_TENANT_IDLE_TIMEOUT_SEC` in config struct (default: `300`)
 - [ ] `MULTI_TENANT_CIRCUIT_BREAKER_THRESHOLD` in config struct (default: `5`)
@@ -2932,12 +2936,80 @@ Bootstrap MUST NOT write app keys to the tenant Pub/Sub Redis nor publish app-do
 
 `tenantId` is treated as opaque by every Redis path — the `tenant:{tenantId}:...` prefix is a literal string concatenation. Do **not** parse it as a UUID or any other structured type.
 
+### `MULTI_TENANT_REDIS_CA_CERT` — required for TLS-enabled per-tenant Pub/Sub Redis
+
+**CONDITIONAL:** Applies when `MULTI_TENANT_REDIS_TLS=true` AND the tenant Pub/Sub Redis endpoint is fronted by a managed cloud provider (AWS ElastiCache, AWS MemoryDB, managed Valkey, GCP Memorystore, etc.) whose CA is not in the deployment image's system trust store by default. Pairs with the app-Redis `REDIS_CA_CERT` documented in [[bootstrap.md]] §Config struct.
+
+Empirically reproduced in `plugin-br-bank-transfer` D9 against AWS ElastiCache for Valkey: with `MULTI_TENANT_REDIS_TLS=true` and no CA cert injected, the tenant Pub/Sub client crashes at boot with `tls: failed to verify certificate: x509: "<endpoint>" certificate is not standards compliant`. The same endpoint connects successfully when the cluster's CA bundle is passed in via `TenantPubSubRedisConfig.CACertBase64`. Root cause: Go's macOS-side x509 verifier (Security Framework) returns `errSecCertificateNotStandardsCompliant` for AWS-issued certs when no explicit `RootCAs` pool is set; the pure-Go verifier WITH an explicit `RootCAs` pool accepts the same chain. Linux deployments using the distro CA bundle generally tolerate this, but cross-platform consistency requires the cert to be injected via config rather than relying on the system trust pool.
+
+The contract:
+
+**`MULTI_TENANT_REDIS_CA_CERT` is an OPTIONAL base64-encoded PEM bundle (single-line) that the consumer service MUST thread into `lib-commons/tenant-manager/redis.TenantPubSubRedisConfig.CACertBase64` whenever `MULTI_TENANT_REDIS_TLS=true` and the cluster's CA is not in the runtime image's system trust pool. Mirrors the existing `REDIS_CA_CERT` pattern for app Redis — see [[bootstrap.md]] §Config struct.**
+
+The config-struct addition (next to the existing `MultiTenantRedisTLS` field in §[Configuration](#configuration)):
+
+```go
+MultiTenantRedisTLS    bool   `env:"MULTI_TENANT_REDIS_TLS"`
+MultiTenantRedisCACert string `env:"MULTI_TENANT_REDIS_CA_CERT"` // base64-encoded PEM bundle; OPTIONAL
+```
+
+The wiring site (`initEventDrivenDiscovery` or equivalent — the only bootstrap call that constructs `TenantPubSubRedisConfig`):
+
+```go
+pubSubClient, err := tmredis.NewTenantPubSubRedisClient(ctx, tmredis.TenantPubSubRedisConfig{
+    Host:         cfg.MultiTenantRedisHost,
+    Port:         cfg.MultiTenantRedisPort,
+    Password:     cfg.MultiTenantRedisPassword,
+    TLS:          cfg.MultiTenantRedisTLS,
+    CACertBase64: cfg.MultiTenantRedisCACert, // MUST be threaded through; lib falls back to system trust when empty
+})
+```
+
+**ALWAYS:**
+
+- Set `MULTI_TENANT_REDIS_CA_CERT` whenever `MULTI_TENANT_REDIS_TLS=true` AND the Pub/Sub Redis endpoint is hosted by a managed cloud provider whose CA isn't in the deployment image's system trust by default (AWS ElastiCache/MemoryDB/Valkey, GCP Memorystore, Azure Cache, CloudAMQP-fronted Redis, etc.).
+- Thread `cfg.MultiTenantRedisCACert` directly into `TenantPubSubRedisConfig.CACertBase64` at the wiring site. The lib decodes base64 → PEM → `tls.Config.RootCAs` internally; the consumer MUST NOT decode the bundle itself.
+- Mirror the symmetry with the app-Redis side: services that already set `REDIS_CA_CERT` for `REDIS_HOST` against the same managed provider SHOULD set `MULTI_TENANT_REDIS_CA_CERT` for `MULTI_TENANT_REDIS_HOST` even when the two endpoints share a CA — the env vars are independent contracts.
+
+**NEVER:**
+
+- Assume system trust alone is sufficient on developer macOS workstations. The macOS Security Framework verifier rejects AWS-issued ElastiCache/Valkey certs that the pure-Go verifier with an explicit `RootCAs` pool accepts. Reproducible regression — do not paper over with `InsecureSkipVerify`.
+- Embed `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` markers as raw newlines in `.env`. Makefile env loaders read line-by-line; multi-line PEM blocks corrupt the env var. Base64-encode the **entire** PEM bundle into a single line, or use `\n` escape literals with a Helm-side decoder.
+- Set `InsecureSkipVerify=true` as a "temporary" workaround. The lib does not expose this knob on `TenantPubSubRedisConfig` deliberately — fix the trust path, do not bypass it.
+- Reuse the lib-commons `commons/security/tls` helpers' assumption that a system-trust fallback is operationally acceptable. Tenant Pub/Sub is on the boot-critical path (§Bootstrap initialisation — the ALWAYS / NEVER list below) — a TLS handshake failure here means the event listener never starts and the pod is effectively single-tenant-blind.
+
+**NON-COMPLIANT signs:**
+
+- `tls: failed to verify certificate: x509: "<endpoint>" certificate is not standards compliant` at process startup against a managed Pub/Sub endpoint. The pod will keep restarting until the cert env is set.
+- `MULTI_TENANT_REDIS_TLS=true` declared without a corresponding `MULTI_TENANT_REDIS_CA_CERT` entry in the config struct, `.env.example`, or Helm values, AND the cluster is fronted by a managed cert issuer.
+- `TenantPubSubRedisConfig` constructed without the `CACertBase64` field (zero-value falls back to system trust — acceptable only on Linux deployments where the system CA bundle covers the managed provider).
+- A consumer-side decode of the base64 PEM (`base64.StdEncoding.DecodeString` + `x509.NewCertPool().AppendCertsFromPEM`) instead of passing the raw base64 string through `CACertBase64`. The lib owns decoding; consumer-side decoding is duplicate logic that drifts.
+
+**Reference implementation:**
+
+| File | What it shows |
+|---|---|
+| `plugin-br-bank-transfer/internal/bootstrap/multi_tenant.go::initEventDrivenDiscovery` | Wiring site — `TenantPubSubRedisConfig` constructed with `CACertBase64: cfg.MultiTenantRedisCACert`. |
+| `lib-commons/commons/tenant-manager/redis/client.go::BuildOptions` / `buildTLSConfig` | Lib side — `CACertBase64` decoded into `tls.Config.RootCAs`; empty value leaves `RootCAs` nil and falls back to the system trust pool. |
+| `bootstrap.md` §Config struct (`REDIS_CA_CERT` / `RedisCACert`) | App-Redis precedent for the same pattern; structurally identical contract. |
+
+**Anti-Rationalization:**
+
+| Rationalization | Why It's WRONG | Required Action |
+|---|---|---|
+| "Plain TCP works in `nc host 6379`, so TLS isn't strictly required" | A successful TCP handshake on port 6379 means the listener is reachable — it does NOT mean Redis will accept commands on a plain socket. Managed Pub/Sub clusters typically force TLS at the listener and reject `AUTH`/`PING`/`SUBSCRIBE` over plain TCP even though the connect succeeds. | **Verify the protocol with a TLS-aware probe**: `(printf "AUTH <password>\r\nPING\r\nQUIT\r\n"; sleep 1) \| openssl s_client -connect host:6379 -quiet`. Treat the cleartext-`nc`-works observation as a noise signal, not evidence. |
+| "System trust on Linux is fine, so we don't need `MULTI_TENANT_REDIS_CA_CERT`" | True in production on a stock Debian/Alpine image with `ca-certificates` installed — but macOS dev workstations and minimal `scratch`/`distroless` images do not carry the same trust pool. Mixed environments require the cert injected via config for consistency. | **Set `MULTI_TENANT_REDIS_CA_CERT` regardless of the target image** when the cluster is fronted by a managed issuer. The empty fallback (`CACertBase64 == ""`) stays available for in-cluster Redis with a private CA already in the trust pool. |
+| "We'll just set `InsecureSkipVerify=true` for staging" | `TenantPubSubRedisConfig` deliberately does not expose `InsecureSkipVerify`. Re-adding it to bypass the trust path would re-open the gap and remove the regression's primary forcing function. | **Fix the trust path with `CACertBase64`**, not by disabling verification. If staging is using a self-signed CA, base64-encode that CA's PEM and ship it as `MULTI_TENANT_REDIS_CA_CERT` for the staging environment. |
+| "The app Redis side already has `REDIS_CA_CERT`; the Pub/Sub side can inherit it" | The two clusters are independent infra (§Redis-isolation invariant). Reusing `REDIS_CA_CERT` for `MULTI_TENANT_REDIS_HOST` couples two env contracts that the rest of this section keeps explicitly separate. | **Declare `MULTI_TENANT_REDIS_CA_CERT` as an independent env var**, even when the two clusters share a CA in practice. |
+
+Cross-reference: §27 (Systemplane in MT mode — compliance pattern) for the runtime-config consumer that depends on this same event-driven Pub/Sub transport; the app-Redis `REDIS_CA_CERT` pattern in [[bootstrap.md]] §Config struct for the structurally identical contract.
+
 ### Bootstrap initialisation — the ALWAYS / NEVER list
 
 **ALWAYS:**
 
 - Initialize the multi-tenant Tenant Manager HTTP client (`client.NewClient(...)` with `client.WithCircuitBreaker` and `client.WithServiceAPIKey` from §1 and §26) — REQUIRED.
-- Connect to the tenant Pub/Sub Redis (`MULTI_TENANT_REDIS_HOST`) and start the event listener / tenant cache (§Tenant Discovery and Cache Invalidation) — REQUIRED.
+- Connect to the tenant Pub/Sub Redis (`MULTI_TENANT_REDIS_HOST`) and start the event listener / tenant cache (§Tenant Discovery and Cache Invalidation) — REQUIRED. When `MULTI_TENANT_REDIS_TLS=true` against a managed cloud issuer, thread `MULTI_TENANT_REDIS_CA_CERT` through `TenantPubSubRedisConfig.CACertBase64` (see §[`MULTI_TENANT_REDIS_CA_CERT` — required for TLS-enabled per-tenant Pub/Sub Redis](#multi_tenant_redis_ca_cert--required-for-tls-enabled-per-tenant-pubsub-redis)).
 - Connect to the app Redis (`REDIS_HOST`) — REQUIRED (data plane).
 - Initialize `tmpostgres.Manager`, `tmmongo.Manager`, `tmrabbitmq.Manager` as **lazy** managers. These hold a configuration handle and a per-tenant connection cache; they MUST NOT eagerly dial any tenant DB.
 - Construct application services with **lazy / context-bound** access to the per-tenant resources (every repo method takes `ctx` and resolves the connection via `tmcore.GetPGContext(ctx)` / `tmcore.GetMBContext(ctx)`).

--- a/dev-team/skills/dev-systemplane-migration/SKILL.md
+++ b/dev-team/skills/dev-systemplane-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ring:dev-systemplane-migration
-description: Migrates Lerian Go services from .env/YAML configuration of operational knobs (log levels, feature flags, rate limits, timeouts) to the lib-systemplane runtime config client — a hot-reloadable plane using Postgres LISTEN/NOTIFY or MongoDB change streams. Use when adding hot-reloadable runtime configuration or migrating from v4 systemplane (formerly lib-commons/v5/commons/systemplane). Detects deleted v4 residue (Supervisor, BundleFactory, SYSTEMPLANE_* env vars).
+description: Migrates Lerian Go services from .env/YAML configuration of operational knobs (log levels, feature flags, rate limits, timeouts) to the lib-systemplane runtime config client — a hot-reloadable plane using Postgres LISTEN/NOTIFY or MongoDB change streams. Wires the standard `make systemplane-ddl` migration-only provisioning pipeline (generator + manifest + drift guard) — runtime DDL is forbidden in v1.6.0+. Use when adding hot-reloadable runtime configuration or migrating from v4 systemplane (formerly lib-commons/v5/commons/systemplane). Detects deleted v4 residue (Supervisor, BundleFactory, SYSTEMPLANE_* env vars) and runtime DDL anti-patterns.
 ---
 
 # Systemplane Migration (lib-systemplane)
@@ -35,11 +35,13 @@ Three-step lifecycle:
 
 | Alias | Import Path | Purpose |
 |-------|-------------|---------|
-| `systemplane` | `github.com/LerianStudio/lib-systemplane` | Client, constructors, options |
+| `systemplane` | `github.com/LerianStudio/lib-systemplane` | Client, constructors, options, `SchemaSQL()` / `DefaultSeedSQL()` provisioning artifacts |
 | `admin` | `github.com/LerianStudio/lib-systemplane/admin` | HTTP admin routes |
 | `systemplanetest` | `github.com/LerianStudio/lib-systemplane/systemplanetest` | Contract test suite |
 
 **Legacy paths are DELETED** — do not use `lib-commons/v4/...` or `lib-commons/v5/commons/systemplane` (extracted to its own module), and do not use `Supervisor`, `BundleFactory`, `ApplyBehavior`.
+
+**Provisioning is migration-only.** lib-systemplane publishes `systemplane.SchemaSQL()` + `systemplane.DefaultSeedSQL()` as public artifacts and consumers MUST fold them into the service's own SQL migration pipeline via the `make systemplane-ddl` generator pattern (Gate 3.5). Runtime DDL provisioning is FORBIDDEN — least-privilege tenant-manager roles cannot run DDL anyway, and any boot-time `runSchema`-style hook is a CRITICAL deviation.
 
 **Scope: operational knobs only** — values that can mutate in-place (log levels, feature flags, rate limits, timeouts, poll intervals).
 NOT for settings requiring resource teardown: DSNs, TLS material, listen addresses → keep in env vars + restart.
@@ -61,6 +63,7 @@ Any key storing credentials MUST use `RedactFull`.
 > WebFetch `https://raw.githubusercontent.com/LerianStudio/lib-systemplane/main/doc.go`.
 > Use only canonical `github.com/LerianStudio/lib-systemplane` import paths. v4 packages and the legacy `lib-commons/v5/commons/systemplane` path no longer exist.
 > systemplane is for operational knobs only — not DSNs, TLS, or listen addresses.
+> Provisioning is migration-only (Gate 3.5). Wire `cmd/generate-systemplane-ddl/` + `make systemplane-ddl` + `check-systemplane-ddl-drift` + `migrations/systemplane_ddl_manifest.json` and a bootstrap seam returning `[]SystemplaneSeedEntry`. NEVER call `SchemaSQL()` at boot. NEVER hand-edit generated `migrations/NNN_systemplane_*.sql`. See multi-tenant.md §27 "Cold-tenant resolution" for the canonical reference.
 > TDD: RED → GREEN → REFACTOR for every gate.
 
 ## Related Skills
@@ -68,7 +71,7 @@ Any key storing credentials MUST use `RedactFull`.
 - [[using-lib-systemplane]] — adoption sweep + API reference for the lib-systemplane module
 - [[using-lib-commons]] — non-observability lib-commons packages (lifecycle, outbox, tenancy)
 - [[using-lib-observability]] — tracing, metrics, logging, assert, runtime, redaction
-- For services running in **multi-tenant mode** (`MULTI_TENANT_ENABLED=true`), the consumer-side pattern (registration shape, no-fallback consumer reads, DI interface, seed migration, Manager binding when available in the pinned lib version) is documented in `dev-team/docs/standards/golang/multi-tenant.md` §27 "Systemplane in MT mode — compliance pattern (MANDATORY)". Load that section in addition to the general systemplane architecture below.
+- For services running in **multi-tenant mode** (`MULTI_TENANT_ENABLED=true`), the consumer-side pattern (registration shape, no-fallback consumer reads, DI interface, `make systemplane-ddl` provisioning generator, Manager binding when available in the pinned lib version) is documented in `dev-team/docs/standards/golang/multi-tenant.md` §27 "Systemplane in MT mode — compliance pattern (MANDATORY)". Load that section — particularly the "Cold-tenant resolution — `make systemplane-ddl` generator" subsection — in addition to the general systemplane architecture below.
 
 ## Gate Overview
 
@@ -79,6 +82,7 @@ Any key storing credentials MUST use `RedactFull`.
 | 1.5 | Implementation Preview | Always | ring:visualize |
 | 2 | lib-commons v5 Upgrade + v4 Removal | Skip only if v5 in go.mod AND zero v4 imports | ring:backend-engineer-golang |
 | 3 | Client Construction + Key Registration | Always | ring:backend-engineer-golang |
+| 3.5 | DDL Provisioning (`make systemplane-ddl`) | Always — STANDARD provisioning mechanism | ring:backend-engineer-golang |
 | 4 | OnChange Subscriptions | Always unless zero hot-reloadable keys (justify) | ring:backend-engineer-golang |
 | 5 | Config Bridge | Skip if no Config struct reads need live values | ring:backend-engineer-golang |
 | 6 | Admin HTTP Mount + Authorizer | Skip only if service has no admin surface (justify) | ring:backend-engineer-golang |
@@ -104,6 +108,13 @@ grep "mongodb\|mongo" go.mod
 # Non-canonical:
 grep -rn "fsnotify\|viper.Watch\|Supervisor\|BundleFactory\|ApplyBehavior" internal/
 grep -rn "lib-commons/v5/commons/systemplane\|lib-commons/v4" internal/  # legacy paths
+# DDL provisioning seam + manifest (Gate 3.5):
+ls cmd/generate-systemplane-ddl/                              # generator presence
+ls migrations/systemplane_ddl_manifest.json                    # append-only manifest
+grep -n "systemplane-ddl\|check-systemplane-ddl-drift" Makefile  # make targets
+grep -rn "SystemplaneSeedEntries\|buildSystemplaneRegistrations" internal/bootstrap/  # seam
+# Runtime DDL anti-pattern (CRITICAL):
+grep -rn "runSchema\|SchemaSQL()\|CREATE TABLE.*systemplane_entries" internal/  # MUST be migration-only
 ```
 
 **Phase 2: Compliance Audit** (if systemplane code detected)
@@ -112,17 +123,23 @@ grep -rn "lib-commons/v5/commons/systemplane\|lib-commons/v4" internal/  # legac
 - `OnChange` wired for hot-reloadable keys
 - `admin.Mount` with `admin.WithAuthorizer`
 - Lifecycle: `client.Start(ctx)` registered with `commons.Launcher`
+- `cmd/generate-systemplane-ddl/` generator present AND `migrations/systemplane_ddl_manifest.json` committed
+- `make systemplane-ddl` + `check-systemplane-ddl-drift` wired in Makefile and called from `check-generated-artifacts`
+- Bootstrap exposes the seam `SystemplaneSeedEntries() ([]SystemplaneSeedEntry, error)` derived from the same `buildSystemplaneRegistrations` (or equivalent) the client uses at boot
+- ZERO runtime DDL — no `runSchema`, no `SchemaSQL()` at boot, no `CREATE TABLE ... systemplane_entries` outside `migrations/`
 
 **Phase 3: Non-Canonical Detection**
 - Any `fsnotify` / `viper.WatchConfig` / `envconfig.Watch` for runtime config → MUST replace
 - Any v4 sub-packages (`domain/`, `ports/`, `registry/`, `service/`, `bootstrap/`) → MUST remove
 - Any `lib-commons/v5/commons/systemplane` imports → MUST migrate to `lib-systemplane`
+- Runtime DDL provisioning (boot-time `SchemaSQL()` execution) → MUST replace with the `make systemplane-ddl` migration pipeline (Gate 3.5)
+- Hand-written `migrations/NNN_systemplane_*.sql` files NOT emitted by the generator → MUST be re-emitted via `make systemplane-ddl` (drift-guarded)
 
 ## Severity Reference
 
 | Severity | Criteria |
 |----------|----------|
-| CRITICAL | Legacy import (`lib-commons/v4/...` or `lib-commons/v5/commons/systemplane`); `admin.Mount` without authorizer; secret with `RedactNone` |
-| HIGH | No `Register` before `Start`; no `OnChange` for live key; `SYSTEMPLANE_*` env vars in code |
-| MEDIUM | Missing `WithLogger`/`WithTelemetry`; no validator on numeric range |
+| CRITICAL | Legacy import (`lib-commons/v4/...` or `lib-commons/v5/commons/systemplane`); `admin.Mount` without authorizer; secret with `RedactNone`; runtime DDL provisioning (boot-time `SchemaSQL()` or `CREATE TABLE systemplane_entries` outside `migrations/`) |
+| HIGH | No `Register` before `Start`; no `OnChange` for live key; `SYSTEMPLANE_*` env vars in code; missing `cmd/generate-systemplane-ddl/` generator or `systemplane_ddl_manifest.json`; `make systemplane-ddl` not wired into `check-generated-artifacts` |
+| MEDIUM | Missing `WithLogger`/`WithTelemetry`; no validator on numeric range; hand-edited generated `migrations/NNN_systemplane_*.sql` (would fail the drift guard) |
 | LOW | Missing `WithDescription`; inconsistent namespace naming |

--- a/dev-team/skills/using-lib-systemplane/SKILL.md
+++ b/dev-team/skills/using-lib-systemplane/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ring:using-lib-systemplane
-description: Dual-mode skill for github.com/LerianStudio/lib-systemplane, Lerian's dual-backend (Postgres LISTEN/NOTIFY or MongoDB change streams) hot-reload runtime configuration plane. Sweep Mode dispatches 7 parallel explorers to detect DIY runtime-config wiring (env reload via SIGHUP, fsnotify/viper.WatchConfig, raw pgx LISTEN, hand-rolled change-stream watchers, manual tenant-scoping, hand-built admin CRUD UIs, v4 systemplane residue). Reference Mode catalogs the API by lifecycle (construct → register → start → read/write/subscribe → close), including tenant-scoped overrides, the Fiber admin surface, redaction policies, and the test harness. For end-to-end migration use ring:dev-systemplane-migration. Skip for non-Go or frontend code.
+description: Dual-mode skill for github.com/LerianStudio/lib-systemplane, Lerian's dual-backend (Postgres LISTEN/NOTIFY or MongoDB change streams) hot-reload runtime configuration plane. Sweep Mode dispatches 7 parallel explorers to detect DIY runtime-config wiring (env reload via SIGHUP, fsnotify/viper.WatchConfig, raw pgx LISTEN, hand-rolled change-stream watchers, manual tenant-scoping, hand-built admin CRUD UIs, v4 systemplane residue + runtime DDL provisioning anti-pattern). Reference Mode catalogs the API by lifecycle (construct → register → start → read/write/subscribe → close), the migration-only provisioning artifacts (`SchemaSQL()` + `DefaultSeedSQL()` vendored via `make systemplane-ddl`), tenant-scoped overrides, the Fiber admin surface, redaction policies, and the test harness. For end-to-end migration use ring:dev-systemplane-migration. Skip for non-Go or frontend code.
 ---
 
 # ring:using-lib-systemplane
@@ -53,6 +53,7 @@ Reference mode:
 - **Tenant context:** `github.com/LerianStudio/lib-commons/v5 v5.0.2` (via `tenant-manager/core`)
 - **Observability:** `github.com/LerianStudio/lib-observability v1.0.0` (`log.Logger`, `tracing.Telemetry`, `runtime.RecoverAndLog`)
 - **Dual backend:** Postgres 13+ (LISTEN/NOTIFY) **or** MongoDB 4.4+ (change streams; polling fallback for standalone deployments)
+- **Provisioning:** migration-only via `systemplane.SchemaSQL()` + `systemplane.DefaultSeedSQL()` public artifacts. Runtime DDL hook (`runSchema`) was removed in v1.6.0. Consumers vendor the artifacts into their own SQL migration pipeline via the `make systemplane-ddl` generator pattern — see [[ring:dev-systemplane-migration]] Gate 3.5 and `multi-tenant.md` §27 "Cold-tenant resolution"
 - **License:** Elastic 2.0
 - **Scope:** runtime-mutable knobs only — never bootstrap-only material (DSNs, TLS, listen addresses, secrets)
 
@@ -211,7 +212,7 @@ If no findings: write file with empty findings array and summary
 
 **Severity rationale:** Default-deny is the safe-by-default property. Hand-built admin routes routinely ship with weaker authorization than the lib-commons-backed reference implementation.
 
-### Angle 7 — v4 systemplane residue (CRITICAL)
+### Angle 7 — v4 systemplane residue + runtime DDL provisioning (CRITICAL)
 
 **DIY patterns to grep:**
 - `github.com/LerianStudio/lib-commons/v[34]/commons/systemplane` imports
@@ -219,10 +220,13 @@ If no findings: write file with empty findings array and summary
 - `SYSTEMPLANE_*` environment variables (the v4-era runtime knobs)
 - Sub-packages from the v4 layout: `domain/`, `ports/`, `registry/`, `service/`, `bootstrap/` under any `systemplane/` tree
 - `lib-commons/v5/commons/systemplane` imports (the v5 package was **extracted** to the standalone `lib-systemplane` module; `lib-commons/v5/commons/systemplane` is the pre-extraction location and signals an out-of-date pin)
+- Runtime DDL provisioning: `systemplane.SchemaSQL()` called at boot, `runSchema`-style hooks, `CREATE TABLE systemplane_entries` executed outside `migrations/`, missing `cmd/generate-systemplane-ddl/` + `migrations/systemplane_ddl_manifest.json`, missing `make systemplane-ddl` / `check-systemplane-ddl-drift` Make targets
 
-**Replacement:** Switch to the standalone module `github.com/LerianStudio/lib-systemplane`. Delete the v4 sub-packages outright; v5 has no equivalent layers because the API surface is flat.
+**Replacement:**
+- v4/v5-extracted paths → switch to the standalone module `github.com/LerianStudio/lib-systemplane`; delete the v4 sub-packages outright (v5 has no equivalent layers — the API surface is flat).
+- Runtime DDL → migration-only provisioning via the `make systemplane-ddl` generator (canonical scaffold: `go-boilerplate-ddd` once its systemplane-ddl PR lands; reference implementation in `plugin-br-bank-transfer` at `cmd/generate-systemplane-ddl/`, `migrations/000011_systemplane_schema.{up,down}.sql` → `000013_systemplane_project_seed.{up,down}.sql`, `migrations/systemplane_ddl_manifest.json`, and the bootstrap seam `SystemplaneSeedEntries() ([]SystemplaneSeedEntry, error)` at `internal/bootstrap/systemplane_ddl_gen.go`).
 
-**Severity rationale:** v4 packages are **deleted** from current lib-commons; any surviving import will fail the build under a clean module cache. Surfacing this in the sweep prevents a CI surprise.
+**Severity rationale:** v4 packages and the runtime DDL hook are **deleted** from current lib-systemplane; any surviving call site will fail the build (v4) or fail at boot (runtime DDL under a least-privilege tenant-manager role). Surfacing both in the sweep prevents a CI/runtime surprise.
 
 ## Phase 4: Consolidated Report
 
@@ -523,11 +527,29 @@ For contract testing against a real backend, see `systemplanetest` in the librar
 | `lib-observability/runtime` | `runtime.RecoverAndLog` wraps the subscribe goroutine **and** every OnChange / OnTenantChange callback dispatch. |
 | `lib-commons/v5/commons/net/http` | The admin package uses `commonshttp.RespondError` for uniform error responses. |
 
-## 12. Scope Reminder (locked)
+## 12. Provisioning Artifacts (`SchemaSQL` / `DefaultSeedSQL`) — migration-only
+
+lib-systemplane v1.6.0+ publishes the DDL it needs as two public functions and removes the runtime `runSchema` hook. Consumers MUST fold the artifacts into their own SQL migration pipeline; provisioning at boot is FORBIDDEN.
+
+| Artifact | Returns | Folds into |
+|---|---|---|
+| `systemplane.SchemaSQL() string` | Byte-faithful DDL for `systemplane_entries` table + `systemplane_notify_v3` function + 2 triggers (fully idempotent: `CREATE TABLE IF NOT EXISTS` / `CREATE OR REPLACE` / `DROP TRIGGER IF EXISTS`). Channel `systemplane_changes`, table `systemplane_entries` are fixed (no placeholders). | `migrations/NNN_systemplane_schema.up.sql` (`down` = drop triggers + function, never the table) |
+| `systemplane.DefaultSeedSQL() string` | `INSERT ... ON CONFLICT (namespace, key) DO NOTHING` over the universal default keys (the lib's own runtime knobs). | `migrations/NNN+1_systemplane_default_seed.up.sql` (`down` = value-guarded DELETE of the universal keys) |
+
+**Canonical scaffold:** `make systemplane-ddl` (generator under `cmd/generate-systemplane-ddl/`) vendors both artifacts into append-only migrations + a `migrations/systemplane_ddl_manifest.json`, then emits a third project-seed migration derived from the service's own registrations via a bootstrap seam returning `[]SystemplaneSeedEntry`. The full pattern (seam contract, manifest, drift guard, MT/ST symmetry) is normative in `multi-tenant.md` §27 "Cold-tenant resolution" and operational in [[ring:dev-systemplane-migration]] Gate 3.5. Reference implementation: `plugin-br-bank-transfer` (`cmd/generate-systemplane-ddl/`, `internal/bootstrap/systemplane_ddl_gen.go`, `migrations/000011..000013_systemplane_*`).
+
+**Invariants (locked):**
+
+- NEVER call `SchemaSQL()` or `DefaultSeedSQL()` at boot. Runtime DDL is a CRITICAL deviation — least-privilege tenant-manager roles cannot execute it.
+- NEVER hand-edit a generated `migrations/NNN_systemplane_*.sql`. The generator is the only writer; `check-systemplane-ddl-drift` enforces this.
+- ALWAYS expose the seam — same signature (`SystemplaneSeedEntries() ([]SystemplaneSeedEntry, error)` or equivalent) across services. The generator depends on it; ad-hoc per-project shapes break the scaffold contract.
+- ST and MT use the SAME migration pipeline (single-tenant `migrate-up` or multi-tenant tenant-manager provisioning — same `.sql` files).
+
+## 13. Scope Reminder (locked)
 
 Systemplane is for **runtime-mutable knobs only**. Bootstrap-only configuration (DB DSNs, secrets, TLS material, telemetry endpoints, server identity, listen addresses) belongs in environment variables or a secret manager — **never** in the systemplane plane. Anything requiring resource teardown to apply (reopening a DB pool, rotating a TLS cert) violates the hot-reload contract by definition.
 
-## 13. Cross-references
+## 14. Cross-references
 
 - [[ring:dev-systemplane-migration]] — gated end-to-end migration cycle (stack detection → v5 upgrade → register → subscribe → admin mount → tests → review). Use after this skill identifies adoption opportunities.
 - [[ring:using-lib-commons]] — tenant-manager/core, idempotency, DLQ, webhook delivery, and the broader v5 surface that composes with systemplane.


### PR DESCRIPTION
## What this fixes

Documents the env-var contract that emerged from a debugging session in `plugin-br-bank-transfer` on macOS workstations against AWS ElastiCache for Valkey:

```
tls: failed to verify certificate: x509: "<cluster-endpoint>" certificate is not standards compliant
```

Empirical reproduction confirmed:

- `MULTI_TENANT_REDIS_TLS=true` without `RootCAs` injected → Go macOS Security Framework verifier rejects AWS-issued certs with `errSecCertificateNotStandardsCompliant`.
- Same endpoint, same TLS config, but with the cluster's CA passed via `TenantPubSubRedisConfig.CACertBase64` → pure-Go verifier accepts the chain → handshake succeeds.
- Linux deployments using the system CA bundle generally tolerate the gap, but cross-platform consistency requires the cert to be threaded through config rather than relying on system trust.

The gap was that the multi-tenant standard documented `MULTI_TENANT_REDIS_TLS` but had no companion entry for the CA bundle, so services had no canonical env-var name to register in Helm values or the config struct. This PR closes that gap with the same shape as the app-Redis `REDIS_CA_CERT` documented in `bootstrap.md`.

## What this adds

In `dev-team/docs/standards/golang/multi-tenant.md`:

1. **New §28 subsection** — `### MULTI_TENANT_REDIS_CA_CERT — required for TLS-enabled per-tenant Pub/Sub Redis`, placed after the existing §28 Redis-isolation invariant block. Follows the `Topic — qualifier` idiom of §27 (Padrão A, Consumer reads, Manager binding) and §28 (Failure modes, Redis-isolation, Bootstrap initialisation). Includes:
   - Why-it-exists paragraph anchored on the macOS verifier reproduction.
   - The contract paragraph (single bold imperative, lib-commons API surface named exactly).
   - Config-struct addition snippet (mirrors §Configuration shape).
   - Wiring-site snippet (`initEventDrivenDiscovery`).
   - `ALWAYS / NEVER` lists framed as in the §28 ALWAYS/NEVER section directly below.
   - NON-COMPLIANT signs (matches §27 review-checklist idiom).
   - Reference-implementation table (`plugin-br-bank-transfer` wiring site + `lib-commons` lib side + `bootstrap.md` precedent).
   - Anti-Rationalization table (matches §27/§28 table shape) — addresses "plain TCP works in `nc`", "system trust on Linux is fine", "we'll set `InsecureSkipVerify=true`", and "the app Redis side already has `REDIS_CA_CERT`".
   - Cross-link to §27 and `bootstrap.md`.

2. **§Environment Variables table row** — adds `MULTI_TENANT_REDIS_CA_CERT` as the 15th OPTIONAL entry, explicitly conditional on `MULTI_TENANT_REDIS_TLS=true` + managed-CA cluster.

3. **`.env` example** — commented-out `MULTI_TENANT_REDIS_CA_CERT=` line next to `MULTI_TENANT_REDIS_TLS=false`.

4. **§Configuration struct snippet** — adds `MultiTenantRedisCACert string` next to `MultiTenantRedisTLS bool`.

5. **§28 ALWAYS-list bullet** — extends the existing Pub/Sub Redis bullet with the TLS conditional pointing at the new subsection.

6. **Checklist (line 1599)** — adds the optional 15th env to the per-service compliance checklist.

In `default/skills/shared-patterns/consolidated-report-template.md`:

7. **Canonical env-list note** — updates the "14 MULTI_TENANT_* env vars" sentence to reference 14 required + 1 optional 15th (`MULTI_TENANT_REDIS_CA_CERT`).

8. **Config struct example** — adds the corresponding `MultiTenantRedisCACert` field.

## Few-shot exemplars mirrored

The new subsection deliberately mirrors three structurally-similar sections in the same file (per the project's voice-matching directive):

| Exemplar | What was mirrored |
|---|---|
| §27 `Registration shape — Padrão A (the only valid shape going forward)` | `Topic — qualifier` heading idiom; bold-contract paragraph; CORRECT/FORBIDDEN ALWAYS/NEVER framing; NON-COMPLIANT-signs bullet list; Anti-Rationalization 3-column table |
| §28 `Redis-isolation invariant — two distinct Redis clusters` | Conditional opener; reference-implementation table; cross-link to sister section (§27 ↔ §28); language about "two distinct" infrastructure boundaries |
| §28 `Bootstrap initialisation — the ALWAYS / NEVER list` | Bold-imperative ALWAYS/NEVER bullets; matched verb shape ("Set X whenever Y"); explicit boot-critical framing |

## Dependency

`lib-commons` v5.3.0+ already ships `TenantPubSubRedisConfig.CACertBase64` and `BuildOptions`/`buildTLSConfig` decoding the base64 PEM into `tls.Config.RootCAs` (`commons/tenant-manager/redis/client.go:35-110`). No lib change is required to land this doc.

## Env-count change

- Required `MULTI_TENANT_*` envs: **14** (unchanged).
- Optional `MULTI_TENANT_*` envs: **+1** (`MULTI_TENANT_REDIS_CA_CERT`).
- Total canonical `MULTI_TENANT_*` surface: **14 required + 1 optional = 15**.

The `MULTI_TENANT_REDIS_CA_CERT` name is the single canonical contract — Helm values, plugin config struct, plugin `.env.example`, and this Ring standard all use the same identifier. No variations (`MT_REDIS_CA_CERT`, `MULTI_TENANT_REDIS_CACERT_BASE64`, `MULTI_TENANT_REDIS_ROOT_CA`).

## Branch base

This PR stacks on top of `docs/multi-tenant-bootstrap-resources` (open PR #408 that introduces §28). Re-target to `main` once #408 lands.

## Not in scope

- No code changes — markdown only.
- No `lib-commons` change required.
- Down-stream service migration (threading `cfg.MultiTenantRedisCACert` into `TenantPubSubRedisConfig.CACertBase64`) belongs in each consumer service's own PR; `plugin-br-bank-transfer` will follow up.

X-Lerian-Ref: 0x1