### PR TITLE
feat(running-dev-cycle): add Lerian Map as optional task source

### DIFF
--- a/dev-team/CHANGELOG.md
+++ b/dev-team/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Added — Lerian Map as an optional task source in `ring:running-dev-cycle`
+
+- The Lerian Map board can now BE the task source for a dev cycle, not just a status mirror. Strictly **opt-in** — users who don't use the Map see zero behavior change (zero Gandalf calls).
+- **Cycle-init question 3 changed** from the Yes/No "Lerian Map Sync?" question to a single-select **Task source** question with three mutually exclusive options, explicitly chosen by the user (no silent default): `Local plan` (`task_source = "plan_file"`, today's default behavior), `Local plan + Map sync` (`"plan_file_synced"`, exactly the existing sync behavior), and `Lerian Map (board is the source)` (`"lerian_map"`, new — source mode implies status sync). Resumed cycles without `task_source` infer it from `lerian_map_sync.enabled` and are never re-asked.
+- **Board-as-source flow** (`SKILL.md` → `## Lerian Map as Task Source (optional)`): discovery handshake + milestone resolution, Gandalf fetch (milestone → features → tasks incl. `body`), body-hygiene validation for the current milestone (elaborate via ONE ANALYSIS-mode planning agent + push back, or abort), and materialization of a derived `docs/ring:running-dev-cycle/plan-from-map.md` in canonical ring:writing-plans format (`milestone` = Phase, `feature` = Epic, `task` = Task, `body` = dispatch-ready block; headings tagged `[map:#<id>]`). All existing gates run unchanged against the derived plan; the board stays the source of truth for WHAT and STATUS.
+- **Rolling-wave write-back:** at each phase boundary (new Step 11.5.5b in `gates/phase-boundary.md`), elaborated task blocks are pushed to the matching Map task `body`; board/local mismatches are surfaced for user reconciliation — never silently created/deleted. Mid-cycle deviations from Gate 8/9 also write back, async fire-and-forget.
+- **Degradation:** at INIT an unreachable Map means the source is unavailable → Retry / fall back to a local plan / Abort. DURING the cycle, outages degrade exactly like sync mode (pending + degraded, fire-and-forget reconciliation) and never block gates.
+- **State schema** (additive): `task_source` enum + optional `lerian_map_source` object (milestone identity; per-unit ids stay in the `[map:#<id>]` tags + `lerian_map_sync.matches[]`, the existing sync-mode pattern). `ring:managing-dev-cycle` status now shows the task source and, for `lerian_map`, the board/milestone identity.
+
 ### Changed — Expand observability migration to context and HTTP/gRPC middleware
 
 - `ring:migrate-observability` now treats deprecated `commons/net/http` HTTP/gRPC logging and telemetry middleware symbols as symbol-level migration targets to `lib-observability/middleware`, while keeping non-observability HTTP helpers in lib-commons.

--- a/dev-team/skills/managing-dev-cycle/SKILL.md
+++ b/dev-team/skills/managing-dev-cycle/SKILL.md
@@ -50,6 +50,7 @@ Display the current development cycle status.
 Displays:
 - Current cycle ID and start time
 - Current phase (if `phases[]` is present in state)
+- Task source (`plan_file` / `plan_file_synced` / `lerian_map`; absent in older state files → infer `plan_file_synced` when `lerian_map_sync.enabled == true`, else `plan_file`). For `lerian_map`, also show the board/milestone identity (`lerian_map_sync.board` + `lerian_map_source`)
 - Epics: total, completed, in progress, pending
 - Current epic and gate being executed
 - Assertiveness score (if epics completed)
@@ -64,6 +65,7 @@ Cycle ID: 2024-01-15-143000
 Started: 2024-01-15 14:30:00
 Status: in_progress
 Phase: Phase 2 - Core flows
+Task source: lerian_map — product 13 / team 5, milestone Desenvolvimento (433)
 
 Epics:
   Completed: 2/5
@@ -98,7 +100,7 @@ Or resume an interrupted cycle:
 
 1. **Discover state file** — check both paths per "Shared: State File Discovery" above
 2. **Read JSON** — parse `current-cycle.json`
-3. **Extract fields** — cycle ID, start time, status (incl. `paused_for_epic_approval`, `paused_for_phase_review`), `current_phase` and `phases[]` (if present), `epics[]` list, `current_epic_index`/gate, iterations
+3. **Extract fields** — cycle ID, start time, status (incl. `paused_for_epic_approval`, `paused_for_phase_review`), `current_phase` and `phases[]` (if present), `task_source` (with the inference fallback above) plus `lerian_map_sync.board`/`lerian_map_source` when `task_source == "lerian_map"`, `epics[]` list, `current_epic_index`/gate, iterations
 4. **Compute metrics** — count completed/in-progress/pending epics from `epics[]`, calculate elapsed time, average assertiveness score across completed epics
 5. **Display** — format and present the output as shown above
 

--- a/dev-team/skills/running-dev-cycle/SKILL.md
+++ b/dev-team/skills/running-dev-cycle/SKILL.md
@@ -11,7 +11,7 @@ description: "Running the backend dev cycle: implements every task in a rolling-
 - Need structured, gate-based epic execution with quality checkpoints and phase cadence
 
 ## Skip when
-- No plan file exists
+- No plan file exists AND the Lerian Map is not the task source (in `lerian_map` mode no local plan is required — the cycle materializes one from the board)
 - Task is documentation-only or planning-only
 - Frontend project (use ring:running-dev-cycle-frontend instead)
 
@@ -20,7 +20,7 @@ You orchestrate. Agents execute. You NEVER read, write, or edit source code dire
 
 ## How This Works
 
-Load the phased plan (plan.md, ring:writing-plans canonical format) and execute the lean backend cycle. The plan is rolling-wave phased: a `## Phase Overview` table (phases + milestone + status), phase sections containing `### Epic N.M:` headings (each epic carries a `**Status:**` line: Pending/Doing/Done/Failed), and inline dispatch-ready `#### Task N.M.T:` blocks written under each epic of the currently-detailed wave. Only the active wave is task-detailed; later phases are epic-level and get elaborated at each phase boundary. Backend implementation owns local runtime and quality so the flow does not dispatch separate QA, SRE, or DevOps gates.
+Load the phased plan (plan.md, ring:writing-plans canonical format) and execute the lean backend cycle. **Exception — board as source:** when cycle-init question 3 (Task source) = `Lerian Map (board is the source)`, do NOT require a plan path — run the Init flow in `## Lerian Map as Task Source (optional)` to materialize the derived plan first, then proceed identically against it. The plan is rolling-wave phased: a `## Phase Overview` table (phases + milestone + status), phase sections containing `### Epic N.M:` headings (each epic carries a `**Status:**` line: Pending/Doing/Done/Failed), and inline dispatch-ready `#### Task N.M.T:` blocks written under each epic of the currently-detailed wave. Only the active wave is task-detailed; later phases are epic-level and get elaborated at each phase boundary. Backend implementation owns local runtime and quality so the flow does not dispatch separate QA, SRE, or DevOps gates.
 
 **Vocabulary:** Phase = independently verifiable milestone. Epic (Epic N.M) = value-driven increment, the UNIT this cycle iterates. Task (Task N.M.T) = dispatch-ready unit, the Gate 0 execution unit.
 
@@ -40,6 +40,9 @@ Gate 0 includes TDD RED/GREEN, coverage threshold enforcement, docker-compose/lo
 ## Execution Order
 
 ```yaml
+# INIT: when task_source == "lerian_map", materialize the derived plan from the board first
+# (see "## Lerian Map as Task Source (optional)") — every loop below runs unchanged against it
+
 for each phase (current wave; starts at Phase 1, the only detailed phase at init):
 
   for each epic in this phase (plan order):
@@ -134,7 +137,7 @@ Read `gates/cycle-completion.md` from this skill directory and execute Steps 12.
 
 ## Execution Modes
 
-Ask user at cycle start (two independent questions):
+Ask user at cycle start (independent questions, in the order given at the end of this section):
 
 **1. Execution mode** (epic/task checkpoint cadence):
 
@@ -153,23 +156,32 @@ Ask user at cycle start (two independent questions):
 
 Mode and phase_checkpoint affect CHECKPOINTS (user approval pauses), not GATES. All listed gates execute regardless of mode. The phase boundary's elaboration step runs in BOTH phase_checkpoint values — only the pause differs.
 
-**3. Lerian Map Sync** (OPTIONAL — default No; see `## Lerian Map Sync (optional)`):
+**3. Task source** (`state.task_source`; see `## Lerian Map Sync (optional)` and `## Lerian Map as Task Source (optional)`):
 
-Ask AFTER execution mode and BEFORE commit timing (the Map decision — esp. `Done` = push-to-develop — influences how the user thinks about commit cadence). Both questions are optional and default to today's behavior (No → zero Gandalf calls, feature fully off).
+Ask AFTER execution mode and BEFORE commit timing (the Map decision — esp. `Done` = push-to-develop — influences how the user thinks about commit cadence). The Map options are opt-in: users who don't use the Map pick `Local plan` and see zero behavior change (zero Gandalf calls, feature fully off).
+
+⛔ **HARD REQUIREMENT: single-select (`multiSelect: false`), exactly ONE option, explicitly selected by the user — NO silent default applied without asking.**
 
 ```yaml
 AskUserQuestion:
-  question: "Do these activities have a mapping in the Lerian Map (kanban board)?"
-  header: "Lerian Map Sync"
+  question: "Where do this cycle's tasks come from?"
+  header: "Task source"
+  multiSelect: false
   options:
-    - label: "No"          # default → no board sync, no Gandalf calls
-    - label: "Yes — sync"  # → run the Lerian Map Sync handshake (see "Lerian Map Sync (optional)")
+    - label: "Local plan"                        # → task_source = "plan_file"
+    - label: "Local plan + Map sync"             # → task_source = "plan_file_synced"
+    - label: "Lerian Map (board is the source)"  # → task_source = "lerian_map"
 ```
 
-- **No:** set `state.lerian_map_sync.enabled = false` (or omit the object); skip the Testing-gate question; behave exactly as today.
-- **Yes — sync:** set `state.lerian_map_sync.enabled = true`, then ask the Testing-gate question below, and run the discovery handshake (see `## Lerian Map Sync (optional)`) before the first Gate 0.
+| Option | `state.task_source` | Behavior |
+|--------|---------------------|----------|
+| **Local plan** | `"plan_file"` | plan.md is the source. No board involvement — set `state.lerian_map_sync.enabled = false` (or omit the object), skip the Testing-gate question, **zero Gandalf/Map calls ever**. Today's default behavior. |
+| **Local plan + Map sync** | `"plan_file_synced"` | plan.md is the source; status is pushed to the board at the existing hooks (exactly the `## Lerian Map Sync (optional)` behavior). Set `state.lerian_map_sync.enabled = true`, then ask the Testing-gate question, and run the discovery handshake before the first Gate 0. |
+| **Lerian Map (board is the source)** | `"lerian_map"` | The Lerian Map board IS the task source — see `## Lerian Map as Task Source (optional)`. Also set `state.lerian_map_sync.enabled = true` (source mode implies status sync) and ask the Testing-gate question. |
 
-**4. Testing gate** (OPTIONAL — only asked when Lerian Map Sync = Yes; stored in `state.lerian_map_sync.testing_gate`):
+**Resume backward compatibility:** if an existing `current-cycle.json` has no `task_source` field, infer `"plan_file_synced"` when `lerian_map_sync.enabled == true`, else `"plan_file"`. NEVER re-ask this question on resume.
+
+**4. Testing gate** (OPTIONAL — only asked when the task source involves the Map (`plan_file_synced` or `lerian_map`); stored in `state.lerian_map_sync.testing_gate`):
 
 ```yaml
 AskUserQuestion:
@@ -182,7 +194,9 @@ AskUserQuestion:
 
 ⚠️ **Does NOT override Gate 9.** Gate 9 (validation/acceptance) is a CRITICAL, non-bypassable gate that always requires explicit user approval per epic (Step 11.1). The Testing gate is a SEPARATE, Map-aware control over the *manual-test wait before PR/develop* — it can only relax that extra Testing wait, never the mandatory Gate 9 acceptance.
 
-**Resulting cycle-init question order:** execution mode → phase checkpoint → **Lerian Map Sync?** → **Testing gate** (only if sync = Yes) → commit timing.
+**5. Commit timing** (`state.commit_timing ∈ {per_task, per_epic, at_end}`): when commits happen during the cycle — see `## Commit Timing` for what each value commits at which gate.
+
+**Resulting cycle-init question order:** execution mode → phase checkpoint → **Task source** → **Testing gate** (only when the source involves the Map) → commit timing.
 
 ## Custom Instructions
 
@@ -209,13 +223,13 @@ If user provides custom context at cycle start, store in `state.custom_prompt` a
 
 ## Lerian Map Sync (optional)
 
-**OPTIONAL and default-off.** When enabled (cycle-init question 3 = `Yes — sync`), this feature keeps the Lerian Map kanban board in sync as epics/tasks move through the gates. When off (the default), the cycle behaves exactly as before — **zero Gandalf calls**. The feature **never blocks gate execution** and **never weakens any mandatory gate** (Gate 9 acceptance still requires explicit user approval per epic, regardless of the Testing-gate setting).
+**OPTIONAL and opt-in.** When enabled (cycle-init question 3 Task source = `Local plan + Map sync`, or implied by `Lerian Map (board is the source)` — see `## Lerian Map as Task Source (optional)`), this feature keeps the Lerian Map kanban board in sync as epics/tasks move through the gates. When off (`Local plan`), the cycle behaves exactly as before — **zero Gandalf calls**. The feature **never blocks gate execution** and **never weakens any mandatory gate** (Gate 9 acceptance still requires explicit user approval per epic, regardless of the Testing-gate setting).
 
 **Hard rule:** the synced status follows the **real board columns exactly** — no invented stand-in statuses. Column enum strings are **read from the board at runtime via Gandalf, never hardcoded**.
 
 ### Discovery handshake (run once, after the cycle-init questions, before the first Gate 0)
 
-When Map sync = Yes, run a one-time handshake (each Gandalf ask is a fresh, self-contained session carrying the full discovery payload):
+When `state.lerian_map_sync.enabled`, run a one-time handshake (each Gandalf ask is a fresh, self-contained session carrying the full discovery payload):
 
 1. **Fetch board tasks via Gandalf** for this repo's product. Discovery is **repo-driven**: map the local git remote to a product via the Map's native **`repositoryUrl`** field on `GET /products` (no manual `productId`/`teamId`/`milestoneId`). Normalize the remote first (`git@github.com:org/repo.git` → `https://github.com/org/repo`).
 2. **Match board cards ↔ local plan units.** Features are matched **by NAME** (e.g. `"E-1.1 …"` / the epic title) — Map features have **no `slug` field**, so name is the feature key (the `docs/pre-dev/{feature}/` path slug has no API equivalent and is only a weak hint). The deterministic per-task matching key is the **`[map:#<board_task_id>]` tag** embedded in the plan/task block; when a tag is present Gandalf skips fuzzy matching entirely. **Title-matching is the fallback** when no tag is present.
@@ -310,6 +324,60 @@ When `state.lerian_map_sync.enabled`, the orchestrator fires the async, fire-and
 - **Known frictions:** no feature slug (match by name — fragile → use `[map:#id]` tags); `iterationId` can be `null`; `GET /teams` currently returns 500 (use `teamId` from the tasks payload instead).
 - **Discovery path:** `repo → /products(repositoryUrl) → /features?productId(name) → /tasks?featureId`.
 
+## Lerian Map as Task Source (optional)
+
+**OPTIONAL.** Active only when `state.task_source == "lerian_map"` (cycle-init question 3 = `Lerian Map (board is the source)`). In this mode the Lerian Map board — not a local plan.md — is the source of truth for WHAT to build and for STATUS. The cycle materializes a derived plan from the board at init, then runs every existing gate unchanged against it. Reuses the discovery handshake, Gandalf transport, status mapping, checkpoint hooks, and degradation rules from `## Lerian Map Sync (optional)` — none of that is duplicated here.
+
+**Hierarchy mapping (Map → plan):**
+
+| Lerian Map | Plan (canonical ring:writing-plans format) |
+|------------|--------------------------------------------|
+| `milestone` | Phase (`## Phase N:` section + Phase Overview row) |
+| `feature` | Epic (`### Epic N.M:`) |
+| `task` | Task (`#### Task N.M.T:`) |
+| `task.body` (markdown, ≤ 20,000 chars) | The dispatch-ready task block: Context (with file:line refs), Implementation vision, Files, Verification, Done when |
+
+### Init flow (source = lerian_map; runs once, instead of loading a local plan)
+
+1. **Discover the board** — run the discovery handshake from `## Lerian Map Sync (optional)` SCOPED for source mode: execute handshake step 1 (repo-driven product discovery) and step 5 (persist into state); SKIP handshake steps 2–4 (card ↔ plan matching, preview, tag auto-injection — there is no local plan to match). Additionally resolve the **milestone** to execute: candidates are milestones that are not fully `done`/`canceled`, lowest `order` first; if more than one candidate exists, AskUserQuestion to pick one. Persist the milestone identity into `state.lerian_map_source` (canonical — see `gates/state-schema.md`).
+2. **Fetch the source data via Gandalf** (`action: ask`, self-contained prompt): milestone → features → tasks, requesting for each task: `id`, `title`, `body`, `status`, `priority`, `feature.{id,name}`, `milestone.{id,name,order}`. After the fetch, populate `state.lerian_map_sync.matches[]` from the resolved milestone's tasks: every unit is board-born, so it is matched by construction.
+3. **Body hygiene validation (current milestone ONLY):** every current-milestone task must carry a `body` that is a dispatch-ready block. Sufficiency = the Step 11.5.5 validation bar (`gates/phase-boundary.md`): no "TBD"/vague deferrals; Context with file:line refs; Implementation vision; Files; Verification; Done when. For any current-milestone task with an empty/insufficient body → AskUserQuestion:
+   - **(a) Elaborate now** — dispatch ONE planning agent in ANALYSIS mode (same mechanism as Step 11.5.4 in `gates/phase-boundary.md`) to produce the dispatch-ready block, then push it to the Map task `body` via Gandalf. A SYNCHRONOUS push is acceptable here — init is the strict point and the body must land before the source is trusted; mid-cycle body pushes stay fire-and-forget.
+   - **(b) Abort init** — stop so the user fills the board first.
+
+   Future-milestone tasks are EXPECTED to have empty bodies — that is the rolling wave; they get elaborated at phase boundaries (Step 11.5).
+4. **Materialize the derived plan** — write `docs/ring:running-dev-cycle/plan-from-map.md` in the canonical ring:writing-plans format, generated from the fetched board data: `## Phase Overview` table from milestones, `### Epic N.M:` sections from features, `#### Task N.M.T:` blocks from task bodies. Phases are renumbered 1..N from the milestones sorted by `milestone.order` (orders need not be contiguous). Phase Overview Status cells: milestones earlier than the resolved one → `Complete`; the resolved milestone → `Detailed`; later ones → `Epic-level`. Tag EVERY epic and task heading with the `[map:#<id>]` convention (the deterministic matching key — see `## Lerian Map Sync (optional)`). Future-milestone tasks ARE materialized as tagged `#### Task N.M.T: … [map:#<id>]` headings with EMPTY bodies — they already exist on the board and carry ids; the init parser ignores them (`gates/state-schema.md`: their epics load with `tasks: []`) until their phase is elaborated at its boundary. Map each fetched board status into the plan `**Status:**` word:
+
+   | Fetched board status | Plan `**Status:**` word |
+   |----------------------|-------------------------|
+   | `done` | `Done` |
+   | `in_progress` / `testing` / `to_review` | `Doing` |
+   | anything else (`backlog`, `todo`, `on_hold`, `blocked`, `canceled`) | `Pending` |
+
+   The table maps per-TASK board statuses, but in the canonical plan format the `**Status:**` line exists per-EPIC (task blocks carry `- [ ] Done` checkboxes, not Status lines). Apply it as follows:
+   - **Epic aggregation:** derive each epic's `**Status:**` word by aggregating its tasks' mapped words: all `Done` → `Done`; any `Doing` → `Doing`; otherwise `Pending`.
+   - **Checkbox materialization:** each `done` board task is materialized with its checkbox checked (`- [x] Done`) so completion is visible in the derived plan.
+   - **Gate 0 implication:** tasks materialized as `- [x] Done` are already complete and are NOT re-executed at Gate 0 — skip them; a mid-flight milestone resumes from the first unchecked task.
+
+   Set `state.source_file` to this derived plan. From here on, ALL existing gates (0 / 8 / 9 / 11.5 / 12.x) run unchanged against it.
+5. **Source-of-truth rule:** the derived plan is an internal, regenerable execution artifact; the board remains the source of truth for WHAT and STATUS. Manual edits to the derived plan that change task content MUST be pushed back to the corresponding Map task `body` (matched via the `[map:#<id>]` tag — see write-back rules below).
+
+**Resume rule:** on `--resume` with `task_source == "lerian_map"` and the derived plan missing from disk, re-run init steps 2 + 4 (fetch + materialize) before resuming the gates — state indices stay authoritative. If the Map is unreachable during this regeneration → treat it as the INIT degradation case below (Retry / fall back / Abort).
+
+### During the cycle
+
+- **Status:** flows to the board via the existing checkpoint hooks (`## Lerian Map Sync (optional)` → Checkpoint hooks). No changes — source mode implies status sync.
+- **Body write-back:** when Gate 8/9 outcomes cause a documented deviation from a task's plan block (the block's content changes), push the updated block to that task's Map `body` — async fire-and-forget, same `pending → dispatched → synced` degradation rules as status pushes. NEVER blocks a gate.
+
+### Phase boundary (Step 11.5)
+
+After the planning agent elaborates the next phase's tasks into the derived plan, push each elaborated task block to the matching Map task `body` (match by `[map:#<id>]`). **Reconciliation:** board/local mismatches are surfaced to the user — never silently created or deleted; the full rule (and its best-effort board fetch) lives in `gates/phase-boundary.md` Step 11.5.5b. This is the rolling-wave behavior: future milestones start with empty bodies and get filled as development reaches them.
+
+### Graceful degradation (source mode is stricter than sync mode at init)
+
+- **At INIT:** Gandalf/Map unreachable = the task source itself is unavailable → AskUserQuestion: **Retry** / **Fall back to a local plan** (switch `state.task_source` to `"plan_file"` AND set `state.lerian_map_sync.enabled = false` — or remove the `lerian_map_sync` object entirely, incl. `testing_gate` — so no sync hook ever fires; ask for the plan path; zero further Map calls) / **Abort**.
+- **DURING the cycle:** the derived plan already holds everything the gates need, so Map outages degrade exactly like sync mode (`pending` + `degraded`, fire-and-forget reconciliation — see `## Lerian Map Sync (optional)`) and NEVER block gates.
+
 ## Blocker Handling
 
 | Blocker | Action |
@@ -350,6 +418,7 @@ A gate is complete ONLY when ALL components succeed:
 |--------|------|
 | Plan (pre-dev flow) | `docs/pre-dev/{feature}/plan.md` |
 | Plan (standalone ring:writing-plans) | `docs/plans/*.md` |
+| Derived plan (Lerian Map as task source) | `docs/ring:running-dev-cycle/plan-from-map.md` — materialized at init when `task_source == "lerian_map"`; see `## Lerian Map as Task Source (optional)` |
 | Legacy tasks (in-flight cycles ONLY) | `docs/pre-dev/{feature}/tasks.md` (old `## Summary` table + E-/T- ids) — accepted only when `current-cycle.json` already exists (init is not re-run); new cycles MUST start from the canonical plan format |
 | Phase tasks | inside the plan, under each epic (`#### Task N.M.T:` blocks) |
 | Refactor tasks | `docs/ring:planning-backend-refactor/*/tasks.md` |

--- a/dev-team/skills/running-dev-cycle/gates/gate-0-implementation.md
+++ b/dev-team/skills/running-dev-cycle/gates/gate-0-implementation.md
@@ -77,6 +77,8 @@ implementation_input = {
 }
 ```
 
+ℹ️ When `state.task_source == "lerian_map"`, the task block read from the (derived) plan originated from the Map task `body` — same contract, no behavioral change here (see SKILL.md `## Lerian Map as Task Source (optional)`).
+
 ### Step 2.2: Invoke ring:implementing-tasks Skill
 
 ```text

--- a/dev-team/skills/running-dev-cycle/gates/phase-boundary.md
+++ b/dev-team/skills/running-dev-cycle/gates/phase-boundary.md
@@ -71,6 +71,11 @@ TASK-AUTHORING BAR (from the ring:writing-plans Task Format — non-negotiable):
 - NO "TBD" / "TODO" / "figure out during implementation" — the detailed wave admits no deferrals.
 - Touch ONLY Phase {next_phase}'s epic blocks. Do NOT detail any later phase.
 
+{Include ONLY when state.task_source == "lerian_map":}
+BOARD-AS-SOURCE MODE: this plan is derived from the Lerian Map. Fill the existing tagged
+`#### Task N.M.T: … [map:#<id>]` stubs IN PLACE, preserving every `[map:#<id>]` tag
+verbatim. Create an untagged new task block ONLY when no board stub fits the work.
+
 RETURN: a summary of tasks written per epic, AND flag any epic whose scope no longer
 matches the codebase reality (deviations made it redundant, larger, smaller, or wrong).
 ```
@@ -86,6 +91,14 @@ After the agent returns, the orchestrator verifies (this is the elaboration's qu
 5. **Scope divergence** — if the agent flagged any epic whose scope no longer matches reality → surface it to the user BEFORE continuing (even when `phase_checkpoint == "auto"` — a scope mismatch is a plan-correctness signal, not a routine pause). Let the user accept the agent's adjusted scope, edit the plan, or drop the epic.
 
 If any check fails → re-dispatch the planning agent with the specific gap, or (for scope divergence) resolve with the user. Do NOT enter Gate 0 on an incompletely elaborated phase.
+
+### Step 11.5.5b: Lerian Map Source Write-Back (Conditional — `state.task_source == "lerian_map"` only)
+
+Runs after Step 11.5.5 validates the elaboration, ONLY in board-as-source mode. Mechanics and degradation rules live in SKILL.md `## Lerian Map as Task Source (optional)` — not duplicated here:
+
+0. **Fetch (best-effort):** fetch the next milestone's tasks via Gandalf — ids + titles + a body-empty flag — as the reconciliation baseline. On fetch failure → log a warning, set `state.lerian_map_sync.degraded = true`, SKIP reconciliation (step 2) for this boundary, and re-attempt at the next trigger (next checkpoint / `--resume` / end of cycle). NEVER blocks the boundary; the body write-back (step 1) still fires from the local `[map:#<id>]` tags.
+1. **Body write-back:** for each task block the planning agent wrote into the derived plan (Step 11.5.4), push the block to the matching Map task `body` via Gandalf — matched by the `[map:#<id>]` tag. Async fire-and-forget, same `pending → dispatched → synced` rules as status pushes; NEVER blocks the boundary.
+2. **Reconciliation:** a next-milestone board task with no counterpart task block, or an agent-created task block with no board counterpart → surface it to the user before resuming the epic loop (same treatment as Step 11.5.5's scope-divergence rule — even when `phase_checkpoint == "auto"`). The user reconciles (add the block, create/drop the board task on the Map themselves, or drop the local block). Do NOT silently create or delete board tasks.
 
 ### Step 11.5.6: Update State and Resume the Epic Loop
 

--- a/dev-team/skills/running-dev-cycle/gates/state-schema.md
+++ b/dev-team/skills/running-dev-cycle/gates/state-schema.md
@@ -9,6 +9,7 @@ The state file path depends on the **source of the plan**:
 | `docs/ring:planning-backend-refactor/*/tasks.md` | `docs/ring:planning-backend-refactor/current-cycle.json` | Refactoring existing code |
 | `docs/pre-dev/*/plan.md` | `docs/ring:running-dev-cycle/current-cycle.json` | New feature development. Legacy `tasks.md` (old `## Summary` table + E-/T- ids) is accepted ONLY for cycles already in flight — a `current-cycle.json` already exists and init is not re-run on them. New cycles MUST start from the canonical plan format. |
 | `docs/plans/*.md` (standalone ring:writing-plans) | `docs/ring:running-dev-cycle/current-cycle.json` | Standalone plan execution |
+| `docs/ring:running-dev-cycle/plan-from-map.md` (derived, `task_source == "lerian_map"`) | `docs/ring:running-dev-cycle/current-cycle.json` | Board-as-source mode: the derived plan is materialized from the Lerian Map at init (SKILL.md `## Lerian Map as Task Source (optional)`) and parses identically to a canonical plan |
 | Any other path | `docs/ring:running-dev-cycle/current-cycle.json` | Default for manual plans |
 
 **Detection Logic:**
@@ -34,11 +35,13 @@ State is persisted to `{state_path}` (either `docs/ring:running-dev-cycle/curren
   "source_file": "path/to/plan.md",
   "state_path": "docs/ring:running-dev-cycle/current-cycle.json | docs/ring:planning-backend-refactor/current-cycle.json",
   "cycle_type": "feature | refactor",
+  "_comment_task_source": "Where this cycle's tasks come from (cycle-init question 3, SKILL.md Execution Modes — single-select, explicitly chosen by the user). 'plan_file' = local plan.md, zero Gandalf/Map calls (today's default behavior). 'plan_file_synced' = local plan.md is the source + status pushed to the Lerian Map board (lerian_map_sync.enabled = true). 'lerian_map' = the board IS the task source: source_file points at the derived docs/ring:running-dev-cycle/plan-from-map.md and lerian_map_sync.enabled = true (source mode implies sync). RESUME INFERENCE (backward compatibility): a current-cycle.json without task_source infers 'plan_file_synced' when lerian_map_sync.enabled == true, else 'plan_file' — NEVER re-ask on resume.",
+  "task_source": "plan_file|plan_file_synced|lerian_map",
   "execution_mode": "manual_per_task|manual_per_epic|automatic",
   "commit_timing": "per_task|per_epic|at_end",
   "_comment_phase_checkpoint": "Asked at cycle init alongside execution_mode. 'manual' (default): AskUserQuestion at each phase boundary (Step 11.5) before elaborating the next phase. 'auto': log a phase summary and continue without pausing.",
   "phase_checkpoint": "manual|auto",
-  "_comment_lerian_map_sync": "OPTIONAL / ADDITIVE. Present ONLY when the user answered 'Yes — sync' to the cycle-init Lerian Map Sync question (SKILL.md Execution Modes, question 3). Absent or enabled:false ⇒ feature off ⇒ zero Gandalf calls ⇒ today's behavior. All Map I/O is async fire-and-forget via the gandalf-webhook; the cycle never polls/blocks. See SKILL.md '## Lerian Map Sync (optional)' for full mechanics. status_enum is READ from the board at runtime (never hardcoded); discovery (productId/teamId/milestoneId) is DISCOVERED by Gandalf from the repo's git remote, not hardcoded.",
+  "_comment_lerian_map_sync": "OPTIONAL / ADDITIVE. Present ONLY when task_source is 'plan_file_synced' or 'lerian_map' (cycle-init Task source question, SKILL.md Execution Modes, question 3). Absent or enabled:false ⇒ feature off ⇒ zero Gandalf calls ⇒ today's behavior. All Map I/O is async fire-and-forget via the gandalf-webhook; the cycle never polls/blocks. See SKILL.md '## Lerian Map Sync (optional)' for full mechanics. status_enum is READ from the board at runtime (never hardcoded); discovery (productId/teamId/milestoneId) is DISCOVERED by Gandalf from the repo's git remote, not hardcoded.",
   "lerian_map_sync": {
     "enabled": true,
     "transport": "gandalf",
@@ -63,6 +66,12 @@ State is persisted to `{state_path}` (either `docs/ring:running-dev-cycle/curren
     ],
     "pending": [],
     "degraded": false
+  },
+  "_comment_lerian_map_source": "Present ONLY when task_source == 'lerian_map' (SKILL.md '## Lerian Map as Task Source (optional)'). Identity of the board milestone being executed as the task source. PRECEDENCE: in source mode lerian_map_source.milestone_id is CANONICAL; lerian_map_sync.board.milestoneId is a discovery-time echo only and MUST be overwritten to match it (or dropped in source mode) — never read board.milestoneId for source-mode decisions. Board/product identity stays in lerian_map_sync.board (discovery handshake, not duplicated); per-epic/per-task board ids live in the [map:#<id>] tags of the derived plan and in lerian_map_sync.matches[] — the same pattern sync mode already uses.",
+  "lerian_map_source": {
+    "milestone_id": 433,
+    "milestone_name": "Desenvolvimento",
+    "fetched_at": "2026-06-11T15:00:00Z"
   },
   "_comment_cached_standards": "Populated by Step 1.5 (Standards Pre-Cache). Dictionary of URL → {fetched_at, content}. Sub-skills MUST read from here instead of calling WebFetch.",
   "cached_standards": {},
@@ -231,7 +240,7 @@ State schema is `version: "2.0.0"` (phased rolling-wave model).
 
 ### Initialization (Parse the Phased Plan)
 
-At cycle init, parse `state.source_file` (plan.md, ring:writing-plans canonical format):
+At cycle init, parse `state.source_file` (plan.md, ring:writing-plans canonical format). In `lerian_map` mode (`task_source == "lerian_map"`), `source_file` is the derived `docs/ring:running-dev-cycle/plan-from-map.md` materialized from the board before this step (SKILL.md `## Lerian Map as Task Source (optional)`) — it is canonical-format and everything below applies unchanged:
 
 1. **Phase Overview** (`## Phase Overview` table: `| Phase | Milestone | Epics | Status |`) → `phases[]`. Map the Status cell: `Epic-level` → `"epic-level"`, `Detailed` → `"detailed"`, `Complete` → `"complete"`. Set `current_phase` to the lowest phase whose status is `detailed` (the active wave; normally Phase 1). This table contract is unchanged.
 2. **Epic registry** — ALL epics load into `epics[]` from the `### Epic N.M:` headings under each phase section (`## Phase N:` ...). There is NO `## Summary` table — do not look for one. Each epic's `phase` field comes from the phase section it sits under (and from `N` in its id). Each epic block carries a `**Status:**` line (`Pending` / `Doing` / `Done` / `Failed` — plain words are the contract; emoji decoration optional). Read it into `epic.status` at init; this line is also the write target for epic status updates.
@@ -246,7 +255,7 @@ At cycle init, parse `state.source_file` (plan.md, ring:writing-plans canonical 
    | `Failed` | `failed` |
 
    On init (read): the plan word on the left sets the enum value on the right. On epic checkpoints (write): the enum transition on the right writes the plan word on the left (e.g., `epic.status = "in_progress"` → plan line becomes `Doing`). The enum value `blocked` has no plan word — a blocked epic keeps `Doing` in the plan until it resolves to `Done` or `Failed`.
-3. **Task blocks** — for each epic in a `detailed` phase, parse the inline `#### Task N.M.T:` blocks under its epic section into `epics[i].tasks[]` (id, and the implementation gate_progress skeleton). Epics in `epic-level` phases load with `tasks: []` — they are elaborated at their phase boundary (Step 11.5).
+3. **Task blocks** — for each epic in a `detailed` phase, parse the inline `#### Task N.M.T:` blocks under its epic section into `epics[i].tasks[]` (id, and the implementation gate_progress skeleton). A task block whose checkbox is already checked (`- [x] Done` — e.g. a `done` board task in a `lerian_map`-derived plan) loads with `status: "completed"` and `gate_progress.implementation.status: "completed"` — Gate 0 skips it; execution resumes from the first unchecked task. Epics in `epic-level` phases load with `tasks: []` — they are elaborated at their phase boundary (Step 11.5). In `lerian_map` mode the derived plan DOES carry tagged, empty-body `#### Task N.M.T: … [map:#<id>]` stubs under epic-level phases (they already exist on the board with ids) — the parser ignores those too until their phase is elaborated.
 
 **FALLBACK — no `## Phase Overview`** (ring:planning-backend-refactor output, flat plans):
 - Synthesize a single `phases[] = [{phase: 1, milestone: "<feature> (flat plan)", status: "detailed"}]`, `current_phase = 1`. Every epic gets `phase: 1`.


### PR DESCRIPTION
## Summary

Builds on #412 (push-only status sync) to let the **Lerian Map board be the task source** for the dev-cycle — fully opt-in.

The cycle-init Lerian Map question becomes a **single-select task source question** (exactly one option, explicitly chosen, no silent default):

| Option | `state.task_source` | Behavior |
|--------|---------------------|----------|
| Local plan | `plan_file` | Today's behavior — zero Gandalf/Map calls ever |
| Local plan + Map sync | `plan_file_synced` | Exactly the #412 push-only status sync |
| Lerian Map (board is the source) | `lerian_map` | Board is the task source (new) |

## `lerian_map` mode

- **Init:** discovery (scoped handshake reuse) → resolve milestone → fetch milestone/features/tasks via Gandalf → body-hygiene validation for the current milestone (empty body → offer to elaborate now, synchronous at init) → materialize a derived `plan-from-map.md` tagged `[map:#id]` → all gates run unchanged on the derived plan
- **Hierarchy mapping:** milestone = Phase, feature = Epic, task = Task, task `body` (markdown ≤20k) = dispatch-ready block
- **Status mapping:** board statuses → plan Status words with epic-level aggregation; `done` board tasks materialize as `- [x] Done` and are **skipped at Gate 0** (mid-flight milestones resume from the first unchecked task)
- **Rolling wave:** phase-boundary elaboration fills the tagged stubs in place and pushes the blocks back to next-milestone task bodies; best-effort reconciliation surfaces mismatches and never silently creates/deletes board tasks
- **Degradation:** init is the only strict point (retry / fall back to local plan with sync disabled / abort); mid-cycle Map outages degrade exactly like sync mode and never block gates
- **Resume:** `task_source` is inferred for pre-existing state files and never re-asked; a deleted derived plan is regenerated from the board

## Files

- `running-dev-cycle/SKILL.md` — task source question (questions now numbered 1–5), new `## Lerian Map as Task Source (optional)` section, entry-path exception for plan-less init
- `gates/state-schema.md` — `task_source`, `lerian_map_source` (canonical milestone identity), `- [x]` parsed as completed
- `gates/phase-boundary.md` — Step 11.5.5b body write-back + reconciliation; source-aware elaboration prompt
- `gates/gate-0-implementation.md` — provenance note
- `managing-dev-cycle/SKILL.md` — status display shows task source + board identity
- `CHANGELOG.md` — Unreleased entry

## Validation

- 2 full review rounds (docs reviewer): 13 findings in round 1, all resolved and re-verified in round 2; 2 residual items (epic-level status aggregation, `matches[]` timing) fixed after
- Grep sweeps confirm no stale references to the old Yes/No sync question; `running-dev-cycle-frontend` untouched (has no Map integration — noted as follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)