### PR TITLE
feat(running-dev-cycle): add optional Lerian Map Sync (async board sync via Gandalf)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -30,7 +30,7 @@
     {
       "name": "ring-dev-team",
       "description": "24 specialized developer agents + 33 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
-      "version": "1.74.1",
+      "version": "1.75.0",
       "source": "./dev-team",
       "homepage": "https://github.com/lerianstudio/ring/tree/main/dev-team",
       "repository": "https://github.com/lerianstudio/ring/tree/main/dev-team",
@@ -104,5 +104,5 @@
       ]
     }
   ],
-  "version": "0.370.0"
+  "version": "0.371.0"
 }

--- a/dev-team/.codex-plugin/plugin.json
+++ b/dev-team/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-dev-team",
-  "version": "1.74.1",
+  "version": "1.75.0",
   "description": "24 specialized developer agents + 33 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists.",
   "author": {
     "name": "Lerian Studio",

--- a/dev-team/.cursor-plugin/plugin.json
+++ b/dev-team/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ring-dev-team",
   "displayName": "Ring Dev Team",
   "description": "24 specialized developer agents + 33 development skills. Backend (Go/TypeScript) and frontend (React/Next.js) dev cycles, DevOps, QA, SRE, and the parallel code-review pool.",
-  "version": "1.74.1",
+  "version": "1.75.0",
   "author": {
     "name": "Lerian Studio",
     "email": "fred@lerian.studio"

--- a/dev-team/CHANGELOG.md
+++ b/dev-team/CHANGELOG.md
@@ -17,6 +17,20 @@
 - Added explicit dependency-blocker handling for transitive modules that still import removed lib-commons observability packages after the target application bumps to a removal release.
 - Tightened root opentelemetry qualifier migration so agents rewrite selector expressions only, never `go.opentelemetry.io` module import paths.
 
+## [1.75.0] — 2026-06-11
+
+### Added — Optional Lerian Map Sync in `ring:running-dev-cycle`
+
+- The development cycle can now keep the Lerian Map kanban board in sync as epics/tasks move through the gates. Strictly **optional and default-off** — when not enabled, the cycle behaves exactly as before (zero Gandalf calls) and no mandatory gate is weakened.
+- **Two new optional cycle-init questions**, asked after execution mode and before commit timing:
+  - **Lerian Map Sync?** (`No` default / `Yes — sync`).
+  - **Testing gate** (`Gate (wait)` / `Bypass`, only asked when sync = Yes) — controls whether the card waits at `Testing` for the user's explicit OK before the PR is opened. Does **not** override the critical Gate 9 acceptance, which always requires explicit user approval per epic.
+- **Async fire-and-forget board updates via Gandalf.** All Map I/O goes through the `gandalf-webhook` (no direct Map API call, no new agent, no new credential). Each checkpoint POSTs one transition, gets a `task_id` back in <1s, and continues — Gandalf's background worker applies the update. The cycle never polls or blocks. Visible dispatch log line per push.
+- **Repo-based board discovery.** Discovers the product by matching the normalized git remote against the Map's native `repositoryUrl` field; features matched by name (no slug); units matched via `[map:#<board_task_id>]` tags with title-matching fallback. Tags can be auto-injected into the plan after the first discovery (with user confirmation).
+- **Status mapped to the real board columns:** `To do → In Progress (Gate 0) → Testing (gates done, awaiting user test) → To Review (PR open) → Done (push to ≥ develop)`, with `Blocked`/`On Hold`/`Canceled` off-path. **`Done` is gated on commit+push-to-develop (PR merge), not Gate 9.**
+- **Deferred reconciliation** when Gandalf is unreachable: three states per transition (`pending → dispatched → synced`), best-effort non-blocking verification and pending-drain at the next checkpoint / `--resume` / end of cycle, idempotent absolute-column pushes, and an end-of-cycle pending report.
+- **State schema:** additive optional `lerian_map_sync` object in `current-cycle.json` (`gates/state-schema.md`), absent when the feature is off.
+
 ## [1.56.1] — 2026-04-17
 
 ### Fixed — Restore Gate 0.5D (Migration Safety) as standalone conditional gate

--- a/dev-team/skills/running-dev-cycle/SKILL.md
+++ b/dev-team/skills/running-dev-cycle/SKILL.md
@@ -153,6 +153,37 @@ Ask user at cycle start (two independent questions):
 
 Mode and phase_checkpoint affect CHECKPOINTS (user approval pauses), not GATES. All listed gates execute regardless of mode. The phase boundary's elaboration step runs in BOTH phase_checkpoint values — only the pause differs.
 
+**3. Lerian Map Sync** (OPTIONAL — default No; see `## Lerian Map Sync (optional)`):
+
+Ask AFTER execution mode and BEFORE commit timing (the Map decision — esp. `Done` = push-to-develop — influences how the user thinks about commit cadence). Both questions are optional and default to today's behavior (No → zero Gandalf calls, feature fully off).
+
+```yaml
+AskUserQuestion:
+  question: "Do these activities have a mapping in the Lerian Map (kanban board)?"
+  header: "Lerian Map Sync"
+  options:
+    - label: "No"          # default → no board sync, no Gandalf calls
+    - label: "Yes — sync"  # → run the Lerian Map Sync handshake (see "Lerian Map Sync (optional)")
+```
+
+- **No:** set `state.lerian_map_sync.enabled = false` (or omit the object); skip the Testing-gate question; behave exactly as today.
+- **Yes — sync:** set `state.lerian_map_sync.enabled = true`, then ask the Testing-gate question below, and run the discovery handshake (see `## Lerian Map Sync (optional)`) before the first Gate 0.
+
+**4. Testing gate** (OPTIONAL — only asked when Lerian Map Sync = Yes; stored in `state.lerian_map_sync.testing_gate`):
+
+```yaml
+AskUserQuestion:
+  question: "When a card reaches Testing, wait for your explicit OK before opening the PR (→ develop)?"
+  header: "Testing gate"
+  options:
+    - label: "Gate (wait)"   # card parks in Testing; cycle pauses until you test + say OK, THEN opens PR → To Review
+    - label: "Bypass"        # after Gate 9, auto-advance: open PR → To Review without waiting for a manual-test OK
+```
+
+⚠️ **Does NOT override Gate 9.** Gate 9 (validation/acceptance) is a CRITICAL, non-bypassable gate that always requires explicit user approval per epic (Step 11.1). The Testing gate is a SEPARATE, Map-aware control over the *manual-test wait before PR/develop* — it can only relax that extra Testing wait, never the mandatory Gate 9 acceptance.
+
+**Resulting cycle-init question order:** execution mode → phase checkpoint → **Lerian Map Sync?** → **Testing gate** (only if sync = Yes) → commit timing.
+
 ## Custom Instructions
 
 If user provides custom context at cycle start, store in `state.custom_prompt` and inject at the top of every agent dispatch:
@@ -176,6 +207,109 @@ If user provides custom context at cycle start, store in `state.custom_prompt` a
 
 `commit_timing ∈ {per_task, per_epic, at_end}`. Convention: `feat|fix|test|chore(scope): description` — keep commits atomic per gate.
 
+## Lerian Map Sync (optional)
+
+**OPTIONAL and default-off.** When enabled (cycle-init question 3 = `Yes — sync`), this feature keeps the Lerian Map kanban board in sync as epics/tasks move through the gates. When off (the default), the cycle behaves exactly as before — **zero Gandalf calls**. The feature **never blocks gate execution** and **never weakens any mandatory gate** (Gate 9 acceptance still requires explicit user approval per epic, regardless of the Testing-gate setting).
+
+**Hard rule:** the synced status follows the **real board columns exactly** — no invented stand-in statuses. Column enum strings are **read from the board at runtime via Gandalf, never hardcoded**.
+
+### Discovery handshake (run once, after the cycle-init questions, before the first Gate 0)
+
+When Map sync = Yes, run a one-time handshake (each Gandalf ask is a fresh, self-contained session carrying the full discovery payload):
+
+1. **Fetch board tasks via Gandalf** for this repo's product. Discovery is **repo-driven**: map the local git remote to a product via the Map's native **`repositoryUrl`** field on `GET /products` (no manual `productId`/`teamId`/`milestoneId`). Normalize the remote first (`git@github.com:org/repo.git` → `https://github.com/org/repo`).
+2. **Match board cards ↔ local plan units.** Features are matched **by NAME** (e.g. `"E-1.1 …"` / the epic title) — Map features have **no `slug` field**, so name is the feature key (the `docs/pre-dev/{feature}/` path slug has no API equivalent and is only a weak hint). The deterministic per-task matching key is the **`[map:#<board_task_id>]` tag** embedded in the plan/task block; when a tag is present Gandalf skips fuzzy matching entirely. **Title-matching is the fallback** when no tag is present.
+3. **Preview + confirm.** Show a preview table (local ↔ board, with each card's current column) and ask the user to confirm the match before any write.
+4. **Auto-inject tags (with confirmation).** After the first successful discovery, offer to **auto-inject** the resolved `[map:#<board_task_id>]` tags into the plan so future runs are deterministic and rename-proof.
+5. **Persist** the mapping + the board's real status enum into `state.lerian_map_sync` (see `gates/state-schema.md`).
+
+**Discovery path that works (validated):** `repo → /products(repositoryUrl) → /features?productId(name) → /tasks?featureId`.
+
+### Status mapping (dev-cycle stage → real board column)
+
+| Dev-cycle event | Board column | Notes |
+|-----------------|--------------|-------|
+| Unit loaded, not started | `To do` | baseline; only set if currently in `Backlog` |
+| Gate 0 begins (coding/TDD) — epic start | `In Progress` | unit is actively being built |
+| All gates passed (incl. Gate 8 review + Gate 9), awaiting user manual test | `Testing` | the "Em Teste" the user actually tests; STAYS here through approval. Gate 8 is an INTERNAL dev-cycle review — it does NOT get its own board column. |
+| User approved → PR opened, awaiting human merge-review | `To Review` | matches the board order `Testing → To Review → Done` |
+| PR merged → committed AND pushed to repo (≥ `develop`) | `Done` | ⭐ the **ONLY** trigger for `Done` — the push-to-develop / PR-merge event, **NOT Gate 9** |
+| A gate fails hard / external blocker | `Blocked` | off-path |
+| Cycle parked for non-blocking reasons | `On Hold` | off-path / optional / manual |
+| Unit dropped | `Canceled` | off-path / optional / manual |
+
+**Lifecycle (monotonic, matches board column order):** `To do → In Progress → Testing → To Review → Done`, with `Blocked`/`On Hold`/`Canceled` off-path.
+
+The `Testing → To Review` hop depends on the **Testing gate** (cycle-init question 4):
+- **`gate` (wait):** card parks in `Testing`; the cycle waits for the user's OK, then opens the PR → `To Review`. (SLC rule — human tests the epic before the PR.)
+- **`bypass`:** the card still passes *through* `Testing` (status is set) but the cycle does not block; it auto-opens the PR → `To Review`. **Gate 9 acceptance still applies** — bypass only relaxes the manual-test wait, never Gate 9.
+
+### Gandalf integration mechanics
+
+All Map I/O goes **through the Gandalf webhook** (`default/skills/gandalf-webhook`) — never a direct Map API call from dev-cycle. This keeps the dev-team plugin free of Map credentials / instance coupling and works for any Map instance. **No new agent and no new credential** are introduced; the existing webhook is reused.
+
+- **Self-contained prompts:** every ask is a fresh Gandalf session — each message carries the discovery payload (repo, feature name, task ids/titles, board ids) and the **absolute target column**.
+- **Fetch + enum read:** the first ask returns both the matched cards AND the list of valid status values for that board (so column strings are never hardcoded).
+- **Status push — ASYNC FIRE-AND-FORGET (never blocks dev):** at each checkpoint the dev-cycle sends ONE webhook POST and immediately gets back a `task_id`; Gandalf's **background worker** performs the actual board update. The dev-cycle **does NOT poll or wait** — it records the dispatch and continues to the next gate/task. The slow work lives on Gandalf's side, off the critical path.
+- **Visible dispatch log line:** when the hook fires, log a line so the user sees it working in the background, e.g.
+  `🔄 Lerian Map Sync: dispatched Task 1.1.1 → In Progress (gandalf task a1b2c3, background)`
+  and record `{task_id, dispatched_at, state: "dispatched"}` in `current-cycle.json`.
+
+### Graceful degradation + deferred reconciliation
+
+Map sync **never blocks gate execution**. Each transition moves through **three states**:
+
+```
+pending    → the dev-cycle wants this column but hasn't fired the hook yet (or the POST failed)
+dispatched → the webhook POST succeeded; Gandalf has a task_id and is updating in background (NOT yet confirmed)
+synced     → confirmed applied on the board
+```
+
+State tracks, per matched unit, `desired_status` (what the dev-cycle wants) vs `synced_status` (last *confirmed*), the dispatch record (`task_id`, `dispatched_at`, `state`), plus an ordered **pending queue** (`state.lerian_map_sync.pending`) and a `degraded` flag.
+
+Rules:
+1. **Fire, don't wait:** at a checkpoint, POST the transition → on a successful POST, mark `dispatched` with the `task_id` and move on immediately (no polling).
+2. **POST itself fails** (Gandalf unreachable / off-Tailscale / timeout): keep the transition `pending`, set `degraded: true`, **log a warning, continue the cycle**.
+3. **Best-effort verification (non-blocking):** opportunistically — at the *next* checkpoint, on `--resume`, and at end of cycle — do ONE batched read of outstanding `dispatched` task_ids; any that completed flip to `synced`. Never blocks; if the read fails, items stay `dispatched` and are re-checked later.
+4. **Drain pending:** at the same triggers, retry `pending` transitions (oldest → newest). A Gandalf that comes back mid- or post-cycle gets the board caught up automatically; when nothing is `pending`, clear `degraded`.
+5. **Idempotent pushes:** each push sets an **absolute column** (status = X), never a relative move — safe to replay even if a partial update landed.
+6. **End-of-cycle report:** print outstanding items at Step 12.1, e.g.
+   `⚠️ Lerian Map Sync: 2 dispatched (awaiting confirmation), 1 pending (Gandalf was down)`.
+
+### Checkpoint hooks (where the async push fires)
+
+When `state.lerian_map_sync.enabled`, the orchestrator fires the async, fire-and-forget board push at these existing checkpoints (each is non-blocking and never gates execution):
+
+| Cycle event | Hook location | Absolute column pushed |
+|-------------|---------------|------------------------|
+| Epic start (Before Gate 0) | `gates/gate-0-implementation.md` Pre-Dispatch checkpoint | `in_progress` |
+| Epic validated, awaiting user test (Gate 9 pass → Step 11.1) | `gates/gate-9-validation.md` Step 11.1 | `testing` (stays here through approval) |
+| User approved → PR opened | Step 11.1 advance (and end-of-cycle / PR-open path) | `to_review` (gated by `testing_gate`) |
+| Push to repo ≥ `develop` (PR merge) | `gates/cycle-completion.md` Step 12.1 (Final Commit / push) | `done` — ONLY trigger for `done`, NOT Gate 9 |
+| Hard block at any gate | Blocker Handling | `blocked` |
+
+### Validated facts (live Gandalf test, 2026-06-11, `br-slc`)
+
+- **Product discovery:** `GET /products` exposes a native **`repositoryUrl`** field. `https://github.com/LerianStudio/br-slc` → `productId=13` (SLC), `teamId=5`. Exact match, no ambiguity.
+- **Feature discovery:** `GET /features?productId=13` → matched **by name** `"E-1.1 …"` → `featureId=245` (status `backlog`, `iterationId: null`). **No `slug` field exists.**
+- **Tasks:** `GET /tasks?featureId=245` → 4 cards, matched 4/4 to local T-1.1.1–T-1.1.4 → board ids **1222, 1223, 1224, 1225**, all `todo`, milestone `Desenvolvimento` (id=433).
+- **Status enum (EXACT API slugs + ids):**
+
+  | id | slug | label | terminal |
+  |----|------|-------|----------|
+  | 1 | `backlog` | Backlog | no |
+  | 2 | `todo` | To do | no |
+  | 3 | `in_progress` | In Progress | no |
+  | 8 | `testing` | Testing | no |
+  | 9 | `to_review` | To Review | no |
+  | 5 | `on_hold` | On Hold | no |
+  | 6 | `blocked` | Blocked | no |
+  | 4 | `done` | Done | **yes** |
+  | 7 | `canceled` | Canceled | **yes** |
+
+- **Known frictions:** no feature slug (match by name — fragile → use `[map:#id]` tags); `iterationId` can be `null`; `GET /teams` currently returns 500 (use `teamId` from the tasks payload instead).
+- **Discovery path:** `repo → /products(repositoryUrl) → /features?productId(name) → /tasks?featureId`.
+
 ## Blocker Handling
 
 | Blocker | Action |
@@ -184,6 +318,8 @@ If user provides custom context at cycle start, store in `state.custom_prompt` a
 | Missing PROJECT_RULES.md | STOP. Create using template. |
 | Agent error | STOP. Diagnose and report. |
 | Architectural decision needed | STOP. Present options to user. |
+
+When `state.lerian_map_sync.enabled` and a gate hard-blocks (failure / external blocker), fire the async board push → absolute column `blocked` for the affected unit (non-blocking, fire-and-forget) before stopping. See `## Lerian Map Sync (optional)`.
 
 ## Gate Completion Rules
 

--- a/dev-team/skills/running-dev-cycle/gates/cycle-completion.md
+++ b/dev-team/skills/running-dev-cycle/gates/cycle-completion.md
@@ -172,3 +172,8 @@ state.gate_progress.migration_safety_verification = {
    - Execute `/ring:committing-changes` with message: `feat({cycle_id}): complete dev cycle for {feature_name}`.
 
 5. **Report:** "Cycle completed. Phases X/X, Epics X/X, Tasks Y, Time Xh Xm, Review iterations X."
+
+6. **Lerian Map Sync (only when `state.lerian_map_sync.enabled`):**
+   - **`done` push:** a unit flips to the terminal `done` column **only when its commit is pushed to the repo (≥ `develop`)** — the push-to-develop / PR-merge event, **NOT Gate 9**. When the Final Commit is pushed to at least `develop`, fire the async board push → absolute column `done` for the affected units. (If this cycle does not push to `develop`, the units remain in `to_review` / `testing` and flip to `done` later via the PR-merge event.)
+   - **Deferred reconciliation:** drain the `state.lerian_map_sync.pending` queue (oldest → newest) and do one batched non-blocking verification of outstanding `dispatched` task_ids, flipping any confirmed ones to `synced`; clear `degraded` when nothing is `pending`.
+   - **End-of-cycle report:** print outstanding items, e.g. `⚠️ Lerian Map Sync: 2 dispatched (awaiting confirmation), 1 pending (Gandalf was down)`. All Map I/O here is non-blocking — see SKILL.md '## Lerian Map Sync (optional)'.

--- a/dev-team/skills/running-dev-cycle/gates/gate-0-implementation.md
+++ b/dev-team/skills/running-dev-cycle/gates/gate-0-implementation.md
@@ -17,6 +17,8 @@ MUST execute the **Before Gate 0 (epic start)** row from the State Persistence C
 
 CANNOT proceed to sub-steps 2.1–2.3 without completing this checkpoint. (The `epic.base_sha` captured here is the lower bound of the Gate 8 cumulative review diff — the SHA before the epic's first task.)
 
+**Lerian Map Sync hook (only when `state.lerian_map_sync.enabled`):** at this epic-start checkpoint, fire the async fire-and-forget board push for this unit → absolute column `in_progress` (set only if the card is currently `backlog`/`todo`). Non-blocking: POST, record `{task_id, dispatched_at, state: "dispatched"}`, log the dispatch line, continue. On POST failure keep it `pending` + `degraded` and continue. See SKILL.md '## Lerian Map Sync (optional)'.
+
 ### ⛔ MANDATORY: Invoke ring:implementing-tasks Skill (not inline execution)
 
 See [shared-patterns/shared-orchestrator-principle.md](../../shared-patterns/shared-orchestrator-principle.md) for full details.

--- a/dev-team/skills/running-dev-cycle/gates/gate-9-validation.md
+++ b/dev-team/skills/running-dev-cycle/gates/gate-9-validation.md
@@ -55,6 +55,8 @@ For the current epic:
 
 > The per-task pause for `manual_per_task` mode lives after Gate 0 (see the `[checkpoint if manual_per_task mode]` step in the Execution Order). There is NO per-task validation pause here — Gate 9 validation is epic-level only.
 
+**Lerian Map Sync hook (only when `state.lerian_map_sync.enabled`):** once Gate 9 passes and the epic enters this checkpoint awaiting the user's manual test, fire the async board push → absolute column `testing` (the card STAYS in `testing` through approval). When the user advances (Continue / Integration Test below) and the PR is opened, fire `to_review` — gated by `state.lerian_map_sync.testing_gate`: `gate` waits for the user's OK before opening the PR; `bypass` auto-opens it. ⚠️ This is independent of and never overrides Gate 9 acceptance. All pushes are non-blocking (fire-and-forget); see SKILL.md '## Lerian Map Sync (optional)'.
+
 0. **COMMIT CHECK (before checkpoint):**
    - `commit_timing == "per_epic"` → execute `/ring:committing-changes` with message `feat({epic_id}): {epic_title}`, including all files changed across the epic's tasks.
    - `commit_timing == "per_task"` → already committed per task.

--- a/dev-team/skills/running-dev-cycle/gates/state-schema.md
+++ b/dev-team/skills/running-dev-cycle/gates/state-schema.md
@@ -38,6 +38,32 @@ State is persisted to `{state_path}` (either `docs/ring:running-dev-cycle/curren
   "commit_timing": "per_task|per_epic|at_end",
   "_comment_phase_checkpoint": "Asked at cycle init alongside execution_mode. 'manual' (default): AskUserQuestion at each phase boundary (Step 11.5) before elaborating the next phase. 'auto': log a phase summary and continue without pausing.",
   "phase_checkpoint": "manual|auto",
+  "_comment_lerian_map_sync": "OPTIONAL / ADDITIVE. Present ONLY when the user answered 'Yes — sync' to the cycle-init Lerian Map Sync question (SKILL.md Execution Modes, question 3). Absent or enabled:false ⇒ feature off ⇒ zero Gandalf calls ⇒ today's behavior. All Map I/O is async fire-and-forget via the gandalf-webhook; the cycle never polls/blocks. See SKILL.md '## Lerian Map Sync (optional)' for full mechanics. status_enum is READ from the board at runtime (never hardcoded); discovery (productId/teamId/milestoneId) is DISCOVERED by Gandalf from the repo's git remote, not hardcoded.",
+  "lerian_map_sync": {
+    "enabled": true,
+    "transport": "gandalf",
+    "testing_gate": "gate|bypass",
+    "discovery": {
+      "repo": "LerianStudio/br-slc",
+      "feature_slug": "slc-v1",
+      "branch": "feat/slc-e1.1-bounded-contexts"
+    },
+    "board": { "discovered": true, "productId": 13, "teamId": 5, "milestoneId": 433 },
+    "status_enum": ["backlog","todo","in_progress","testing","to_review","on_hold","blocked","done","canceled"],
+    "status_map": { "gate0": "in_progress", "awaiting_test": "testing", "pr_open": "to_review", "pushed_develop": "done" },
+    "matches": [
+      {
+        "unit_id": "Task 1.1.1",
+        "board_task_id": 1222,
+        "matched": true,
+        "desired_status": "in_progress",
+        "synced_status": "todo",
+        "dispatch": { "task_id": "a1b2c3", "to": "in_progress", "dispatched_at": "2026-06-11T15:00:00Z", "state": "pending|dispatched|synced" }
+      }
+    ],
+    "pending": [],
+    "degraded": false
+  },
   "_comment_cached_standards": "Populated by Step 1.5 (Standards Pre-Cache). Dictionary of URL → {fetched_at, content}. Sub-skills MUST read from here instead of calling WebFetch.",
   "cached_standards": {},
   "_comment_visual_report_granularity": "Opt-in code-diff report via ring:visualizing: 'none' (default, no report) | 'epic' (aggregate per epic) | 'task' (per task).",


### PR DESCRIPTION
## What

Adds a strictly **optional, default-off** "Lerian Map Sync" capability to the `ring:running-dev-cycle` skill. When enabled, the dev-cycle keeps the Lerian Map kanban board in sync as epics/tasks move through the gates — all via the existing **Gandalf webhook** (`default/skills/gandalf-webhook`), with **no new agent and no new credential**.

When the feature is off (the default), the dev-cycle behaves exactly as today — **zero Gandalf calls** — and no mandatory gate is weakened.

## Why

Today, keeping the board in sync with what the dev-cycle is doing is a manual, out-of-band orchestration (driving Gandalf by hand, one ask at a time). This makes that sync a first-class, opt-in step so the board reflects reality automatically.

## New cycle-init question order

The two new questions are asked at cycle init, after execution mode and before commit timing (the Map decision — esp. `Done` = push-to-develop — influences how the user thinks about commit cadence). Both are optional and default to today's behavior.

```
1. (mandatory) Execution mode
2. (mandatory) Phase checkpoint
3. (optional)  Lerian Map Sync?   ← new   (No default / Yes — sync)
4. (optional)  Testing gate       ← new, only if #3 = Yes  (Gate (wait) / Bypass)
5. (mandatory) Commit timing
```

The **Testing gate** controls whether the card waits at `Testing` for the user's explicit OK before the PR is opened. It does **NOT** override the critical Gate 9 acceptance, which always requires explicit user approval per epic.

## Status → real board column mapping

| Dev-cycle event | Board column | Trigger |
|-----------------|--------------|---------|
| Unit loaded, not started | `To do` | only if currently in `Backlog` |
| Gate 0 begins (coding/TDD) — epic start | `In Progress` | unit actively built |
| All gates passed (incl. Gate 8 review + Gate 9), awaiting user manual test | `Testing` | stays here through approval; Gate 8 is INTERNAL — no column |
| User approved → PR opened | `To Review` | PR open (gated by `testing_gate`) |
| Commit AND pushed to repo (≥ `develop`) — PR merge | `Done` | ⭐ ONLY trigger for `Done`; NOT Gate 9 |
| Gate fails hard / external blocker | `Blocked` | off-path |
| Cycle parked (non-blocking) | `On Hold` | off-path / manual |
| Unit dropped | `Canceled` | off-path / manual |

Column enum strings are read from the board at runtime via Gandalf, never hardcoded. Discovery is repo-driven (Map's native `repositoryUrl` field), features matched by name (no slug exists), units matched via `[map:#<board_task_id>]` tags (auto-injected with confirmation) with a title-matching fallback.

## Async / degradation behavior

- **Fire-and-forget:** each checkpoint POSTs one transition, gets a `task_id` back in <1s; Gandalf's background worker applies the board update. The cycle **never polls or blocks**. Visible dispatch log line per push.
- **Three states per transition:** `pending → dispatched → synced`.
- **Degradation:** if the POST fails (Gandalf unreachable), keep `pending`, set `degraded`, log a warning, and continue the cycle.
- **Deferred reconciliation:** best-effort, non-blocking verification + pending-drain at the next checkpoint / `--resume` / end of cycle; idempotent absolute-column pushes; end-of-cycle pending report.
- **State:** additive optional `lerian_map_sync` object in `current-cycle.json` (`gates/state-schema.md`), absent when off.

## Where it's wired (new split structure)

- `SKILL.md` — `## Execution Modes` (the two new questions), new `## Lerian Map Sync (optional)` feature section, `## Blocker Handling` (`blocked` push note).
- `gates/state-schema.md` — additive `lerian_map_sync` object.
- `gates/gate-0-implementation.md` — epic-start hook → `In Progress`.
- `gates/gate-9-validation.md` — Step 11.1 hooks → `Testing` / `To Review`.
- `gates/cycle-completion.md` — Step 12.1 hook → `Done` (push-to-develop) + reconciliation/report.

## Notes

- **Strictly optional + default-off.** No existing mandatory gate or question is removed or weakened.
- **Validated live** against `br-slc` on 2026-06-11 (discovery + 4/4 unit match, status enum confirmed).
- Version bumps: `ring-dev-team` `1.74.1` → `1.75.0`; root marketplace `0.370.0` → `0.371.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)