### PR TITLE
fix(dev-team): migrate-observability skill bumps lib-commons v5.7.0 and lib-observability v1.1.0

### DIFF
--- a/dev-team/CHANGELOG.md
+++ b/dev-team/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed — Bump observability stack to lib-commons v5.7.0 + lib-observability v1.1.0
+
+- Updated the documented stable targets across the dev-team and pm-team skill set to lib-commons `v5.7.0` and lib-observability `v1.1.0`: `dev-team/agents/backend-go.md`, `dev-team/skills/using-lib-observability/SKILL.md`, `dev-team/skills/using-lib-systemplane/SKILL.md` (companion dependency), and `pm-team/skills/shared-patterns/code-example-standards.md`. Historical migration-baseline notes (e.g. the `v5.2.0` / `v1.0.0` pins) are left unchanged as provenance.
+
 ### Added — Author attribution (on-behalf-of) on Lerian Map writes (`ring:running-dev-cycle`)
 
 - Board writes are now attributed to the person RUNNING the cycle instead of Gandalf's own Map account. A new discovery-handshake step (step 0, both Map modes) resolves the acting user — `git config user.email`/`user.name` in the repo (matches who signs the cycle's commits, per-machine) → session user's email (name may be null — email used alone) → object-level `acting_user: null` when unresolved — stored in `lerian_map_sync.acting_user` (best-effort, never blocking). EVERY write ask (status pushes, date stamps, feature status/`repositoryPath`, body write-backs, comment POST/UPDATE) carries one attribution line; Gandalf resolves email → Map userId at write time and writes with `X-On-Behalf-Of` (impersonate-scoped key held by Gandalf — Ring never sees or stores any secret or Map userId). Fallback in two branches: impersonation-unavailable is delegated to GANDALF inside the ask template (Ring never sees write outcomes — pushes are fire-and-forget) — write under its own identity, and for comments prepend `_em nome de {name} <{email}>_` above the template's first line (~11-line cap in fallback mode); an unresolved `acting_user` omits the attribution line entirely (Ring-side — no em-nome-de possible). UPDATEs preserve an existing em-nome-de first line verbatim, never add one to an attributed comment, and run under the authoring identity (best-effort). See `SKILL.md` → `### Author attribution (on-behalf-of)`.

--- a/dev-team/agents/backend-go.md
+++ b/dev-team/agents/backend-go.md
@@ -5,7 +5,7 @@ description: Senior Backend Engineer specialized in Go for high-demand financial
 
 # Backend Engineer (Go)
 
-You are a Senior Backend Engineer specialized in Go at Lerian Studio. You build financial systems that process millions of transactions daily using hexagonal architecture and the Lerian four-library stack: **lib-commons v5** (lifecycle, outbox repository, circuit breakers, tenant management, HTTP, idempotency), **lib-observability v1.0.0** (logging, tracing, metrics, assertions, panic recovery, redaction), **lib-systemplane** (hot-reloadable runtime config), and **lib-streaming** (past-tense business event emission).
+You are a Senior Backend Engineer specialized in Go at Lerian Studio. You build financial systems that process millions of transactions daily using hexagonal architecture and the Lerian four-library stack: **lib-commons v5** (lifecycle, outbox repository, circuit breakers, tenant management, HTTP, idempotency), **lib-observability v1.1.0** (logging, tracing, metrics, assertions, panic recovery, redaction), **lib-systemplane** (hot-reloadable runtime config), and **lib-streaming** (past-tense business event emission).
 
 ## Core Responsibilities
 

--- a/dev-team/skills/migrating-to-lib-observability/SKILL.md
+++ b/dev-team/skills/migrating-to-lib-observability/SKILL.md
@@ -37,16 +37,17 @@ This skill replaces imports/usages of lib-commons observability APIs
 with their canonical lib-observability equivalents.
 
 **Stable target baseline for this migration:**
-- `github.com/LerianStudio/lib-commons/v5` >= `v5.2.0`
-- `github.com/LerianStudio/lib-observability` >= `v1.0.0`
+- `github.com/LerianStudio/lib-commons/v5` >= `v5.7.0`
+- `github.com/LerianStudio/lib-observability` >= `v1.1.0`
 - `github.com/LerianStudio/lib-auth/v2` >= `v2.8.0` when present
 - `github.com/LerianStudio/lib-license-go/v2` >= `v2.3.5` when present
 - `github.com/LerianStudio/lib-streaming` >= `v1.3.1` when present
 - `github.com/LerianStudio/lib-systemplane` >= `v1.0.0` when systemplane is used
 
-`lib-commons/v5.2.0` is the first stable lib-commons release where the
-deprecated observability shims are removed. `lib-observability/v1.0.0` is the
-first stable lib-observability release. `lib-auth/v2.8.0` and
+`lib-commons/v5.7.0` is the current stable lib-commons target for this
+migration (the deprecated observability shims were first removed in `v5.2.0`).
+`lib-observability/v1.1.0` is the current stable lib-observability target
+release (`v1.0.0` was the first stable release). `lib-auth/v2.8.0` and
 `lib-license-go/v2.3.5` are the first stable companion releases known to be
 compatible with the removed lib-commons observability APIs. `lib-streaming/v1.3.1`
 is the first stable streaming release in this validation set that no longer
@@ -367,7 +368,7 @@ Migration rule:
    if [ -z "$LIB_OBSERVABILITY_DIR" ]; then
      GONOSUMDB="github.com/LerianStudio/lib-observability" \
      GOPRIVATE="github.com/LerianStudio/lib-observability" \
-       go get github.com/LerianStudio/lib-observability@v1.0.0
+       go get github.com/LerianStudio/lib-observability@v1.1.0
      LIB_OBSERVABILITY_DIR=$(go list -m -f '{{.Dir}}' github.com/LerianStudio/lib-observability)
    fi
    DOC_PATH="${LIB_COMMONS_DIR}/commons/log/doc.go"
@@ -607,21 +608,26 @@ If dry_run=true from input, skip this step and show diffs only.
 
 ---
 
-## Step 4: Add lib-observability to go.mod
+## Step 4: Bump lib-commons and add lib-observability in go.mod
 
 ```bash
 # lib-observability may not yet be indexed by the Go sum database.
 # Always use GONOSUMDB + GOPRIVATE to avoid sum.golang.org 404 errors.
-GONOSUMDB="github.com/LerianStudio/lib-observability" \
-GOPRIVATE="github.com/LerianStudio/lib-observability" \
-  go get github.com/LerianStudio/lib-observability@v1.0.0
-# v1.0.0 is the stable target baseline for this migration.
+# Bump both modules together: lib-commons to the current stable target and
+# lib-observability to the current stable target.
+GONOSUMDB="github.com/LerianStudio/*" \
+GOPRIVATE="github.com/LerianStudio/*" \
+  go get github.com/LerianStudio/lib-commons/v5@v5.7.0 \
+         github.com/LerianStudio/lib-observability@v1.1.0
+# v5.7.0 is the stable lib-commons target baseline and v1.1.0 is the stable
+# lib-observability target baseline for this migration.
 ```
 
-Verify it appears in go.mod:
+Verify both appear in go.mod:
 ```bash
-grep "lib-observability" go.mod
-# Expected: github.com/LerianStudio/lib-observability v1.0.0
+grep -E "lib-commons|lib-observability" go.mod
+# Expected: github.com/LerianStudio/lib-commons/v5 v5.7.0
+# Expected: github.com/LerianStudio/lib-observability v1.1.0
 # Note: the entry may be marked "// indirect" at this stage — import paths have
 # not been updated yet (that happens in Step 5). The "// indirect" marker is
 # removed after Step 5 (import replacements) and Step 6 (go mod tidy).

--- a/dev-team/skills/using-lib-observability/SKILL.md
+++ b/dev-team/skills/using-lib-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ring:using-lib-observability
-description: "Using lib-observability v1.0.0, Lerian's OpenTelemetry foundation (lib-commons, lib-systemplane, lib-streaming depend on it), in two modes. Sweep Mode detects DIY zap/slog logging, raw OTel metrics, hand-rolled redaction, and hard-coded attribute strings. Reference Mode catalogs the log, metrics, zap, redaction, and constants packages. Go-only. Skip for non-Go or assert/runtime/tracing."
+description: "Using lib-observability v1.1.0, Lerian's OpenTelemetry foundation (lib-commons, lib-systemplane, lib-streaming depend on it), in two modes. Sweep Mode detects DIY zap/slog logging, raw OTel metrics, hand-rolled redaction, and hard-coded attribute strings. Reference Mode catalogs the log, metrics, zap, redaction, and constants packages. Go-only. Skip for non-Go or assert/runtime/tracing."
 ---
 
 # ring:using-lib-observability
@@ -276,7 +276,7 @@ Surface report path + task count to user; offer handoff to `ring:running-dev-cyc
 
 # REFERENCE MODE
 
-Module: `github.com/LerianStudio/lib-observability` @ `v1.0.0`
+Module: `github.com/LerianStudio/lib-observability` @ `v1.1.0`
 Go: `1.25.9` | OTel: `1.43.0` / `log v0.19.0` | zap: `1.28.0`
 
 ## Package Index

--- a/dev-team/skills/using-lib-systemplane/SKILL.md
+++ b/dev-team/skills/using-lib-systemplane/SKILL.md
@@ -51,7 +51,7 @@ Reference mode:
 - **Module path:** `github.com/LerianStudio/lib-systemplane`
 - **Go version:** 1.26.3+
 - **Tenant context:** `github.com/LerianStudio/lib-commons/v5 v5.0.2` (via `tenant-manager/core`)
-- **Observability:** `github.com/LerianStudio/lib-observability v1.0.0` (`log.Logger`, `tracing.Telemetry`, `runtime.RecoverAndLog`)
+- **Observability:** `github.com/LerianStudio/lib-observability v1.1.0` (`log.Logger`, `tracing.Telemetry`, `runtime.RecoverAndLog`)
 - **Dual backend:** Postgres 13+ (LISTEN/NOTIFY) **or** MongoDB 4.4+ (change streams; polling fallback for standalone deployments)
 - **Provisioning:** migration-only via `systemplane.SchemaSQL()` + `systemplane.DefaultSeedSQL()` public artifacts. Runtime DDL hook (`runSchema`) was removed in v1.6.0. Consumers vendor the artifacts into their own SQL migration pipeline via the `make systemplane-ddl` generator pattern — see `ring:migrating-to-lib-systemplane` Gate 3.5 and `multi-tenant.md` §27 "Cold-tenant resolution"
 - **License:** Elastic 2.0

--- a/pm-team/skills/shared-patterns/code-example-standards.md
+++ b/pm-team/skills/shared-patterns/code-example-standards.md
@@ -9,7 +9,7 @@ This file defines MANDATORY rules for code examples in pre-dev documents (PRDs, 
 MUST use the canonical Lerian libraries instead of creating custom utilities when generating Go code examples. Four libraries cover the surface:
 
 - **lib-commons** (v5) — HTTP, DB drivers, idempotency, security/TLS, lifecycle, outbox, tenant management, RabbitMQ command queues
-- **lib-observability** (v1.0.0) — logging, metrics, tracing, OTel constants, assertions, panic recovery (see [[using-lib-observability]], [[using-tracing]])
+- **lib-observability** (v1.1.0) — logging, metrics, tracing, OTel constants, assertions, panic recovery (see [[using-lib-observability]], [[using-tracing]])
 - **lib-systemplane** — hot-reloadable runtime config (Postgres LISTEN/NOTIFY + MongoDB change streams) (see [[using-lib-systemplane]])
 - **lib-streaming** — past-tense, durable, tenant-scoped business event emission (CloudEvents, outbox-backed) (see [[using-lib-streaming]], [[using-outbox]])
 


### PR DESCRIPTION
## What

Updates the `dev-team/skills/migrating-to-lib-observability` skill so it performs **both** dependency bumps:

- `github.com/LerianStudio/lib-commons/v5` → **v5.7.0**
- `github.com/LerianStudio/lib-observability` → **v1.1.0**

## Changes

- Stable target baseline updated to lib-commons `v5.7.0` and lib-observability `v1.1.0` (historical `v5.2.0` first-removal note preserved).
- Step 4 now bumps both modules together via a single `go get` and verifies both in `go.mod`.
- Step 1 hard-gate fallback fetch bumped to lib-observability `v1.1.0`.

## Why

The migration skill should drive consumers to the current stable targets for both libraries, not just add lib-observability.

Requested-by: @qnen