### PR TITLE
feat(skills): add committing-changes, opening-pull-requests and shipping-changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
   "plugins": [
     {
       "name": "ring-default",
-      "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. Features parallel code review orchestration with 9 default reviewers plus triggered conditional specialists. 22 essential skills for software engineering excellence, including plan authoring and execution.",
-      "version": "1.39.0",
+      "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. Features parallel code review orchestration with 9 default reviewers plus triggered conditional specialists, and git shipping skills (ring:committing-changes, ring:opening-pull-requests, ring:shipping-changes) with scope allowlist enforcement. 25 essential skills for software engineering excellence, including plan authoring and execution.",
+      "version": "1.40.0",
       "source": "./default",
       "homepage": "https://github.com/lerianstudio/ring/tree/main/default",
       "repository": "https://github.com/lerianstudio/ring/tree/main/default",
@@ -24,7 +24,17 @@
         "orchestration",
         "validation",
         "code-review",
-        "parallel-review"
+        "parallel-review",
+        "git",
+        "pull-requests"
+      ],
+      "skills": [
+        "ring:committing-changes",
+        "ring:opening-pull-requests",
+        "ring:shipping-changes"
+      ],
+      "deprecated": [
+        "ring:generating-pr-descriptions"
       ]
     },
     {
@@ -104,5 +114,5 @@
       ]
     }
   ],
-  "version": "0.384.0"
+  "version": "0.385.0"
 }

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -209,7 +209,24 @@ For each commit group, in order:
      --trailer "X-Lerian-Ref: 0x1"
    ```
 
-**If GPG signing fails:** check `git config user.signingkey` and `gpg --list-secret-keys`. If no key configured, proceed without `-S` and inform the user.
+**If GPG signing fails:** check `git config user.signingkey` and `gpg --list-secret-keys`.
+
+If no usable key is found, STOP and ask the user:
+
+```javascript
+AskUserQuestion({
+  questions: [{
+    question: "No GPG signing key is configured. How should I proceed?",
+    header: "GPG Signing",
+    options: [
+      { label: "Configure key first", description: "I'll set up GPG signing before committing" },
+      { label: "Commit unsigned", description: "Proceed without -S for this commit (not recommended)" }
+    ]
+  }]
+});
+```
+
+Only omit `-S` if the user explicitly selects "Commit unsigned". NEVER drop signing silently.
 
 3. Repeat for each commit group.
 

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -236,9 +236,12 @@ Only omit `-S` if the user explicitly selects "Commit unsigned". NEVER drop sign
 
 ```bash
 git log --oneline -<number_of_commits>
-git log --show-signature -1   # if signed
+git verify-commit HEAD                                          # fails non-zero if not signed
+git log -1 --format="%(trailers)" | grep -q '^X-Lerian-Ref: ' # fails if trailer missing
 git status
 ```
+
+If `git verify-commit HEAD` exits non-zero, the commit is unsigned — stop and report to the user. If the `grep` fails, the `X-Lerian-Ref` trailer is missing — stop and report. Both failures indicate Step 6 was not executed correctly.
 
 ---
 
@@ -353,5 +356,5 @@ If the user provides a commit message as an argument:
 | "I'll commit everything at once" | Mixed changes = messy history, hard to bisect/revert. | **Analyze and group changes first** |
 | "Grouping takes too long" | Clean history saves hours of debugging later. | **Always propose commit plan** |
 | "I'll put the trailer text in the message body" | `--trailer` is a GIT FLAG, not message text. | **Use `--trailer "X-Lerian-Ref: 0x1"` as separate argument** |
-| "I'll skip GPG signing" | Unsigned commits cannot be verified. | **Use `-S` flag (skip only if no GPG key configured)** |
+| "I'll skip GPG signing" | Unsigned commits cannot be verified. `-S` is always required — the only exception is when the user explicitly approves unsigned via `AskUserQuestion` after being prompted. | **MUST prompt user with `AskUserQuestion` before dropping `-S`** |
 | "HEREDOC will format trailers correctly" | HEREDOC puts everything in the message body. | **Use `--trailer` flag, NOT HEREDOC** |

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -1,156 +1,340 @@
 ---
 name: ring:committing-changes
-description: "Committing working-tree changes as atomic conventional commits: analyzes the diff, groups it into coherent commits, confirms the plan, then creates GPG-signed commits carrying the mandatory X-Lerian-Ref trailer and offers to push. Use when the user says 'commit' or has changes ready to record. Skip when the tree is clean, work is still in progress, or the user wants raw git commands without grouping."
+description: >-
+  Commit changes with scope allowlist enforcement, atomic grouping, GPG-signed
+  conventional commits, and trailer management. Detects the repo's PR-validation
+  scope policy before proposing any message. Use when the user asks to commit or
+  has changes ready to record. Skip when the working tree is clean or the user
+  wants raw git commands without grouping.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
 ---
 
-# Smart Commit Organization
+Analyze changes, enforce scope policy, group them into coherent atomic commits, and create signed commits following repository conventions. This skill transforms a messy working directory into a clean, logical commit history — with a scope that will actually pass PR validation.
 
-## When to use
-- User asks to commit changes or says "commit"
-- Working directory has staged or unstaged changes ready to commit
-- End of a development task where changes need to be recorded
+## ⛔ HARD STOP — READ SCOPE POLICY BEFORE ANYTHING ELSE
 
-## Skip when
-- No changes in working directory
-- Changes are still work-in-progress
-- User explicitly wants raw git commands without smart grouping
+**The scope is REQUIRED in every commit message. It MUST come from the repo's allowlist.**
 
-Analyze changes, group into coherent atomic commits, create signed commits following repository conventions.
+MUST detect the allowlist in Step 0 before analyzing or drafting any commit message. A commit with an invented or omitted scope will fail PR validation and block the PR.
 
-## Smart Commit Organization
+---
 
-Analyze → Group → Order → Confirm → Execute.
+## Step 0 — Detect Scope Policy
 
-**Grouping principles:**
+Many repos enforce an allowlist of valid `scope` values via a GitHub Actions workflow. Failing this check blocks the PR, so MUST detect it before proposing any commit message.
 
-| Pattern | Group |
-|---------|-------|
-| Implementation + tests | Together (same commit) |
-| package.json, *-lock.json | Dependency changes |
-| *.md, docs/ | Documentation |
-| Same module/directory | Often related |
+### 0.1 — Locate the policy file
 
-**Commit order:** dependencies first → core changes → tests with implementation → docs last.
+Check in this order:
 
-**Single commit when:** all changes are one coherent feature/fix, or user provides a specific message.  
-**Multiple commits when:** changes span different concerns.
+1. `.github/workflows/pr-validation.yml` (primary)
+2. `.github/workflows/pr-title.yml`
+3. `.github/workflows/commitlint.yml`
+4. `.github/workflows/semantic-pull-request.yml`
+5. Root configs: `commitlint.config.{js,cjs,mjs,ts}`, `.commitlintrc*`
 
-## ⛔ HARD STOP — TRAILER RULES
+### 0.2 — Extract the allowed scope list
+
+Common forms to look for:
+
+| Form | Example |
+|------|---------|
+| `scopes:` block (one per line) | Under `amannn/action-semantic-pull-request` |
+| `scopes: a,b,c` inline | Comma-separated on one line |
+| `scope-enum` rule | In commitlint config arrays |
+
+Also note any **type** restrictions — some repos limit types beyond the default Conventional Commits set.
+
+### 0.3 — Apply the policy
+
+| Situation | Required Action |
+|-----------|-----------------|
+| Policy found, scope is clear | Use only scopes from the allowlist |
+| Policy found, scope is ambiguous | STOP and ask the user which allowed scope to use |
+| No policy file found | MUST still include a scope — ask the user what scope to use |
+
+**NEVER** omit the scope. **NEVER** invent a scope not in the allowlist. A bare `type: description` is FORBIDDEN.
+
+State the policy source and chosen scope to the user before proceeding.
+
+---
+
+## Step 1 — Gather Context
+
+Run in parallel:
+
+```bash
+git status
+git diff
+git diff --cached
+git log --oneline -10
+```
+
+---
+
+## Step 2 — Analyze and Group Changes
+
+For each changed file determine:
+1. **Type**: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `ci`, `build`
+2. **Scope**: from the allowlist resolved in Step 0
+3. **Logical group**: what other files belong with this change?
+
+### Grouping Principles
+
+| Principle | Description |
+|-----------|-------------|
+| **Feature + Tests** | Implementation and its tests go together |
+| **Config Changes** | `package.json`, `tsconfig`, etc. grouped separately |
+| **Documentation** | `README`, `docs/` changes grouped together |
+| **Refactoring** | Pure refactors (no behavior change) separate |
+| **Bug Fixes** | Each fix is atomic with its test |
+
+### Single vs Multiple Commits
+
+**Single commit when:**
+- All changes belong to one coherent feature/fix
+- User provides a specific message via argument
+- Changes are minimal and related
+
+**Multiple commits when:**
+- Changes span different concerns (feature + docs + deps)
+- Mix of features, fixes, and chores
+- Better git history benefits future archaeology
+
+---
+
+## Step 3 — Determine Commit Order
+
+Order matters for bisectability:
+
+1. **Dependencies first** — so subsequent commits can use them
+2. **Core changes** — implementation before consumers
+3. **Tests with implementation** — keep them atomic
+4. **Documentation last** — documents the final state
+
+---
+
+## Step 4 — Present Plan and Confirm
+
+MUST get user confirmation before executing.
+
+```
+Proposed Commit Plan:
+─────────────────────
+Scope policy: .github/workflows/pr-validation.yml → allowed scopes: [api, auth, docs, ci]
+Chosen scope: auth
+
+1. feat(auth): add OAuth2 refresh token support
+   - src/auth/oauth.ts (modified)
+   - src/auth/oauth.test.ts (modified)
+
+2. chore(deps): update authentication dependencies
+   - package.json (modified)
+   - package-lock.json (modified)
+
+3. docs(docs): update OAuth2 setup guide
+   - docs/auth/oauth-setup.md (modified)
+
+Proceed with this plan? [Execute plan / Single commit / Let me review]
+```
+
+Use `AskUserQuestion` to confirm before proceeding.
+
+---
+
+## Step 5 — Draft Commit Messages
+
+Every commit message MUST follow:
+
+```
+<type>(<scope>): <subject>
+
+<body — optional>
+```
+
+- Subject: max 50 characters, imperative mood ("add" not "added")
+- Body: wrap at 72 characters, explain motivation/context
+- Scope: REQUIRED, from the allowlist — NEVER omit, NEVER invent
+
+---
+
+## Step 6 — Execute Commits
+
+### ⛔ HARD STOP — TRAILER RULES
 
 **THE MOST COMMON MISTAKE:** Putting trailer text INSIDE the `-m` quotes.
 
 ```bash
-# ❌ WRONG — trailer text INSIDE -m quotes
-git commit -m "feat: add feature
+# ❌ WRONG — trailer text is INSIDE the -m quotes
+git commit -m "feat(auth): add feature
 
 X-Lerian-Ref: 0x1"
 
 # ✅ CORRECT — --trailer is a SEPARATE argument OUTSIDE quotes
-git commit -S -m "feat: add feature" --trailer "X-Lerian-Ref: 0x1"
+git commit -m "feat(auth): add feature" --trailer "X-Lerian-Ref: 0x1"
 ```
 
-**Checkpoint before writing any commit command:**
+**Before writing ANY git commit command, verify:**
+
 - [ ] `-m "..."` contains ONLY the commit message (no trailer text inside)
-- [ ] `--trailer` is OUTSIDE and AFTER all `-m` parameters
-- [ ] Structure: `git commit -S -m "msg" --trailer "X-Lerian-Ref: 0x1"`
+- [ ] `--trailer` flags are OUTSIDE and AFTER the `-m` parameter
+- [ ] Command is structured as: `git commit -S -m "msg" --trailer "key: value"`
 
-## MANDATORY RULES
+### Required Command Structure
 
-1. **NEVER include in commit message body:** emoji signatures, hashtags, `Co-Authored-By`, "Generated by", `X-Lerian-Ref` text, or any system markers.  
-   `-m` contains ONLY the commit description. Period.
-
-2. **ALWAYS use `--trailer "X-Lerian-Ref: 0x1"`** — separate command-line argument after all `-m` parameters.
-
-3. **ALWAYS use `-S` for GPG signing** — skip only if GPG key not configured.
-
-## Commit Process
-
-### Step 1: Gather Context
 ```bash
-git status
-git diff && git diff --cached
-git log --oneline -10  # reference style
-```
-
-### Step 2: Analyze and Group
-Determine type (feat/fix/chore/docs/refactor/test/perf/ci), scope, and logical group for each file.
-
-### Step 3: Present Plan and Confirm
-```
-Proposed Commit Plan:
-1. feat(auth): add OAuth2 refresh token support
-   - src/auth/oauth.ts, src/auth/oauth.test.ts
-2. chore(deps): update authentication dependencies
-   - package.json, package-lock.json
-
-Proceed? [Execute plan / Single commit / Let me review]
-```
-
-Use AskUserQuestion to confirm. **MANDATORY: get confirmation before executing.**
-
-### Step 4: Draft Commit Messages
-- Subject: max 50 chars, imperative mood ("add" not "added")
-- Body: wrap at 72 chars, explain motivation (optional)
-- NO emoji, hashtags, markers of any kind in the body
-
-### Step 5: Execute Commits
-For each group:
-```bash
-git add <file1> <file2>
 git commit -S \
   -m "<type>(<scope>): <subject>" \
-  -m "<optional body>" \
+  -m "<body if needed>" \
   --trailer "X-Lerian-Ref: 0x1"
 ```
 
-### Step 6: Verify
+For each commit group, in order:
+
+1. Stage only the files for this commit:
+   ```bash
+   git add <file1> <file2> ...
+   ```
+
+2. Create signed commit with trailer:
+   ```bash
+   git commit -S \
+     -m "<type>(<scope>): <subject>" \
+     -m "<body if needed>" \
+     --trailer "X-Lerian-Ref: 0x1"
+   ```
+
+**If GPG signing fails:** check `git config user.signingkey` and `gpg --list-secret-keys`. If no key configured, proceed without `-S` and inform the user.
+
+3. Repeat for each commit group.
+
+---
+
+## Step 7 — Verify Commits
+
 ```bash
-git log --oneline -<N>
-git log --show-signature -1  # if signed
-git status  # confirm clean
+git log --oneline -<number_of_commits>
+git log --show-signature -1   # if signed
+git status
 ```
 
-### Step 7: Offer Push
-Ask user: push to remote? If yes: `git push` (or `git push -u origin <branch>` if no upstream).
+---
+
+## Step 8 — Offer Push
+
+After successful commit, ask the user:
+
+```javascript
+AskUserQuestion({
+  questions: [{
+    question: "Push commits to remote?",
+    header: "Push",
+    options: [
+      { label: "Yes", description: "Push to current branch" },
+      { label: "No", description: "Keep local only" }
+    ]
+  }]
+});
+```
+
+If yes:
+```bash
+# Branch with upstream:
+git push
+
+# Branch without upstream:
+git push -u origin <current-branch>
+```
+
+---
 
 ## Examples
 
+### Feature commit
 ```bash
-# Feature
-git commit -S -m "feat(auth): add OAuth2 refresh token support" --trailer "X-Lerian-Ref: 0x1"
-
-# Bug fix
-git commit -S -m "fix(api): handle null response in user endpoint" --trailer "X-Lerian-Ref: 0x1"
-
-# Chore
-git commit -S -m "chore(deps): update authentication dependencies" --trailer "X-Lerian-Ref: 0x1"
+git commit -S \
+  -m "feat(auth): add OAuth2 refresh token support" \
+  -m "Implements automatic token refresh when access token expires." \
+  --trailer "X-Lerian-Ref: 0x1"
 ```
 
-## Trailer Query
+### Bug fix
 ```bash
+git commit -S \
+  -m "fix(api): handle null response in user endpoint" \
+  --trailer "X-Lerian-Ref: 0x1"
+```
+
+### Chore
+```bash
+git commit -S \
+  -m "chore(deps): update dependencies to latest versions" \
+  --trailer "X-Lerian-Ref: 0x1"
+```
+
+---
+
+## Anti-Patterns (FORBIDDEN)
+
+```bash
+# ❌ WRONG — no scope
+git commit -m "feat: add feature"
+
+# ❌ WRONG — invented scope not in allowlist
+git commit -m "feat(custom-scope): add feature"
+
+# ❌ WRONG — trailer text inside -m
+git commit -m "feat(auth): add feature
+
+X-Lerian-Ref: 0x1"
+
+# ❌ WRONG — emoji or hashtags in message body
+git commit -m "feat(auth): add feature
+🤖 Generated with Claude"
+
+# ✅ CORRECT
+git commit -S \
+  -m "feat(auth): add feature" \
+  --trailer "X-Lerian-Ref: 0x1"
+```
+
+---
+
+## Trailer Query Commands
+
+```bash
+# Find commits with specific trailer value
 git log --all --format="%H %s %(trailers:key=X-Lerian-Ref,valueonly)" | grep "0x1"
+
+# Show all trailers for a commit
 git log -1 --format="%(trailers)"
 ```
 
+---
+
 ## When User Provides Message
-Skip grouping. Use their message as subject. Still sign with `-S` and add trailer.
-```bash
-git commit -S -m "fix: fix login bug" --trailer "X-Lerian-Ref: 0x1"
-```
 
-## Anti-Patterns (FORBIDDEN)
-```bash
-# ❌ Trailer text inside -m
-git commit -m "feat: add feature\n\nX-Lerian-Ref: 0x1"
+If the user provides a commit message as an argument:
+1. Use it as the subject/body
+2. Validate it has a scope from the allowlist — if missing, ask which scope to use
+3. Create signed commit with trailer
 
-# ❌ Emoji/hashtags in body
-git commit -m "feat: add feature\n\n🤖 Generated with Claude Code"
+---
 
-# ❌ Co-Authored-By in body
-git commit -m "feat: add feature\n\nCo-Authored-By: System <noreply@example.com>"
+## Anti-Rationalization Table
 
-# ❌ Hashtag tracking
-git commit -m "feat: add feature #0x1"
-```
-
-All of these pollute the commit message body. Use `--trailer` as a separate flag — always.
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "I'll omit the scope for this one" | Every commit MUST carry a scope. A bare `type: description` fails PR validation. | **MUST include scope from allowlist** |
+| "This scope isn't in the allowlist but it makes sense" | Invented scopes fail automated checks. The allowlist exists for a reason. | **MUST use only allowlist scopes or ask user** |
+| "No policy file, so scope is optional" | Scope is always required. Without a policy, ask the user which scope to use. | **MUST ask user for scope if no policy found** |
+| "I'll commit everything at once" | Mixed changes = messy history, hard to bisect/revert. | **Analyze and group changes first** |
+| "Grouping takes too long" | Clean history saves hours of debugging later. | **Always propose commit plan** |
+| "I'll put the trailer text in the message body" | `--trailer` is a GIT FLAG, not message text. | **Use `--trailer "X-Lerian-Ref: 0x1"` as separate argument** |
+| "I'll skip GPG signing" | Unsigned commits cannot be verified. | **Use `-S` flag (skip only if no GPG key configured)** |
+| "HEREDOC will format trailers correctly" | HEREDOC puts everything in the message body. | **Use `--trailer` flag, NOT HEREDOC** |

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -241,7 +241,7 @@ git log --oneline -<number_of_commits>
 for commit in $(git rev-list --max-count=<number_of_commits> HEAD); do
   # %G? returns: G=good, U=unknown-validity, X/Y=expired, B=bad, E=missing key, N=no signature
   sig_status=$(git log -1 --format="%G?" "$commit")
-  echo "$sig_status" | grep -qE '^[GUXY]' || { echo "Commit $commit: signature missing or bad (status=$sig_status)"; exit 1; }
+  echo "$sig_status" | grep -qE '^[GU]' || { echo "Commit $commit: signature invalid or insufficient (status=$sig_status)"; exit 1; }
   git log -1 --format="%(trailers)" "$commit" | grep -q '^X-Lerian-Ref: '  # fails if trailer missing
 done
 
@@ -252,10 +252,10 @@ Iterate over **every** commit created in Step 6.
 
 For each commit:
 - `%G?` returns the signature status: `G`=good, `U`=unknown validity, `X`/`Y`=expired, `B`=bad, `E`=missing key, `N`=no signature.
-- Accept `G`, `U`, `X`, `Y` (commit is signed, regardless of key trust level). Stop and report on `B` (bad signature), `E` (missing key), or `N` (unsigned).
+- Accept only `G` (good, trusted) and `U` (signed but key trust level unknown). Stop and report on `X`/`Y` (expired key), `B` (bad signature), `E` (missing key), or `N` (unsigned).
 - If the `grep` for `X-Lerian-Ref` fails, the trailer is missing — stop and report.
 
-Note: `git verify-commit` exits non-zero for both unsigned commits **and** untrusted keys, which would reject valid signed commits from unconfigured GPG trust chains. Using `%G?` directly is more precise and avoids false failures.
+Note: `git verify-commit` exits non-zero for both unsigned commits **and** untrusted/expired keys. Using `%G?` directly is more precise. Expired keys (`X`/`Y`) are explicitly rejected — renew or replace the signing key before committing.
 
 ---
 

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -235,14 +235,16 @@ Only omit `-S` if the user explicitly selects "Commit unsigned". NEVER drop sign
 ## Step 7 — Verify Commits
 
 ```bash
-git log --oneline -<number_of_commits>
+git log --oneline origin/$BASE..HEAD
 
-# Verify every commit in the batch, not just HEAD
-for commit in $(git rev-list --max-count=<number_of_commits> HEAD); do
+# Verify every commit in the batch (scoped to current branch, not general HEAD)
+for commit in $(git rev-list origin/$BASE..HEAD); do
   # %G? returns: G=good, U=unknown-validity, X/Y=expired, B=bad, E=missing key, N=no signature
   sig_status=$(git log -1 --format="%G?" "$commit")
-  echo "$sig_status" | grep -qE '^[GU]' || { echo "Commit $commit: signature invalid or insufficient (status=$sig_status)"; exit 1; }
-  git log -1 --format="%(trailers)" "$commit" | grep -q '^X-Lerian-Ref: '  # fails if trailer missing
+  echo "$sig_status" | grep -qE '^[GU]' \
+    || { echo "Commit $commit: signature invalid or insufficient (status=$sig_status)"; exit 1; }
+  git log -1 --format="%(trailers)" "$commit" | grep -q '^X-Lerian-Ref: ' \
+    || { echo "Commit $commit: X-Lerian-Ref trailer missing"; exit 1; }
 done
 
 git status

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -239,14 +239,23 @@ git log --oneline -<number_of_commits>
 
 # Verify every commit in the batch, not just HEAD
 for commit in $(git rev-list --max-count=<number_of_commits> HEAD); do
-  git verify-commit "$commit"                                         # fails non-zero if not signed
+  # %G? returns: G=good, U=unknown-validity, X/Y=expired, B=bad, E=missing key, N=no signature
+  sig_status=$(git log -1 --format="%G?" "$commit")
+  echo "$sig_status" | grep -qE '^[GUXY]' || { echo "Commit $commit: signature missing or bad (status=$sig_status)"; exit 1; }
   git log -1 --format="%(trailers)" "$commit" | grep -q '^X-Lerian-Ref: '  # fails if trailer missing
 done
 
 git status
 ```
 
-Iterate over **every** commit created in Step 6. If `git verify-commit` exits non-zero for any commit, it is unsigned — stop and report to the user. If `grep` fails for any commit, the `X-Lerian-Ref` trailer is missing — stop and report. Both failures indicate Step 6 was not executed correctly for that commit.
+Iterate over **every** commit created in Step 6.
+
+For each commit:
+- `%G?` returns the signature status: `G`=good, `U`=unknown validity, `X`/`Y`=expired, `B`=bad, `E`=missing key, `N`=no signature.
+- Accept `G`, `U`, `X`, `Y` (commit is signed, regardless of key trust level). Stop and report on `B` (bad signature), `E` (missing key), or `N` (unsigned).
+- If the `grep` for `X-Lerian-Ref` fails, the trailer is missing — stop and report.
+
+Note: `git verify-commit` exits non-zero for both unsigned commits **and** untrusted keys, which would reject valid signed commits from unconfigured GPG trust chains. Using `%G?` directly is more precise and avoids false failures.
 
 ---
 

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -211,22 +211,20 @@ For each commit group, in order:
 
 **If GPG signing fails:** check `git config user.signingkey` and `gpg --list-secret-keys`.
 
-If no usable key is found, STOP and ask the user:
+If no usable key is found, STOP — do NOT offer an unsigned path. Inform the user:
 
-```javascript
-AskUserQuestion({
-  questions: [{
-    question: "No GPG signing key is configured. How should I proceed?",
-    header: "GPG Signing",
-    options: [
-      { label: "Configure key first", description: "I'll set up GPG signing before committing" },
-      { label: "Commit unsigned", description: "Proceed without -S for this commit (not recommended)" }
-    ]
-  }]
-});
+```
+GPG signing is required. No usable signing key was found.
+
+To proceed:
+  1. Generate a key: gpg --gen-key
+  2. Configure git:  git config --global user.signingkey <key-id>
+  3. Re-run this skill.
+
+Committing without -S is not an option — Step 7 will reject unsigned commits.
 ```
 
-Only omit `-S` if the user explicitly selects "Commit unsigned". NEVER drop signing silently.
+MUST wait for the user to configure a key before continuing. NEVER drop `-S` silently or offer "unsigned" as a fallback.
 
 3. Repeat for each commit group.
 
@@ -372,5 +370,5 @@ If the user provides a commit message as an argument:
 | "I'll commit everything at once" | Mixed changes = messy history, hard to bisect/revert. | **Analyze and group changes first** |
 | "Grouping takes too long" | Clean history saves hours of debugging later. | **Always propose commit plan** |
 | "I'll put the trailer text in the message body" | `--trailer` is a GIT FLAG, not message text. | **Use `--trailer "X-Lerian-Ref: 0x1"` as separate argument** |
-| "I'll skip GPG signing" | Unsigned commits cannot be verified. `-S` is always required — the only exception is when the user explicitly approves unsigned via `AskUserQuestion` after being prompted. | **MUST prompt user with `AskUserQuestion` before dropping `-S`** |
+| "I'll skip GPG signing" | Unsigned commits fail Step 7 verification. There is no unsigned fallback path — configure a key and retry. | **MUST stop and instruct user to configure GPG key. NEVER drop `-S`** |
 | "HEREDOC will format trailers correctly" | HEREDOC puts everything in the message body. | **Use `--trailer` flag, NOT HEREDOC** |

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -232,11 +232,31 @@ MUST wait for the user to configure a key before continuing. NEVER drop `-S` sil
 
 ## Step 7 — Verify Commits
 
-```bash
-git log --oneline origin/$BASE..HEAD
+First, resolve the range ref for verification. `$BASE` may be provided by an orchestrating skill (e.g., `ring:shipping-changes`). Resolve in this order:
 
-# Verify every commit in the batch (scoped to current branch, not general HEAD)
-for commit in $(git rev-list origin/$BASE..HEAD); do
+```bash
+# 1. Upstream tracking ref (works when branch already has a remote tracking branch)
+if git rev-parse @{u} >/dev/null 2>&1; then
+  RANGE_REF="@{u}"
+
+# 2. $BASE propagated by the orchestrating skill (e.g., ring:shipping-changes)
+elif [ -n "$BASE" ]; then
+  RANGE_REF="origin/$BASE"
+
+# 3. Standalone: detect base branch via GitHub API
+else
+  BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null \
+    || git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}')
+  RANGE_REF="origin/$BASE"
+fi
+```
+
+Then verify every commit in the batch:
+
+```bash
+git log --oneline "$RANGE_REF..HEAD"
+
+for commit in $(git rev-list "$RANGE_REF..HEAD"); do
   # %G? returns: G=good, U=unknown-validity, X/Y=expired, B=bad, E=missing key, N=no signature
   sig_status=$(git log -1 --format="%G?" "$commit")
   echo "$sig_status" | grep -qE '^[GU]' \
@@ -248,14 +268,11 @@ done
 git status
 ```
 
-Iterate over **every** commit created in Step 6.
-
 For each commit:
-- `%G?` returns the signature status: `G`=good, `U`=unknown validity, `X`/`Y`=expired, `B`=bad, `E`=missing key, `N`=no signature.
-- Accept only `G` (good, trusted) and `U` (signed but key trust level unknown). Stop and report on `X`/`Y` (expired key), `B` (bad signature), `E` (missing key), or `N` (unsigned).
-- If the `grep` for `X-Lerian-Ref` fails, the trailer is missing — stop and report.
+- Accept `G` (good) or `U` (unknown validity). Reject `X`/`Y` (expired key), `B` (bad signature), `E` (missing key), `N` (unsigned).
+- If the trailer `grep` fails → stop and report the missing trailer.
 
-Note: `git verify-commit` exits non-zero for both unsigned commits **and** untrusted/expired keys. Using `%G?` directly is more precise. Expired keys (`X`/`Y`) are explicitly rejected — renew or replace the signing key before committing.
+Note: when called from `ring:shipping-changes`, `$BASE` is already resolved in Phase 0 and propagated here — the `@{u}` and standalone detection paths are only needed for standalone invocations.
 
 ---
 

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -236,12 +236,17 @@ Only omit `-S` if the user explicitly selects "Commit unsigned". NEVER drop sign
 
 ```bash
 git log --oneline -<number_of_commits>
-git verify-commit HEAD                                          # fails non-zero if not signed
-git log -1 --format="%(trailers)" | grep -q '^X-Lerian-Ref: ' # fails if trailer missing
+
+# Verify every commit in the batch, not just HEAD
+for commit in $(git rev-list --max-count=<number_of_commits> HEAD); do
+  git verify-commit "$commit"                                         # fails non-zero if not signed
+  git log -1 --format="%(trailers)" "$commit" | grep -q '^X-Lerian-Ref: '  # fails if trailer missing
+done
+
 git status
 ```
 
-If `git verify-commit HEAD` exits non-zero, the commit is unsigned — stop and report to the user. If the `grep` fails, the `X-Lerian-Ref` trailer is missing — stop and report. Both failures indicate Step 6 was not executed correctly.
+Iterate over **every** commit created in Step 6. If `git verify-commit` exits non-zero for any commit, it is unsigned — stop and report to the user. If `grep` fails for any commit, the `X-Lerian-Ref` trailer is missing — stop and report. Both failures indicate Step 6 was not executed correctly for that commit.
 
 ---
 

--- a/default/skills/committing-changes/SKILL.md
+++ b/default/skills/committing-changes/SKILL.md
@@ -272,6 +272,8 @@ For each commit:
 - Accept `G` (good) or `U` (unknown validity). Reject `X`/`Y` (expired key), `B` (bad signature), `E` (missing key), `N` (unsigned).
 - If the trailer `grep` fails → stop and report the missing trailer.
 
+**Why `U` is accepted:** `U` means the commit is cryptographically signed with a valid key, but GPG has not established a trust chain for that key (e.g., the key was not signed by a trusted introducer). This is the normal state for freshly generated keys or keys imported from colleagues without manual trust assignment. The signature itself is valid — it proves authorship. `G` additionally requires GPG's web-of-trust to vouch for the key identity, which is stricter than needed for commit attribution. Both are acceptable; only unsigned (`N`), bad (`B`), missing-key (`E`), and expired-key (`X`/`Y`) commits are rejected.
+
 Note: when called from `ring:shipping-changes`, `$BASE` is already resolved in Phase 0 and propagated here — the `@{u}` and standalone detection paths are only needed for standalone invocations.
 
 ---

--- a/default/skills/dispatching-workflows/SKILL.md
+++ b/default/skills/dispatching-workflows/SKILL.md
@@ -125,6 +125,7 @@ When the phase is complete and verified:
 1. Update the plan: flip the phase Status to `Complete`; record deviations that affect later phases.
 2. Present to the user: what was built, test results, review/contrarian outcome, deviations and why.
 3. **STOP and wait** for the user's check before elaborating the next phase — unless the user pre-authorized continuous execution, in which case say so and proceed.
+4. After the user approves, call `Skill("ring:committing-changes")` to commit all phase work before rolling to the next phase.
 
 ### Step 6: Roll to the next phase, then complete
 Return to Step 2 for the next phase. Repeat until every phase is `Complete`. At plan close:

--- a/default/skills/executing-plans/SKILL.md
+++ b/default/skills/executing-plans/SKILL.md
@@ -1,145 +1,230 @@
 ---
 name: ring:executing-plans
-description: "Executing a phased plan from ring:writing-plans in rolling waves: the main agent supervises, dispatching one workflow per wave-unit (phase or epic — user's choice) that implements its tasks with TDD and signed commits via ring:committing-changes, reviews the returned work, checkpoints with the user, then elaborates the next phase against the real landed code. Use when a phased plan exists and you want session-supervised execution with a human reviewing each wave. Skip when no plan exists (use ring:writing-plans) or the full gated specialist + reviewer pool is wanted (use ring:running-dev-cycle)."
+description: |
+  Controlled plan execution with human review checkpoints - loads plan, executes
+  in batches, pauses for feedback. Supports one-go (autonomous) or batch modes.
+
+trigger: |
+  - Have a plan file ready to execute
+  - Want human review between task batches
+  - Need structured checkpoints during implementation
+
+skip_when: |
+  - Same session with independent tasks → use ring:subagent-driven-development
+  - No plan exists → use ring:writing-plans first
+  - Plan needs revision → use ring:brainstorming first
+
+sequence:
+  after: [ring:writing-plans, ring:pre-dev-task-breakdown]
+
+related:
+  similar: [ring:subagent-driven-development]
 ---
 
 # Executing Plans
 
-## When to use
-- A phased plan exists (typically produced by ring:writing-plans)
-- You want to supervise execution from this session — review each dispatched wave, checkpoint between phases — rather than hand off to the full gated dev cycle
-- Work benefits from phase checkpoints and course-correction between phases
+## Overview
 
-## Skip when
-- Plan doesn't exist yet — use ring:writing-plans first
-- Production-grade work requiring the full review pool — use ring:running-dev-cycle instead (lean backend cycle, Gate 0/8/9, dispatches specialists in parallel)
-- Each wave should run as a multi-agent harness with review and a contrarian pass baked in — use ring:dispatching-workflows (this skill dispatches one supervised subagent per wave; review happens after it returns)
-- Plan covers multiple independent subsystems — split into separate plans before executing
+Load plan, review critically, choose execution mode, execute tasks with code review.
 
-## Sequence
-**Runs after:** ring:writing-plans (consumes and updates its plan document)
-**Alternative:** ring:running-dev-cycle (subagent-orchestrated, gated workflow with parallel specialist dispatch)
+**Core principle:** User chooses between autonomous execution or batch execution with human review checkpoints.
 
-## Related
-**Companion skills:** ring:writing-plans (defines the Epic and Task formats used during elaboration), ring:test-driven-development (enforces RED→GREEN→REFACTOR per task), ring:committing-changes (closes each task with a signed atomic commit)
+**Two execution modes:**
+- **One-go (autonomous):** Execute all batches continuously with code review, report only at completion
+- **Batch (with review):** Execute one batch, code review, pause for human feedback, repeat
 
----
-
-The loop: **dispatch the current wave as a workflow → review the returned work → phase checkpoint → elaborate the next phase against the real landed code → dispatch the next wave → repeat.** The main agent stays the supervisor and reviewer; the dispatched workflow does the task-by-task implementation. The plan document is the living source of truth — elaboration writes tasks back into it.
-
-**Announce at start:** "Using ring:executing-plans to implement this plan."
+**Announce at start:** "I'm using the ring:executing-plans skill to implement this plan."
 
 ## The Process
 
 ### Step 1: Load and Review Plan
+1. Read plan file
+2. Review critically - identify any questions or concerns about the plan
+3. If concerns: Raise them with your human partner before starting
+4. If no concerns: Create TodoWrite and proceed to Step 2
 
-1. Read the plan file end-to-end
-2. Verify the header (Goal, Architecture, Tech Stack, Phase Overview) is present
-3. Verify exactly one phase is task-detailed (the current wave); later phases sit at epic level
-4. Review critically — raise concerns with the user **before starting**
+### Step 2: Choose Execution Mode (MANDATORY)
 
-| Concern type | Action |
-|--------------|--------|
-| Vague detailed-wave task ("appropriate error handling", "TBD") | Block; ask user to refine or fill in |
-| Phase that doesn't end in working, verifiable software | Block; ask user to redraw the boundary |
-| Contract inconsistency between epics | Block; ask user to reconcile |
-| Later phases already task-detailed | Warn — those tasks are stale risk; treat as drafts to re-validate at elaboration time |
-| Stylistic / "nice to have" | Note but proceed |
+**⚠️ THIS STEP IS NON-NEGOTIABLE. You MUST use `AskUserQuestion` before executing ANY tasks.**
 
-**Then choose dispatch granularity.** Ask the user — using the question/ask tool the harness provides (e.g. `AskUserQuestion` in Claude Code) — whether to dispatch **one workflow per phase** (the whole phase runs as a single wave) or **one workflow per epic** (finer-grained: the main agent reviews and course-corrects between epics inside a phase). Default to per-phase if the user skips. This sets the wave-unit for the rest of execution.
+Ask: "How would you like to execute this plan?" Options: (1) **One-go (autonomous)** - all batches with code review, no human review until completion (2) **Batch (with review)** - pause for human review after each batch
 
-### Step 2: Dispatch and Supervise the Current Wave
+**Based on response:** One-go → Steps 3-4 loop until done | Batch → Steps 3-5 loop
 
-Dispatch the wave-unit chosen in Step 1 — a whole phase, or a single epic — as **one workflow** covering all its tasks. The main agent does not implement; it supervises and reviews.
+### Why AskUserQuestion is Mandatory (Not "Contextual Guidance")
 
-The dispatched workflow runs each task in the unit, in dependency order, and for every task MUST:
+**This is a structural checkpoint, not optional UX polish.**
 
-1. Implement per the task's **Implementation vision** — its decisions are binding; raise a blocker rather than silently diverging
-2. Use ring:test-driven-development for new production code: write the failing test first from the task's **Verification** intent, capture the RED output, then implement
-3. Run the task's verification; capture the output
-4. Close the task with ring:committing-changes (atomic, signed)
-5. Tick the task's `- [ ] Done` checkbox in the plan document only after verification passes
+User saying "don't wait", "don't ask questions", or "just execute" does NOT skip this step because:
 
-**Do not skip the RED phase.** The plan carries no test code — the failing test comes from the verification intent.
+1. **Execution mode affects architecture** - One-go vs batch determines review checkpoints, error recovery paths, and rollback points
+2. **Implicit intent ≠ explicit choice** - "Don't wait" might mean "use one-go" OR "ask quickly and proceed"
+3. **AskUserQuestion takes 3 seconds** - It's not an interruption, it's a confirmation
+4. **Emergency pressure is exactly when mistakes happen** - Structural gates exist FOR high-pressure moments
 
-When the workflow returns, the main agent **reviews** the wave as supervisor: confirm each task's tests actually ran and passed, commits are atomic and signed, the implementation matches the vision, and nothing was silently deferred. Bounce anything that fails review into a follow-up dispatch before moving on. If the wave-unit is an epic and the phase has more epics, dispatch the next epic; advance to the checkpoint only once the phase has no tasks left.
+**Common Rationalizations That Mean You're About to Violate This Rule:**
 
-### Step 3: Phase Checkpoint (user gate)
+| Rationalization | Reality |
+|-----------------|---------|
+| "User intent is crystal clear" | Intent is not the same as explicit selection. Ask anyway. |
+| "This is contextual guidance, not absolute law" | Wrong. It says MANDATORY. That means mandatory. |
+| "Asking would violate their 'don't ask' instruction" | AskUserQuestion is a 3-second structural gate, not a conversation. |
+| "Skills are tools, not bureaucratic checklists" | This skill IS the checklist. Follow it. |
+| "Interpreting spirit over letter" | The spirit IS the letter. Use AskUserQuestion. |
+| "User already chose by saying 'just execute'" | Verbal shorthand ≠ structured mode selection. Ask. |
 
-When every task in the phase is complete and verified:
+**If you catch yourself thinking any of these → STOP → Use AskUserQuestion anyway.**
 
-1. Update the plan document: flip the phase's Status to `Complete` in the Phase Overview; record any deviations from the plan that affect later phases
-2. Present to the user: what was built, test results, deviations and why
-3. **STOP and wait for the user's check** before elaborating the next phase — unless the user pre-authorized continuous execution, in which case state that and proceed
+### Step 2.5: Context Switching for Multi-Module Plans
 
-### Step 4: Elaborate the Next Phase (rolling wave)
+**If plan has tasks with `target:` and `working_directory:` fields:**
 
-After the checkpoint, detail the next phase before implementing it:
+1. **Track current module:**
+   ```
+   current_module = None
+   current_directory = "."
+   ```
 
-1. Re-read the phase's epics against the codebase **as it now exists** — not as the plan assumed it would
-2. Fold in learnings and deviations from completed phases; if reality diverged enough to change an epic's scope or approach, surface that to the user before proceeding
-3. Break each epic into dispatch-ready tasks using the **Task Format from ring:writing-plans** (load that skill if the format is not in context) — same bar: context with file:line references, implementation vision with decisions made, exact files, verification, done-when
-4. Write the tasks into the plan document under their epics; flip the phase's Status to `Detailed`
-5. Return to Step 2 — dispatch the newly detailed wave (per the granularity chosen in Step 1) and await its return
+2. **Before each task, check for context switch:**
+   ```
+   IF task.target != current_module AND current_module != None:
+     # Prompt user for confirmation
+     AskUserQuestion:
+       question: "Switching to {task.target} module at {task.working_directory}. Continue?"
+       header: "Context"
+       options:
+         - label: "Continue"
+           description: "Switch to {task.target} and execute task"
+         - label: "Skip task"
+           description: "Skip this task and continue with next"
+         - label: "Stop"
+           description: "Stop execution for manual review"
 
-Repeat Steps 2–4 until every phase is complete.
+     IF answer == "Continue":
+       current_module = task.target
+       current_directory = task.working_directory
+     ELIF answer == "Skip":
+       Mark task as skipped → proceed to next
+     ELSE:
+       Stop execution → report progress
+   ```
 
-### Step 5: Complete Development
+3. **Load module-specific PROJECT_RULES.md:**
+   ```
+   IF {task.working_directory}/PROJECT_RULES.md exists:
+     Instruct agent to read module-specific rules
+     Module rules override root rules
+   ```
 
-After all phases complete and verified:
+4. **Pass working directory to agent:**
+   ```
+   Task(
+     subagent_type=task.agent,
+     prompt="Working directory: {task.working_directory}
 
-- Announce: "All phases complete and verified. Closing with ring:committing-changes."
-- Use ring:committing-changes for the final commit if uncommitted work remains
-- Offer to push: `git push` (or `git push -u origin <branch>` if no upstream)
+     Before executing, cd to the working directory:
+     cd {task.working_directory}
 
-For production work, hand off to ring:reviewing-code to run the review pool against the cumulative diff.
+     If PROJECT_RULES.md exists in this directory, read and follow it.
 
-## ⛔ When to Stop and Ask
+     {task.prompt}"
+   )
+   ```
 
-**Stop executing immediately when:**
+**Optimization:** To minimize context switches, batch tasks by module when possible:
+- Original: [backend, frontend, backend, frontend]
+- Optimized: [backend, backend, frontend, frontend]
+- **Only reorder if no dependencies between modules**
 
-| Trigger | Why it blocks |
-|---------|---------------|
-| Missing dependency | Can't proceed reliably without it |
-| Test fails unexpectedly (not RED phase) | Either plan is wrong or implementation diverged |
-| Task's implementation vision conflicts with the actual codebase | The wave is stale; re-elaborate, don't improvise |
-| Instruction unclear or ambiguous | Guessing wastes more time than asking |
-| Verification fails repeatedly | Underlying issue, not a flakiness retry |
-| Epic scope no longer matches reality at elaboration time | User decides whether scope shifts or plan changes |
+---
 
-**Ask for clarification rather than guessing.** Plan execution is not the place for taste calls.
+### Step 3: Execute Batch
+**Default: First 3 tasks**
 
-## ⛔ Branch Safety
+**Agent Selection:** Backend Go → `ring:backend-engineer-golang` | Backend TS → `ring:backend-engineer-typescript` | Frontend → `ring:frontend-bff-engineer-typescript` | Infra → `ring:devops-engineer` | Testing → `ring:qa-analyst` | Reliability → `ring:sre`
 
-**MUST NOT** start implementation on `main`/`master` without explicit user consent. If currently on a protected branch:
+For each task: Check context switch (Step 2.5) → Mark in_progress → Dispatch to agent with working_directory → Follow plan steps exactly → Run verifications → Mark completed
 
-1. Stop
-2. Ask the user to create or switch to a feature branch (or invoke ring:creating-worktrees for an isolated workspace)
-3. Resume only after branch confirmation
+### Step 4: Run Code Review
+**After each batch, REQUIRED:** Use ring:requesting-code-review (all 7 reviewers in parallel)
+
+**Handle by severity:**
+- **Critical/High/Medium:** Fix immediately (no TODO) → re-run all 7 reviewers → repeat until resolved
+- **Low:** Add `TODO(review): [Issue] ([reviewer], [date], Low)`
+- **Cosmetic:** Add `FIXME(nitpick): [Issue] ([reviewer], [date], Cosmetic)`
+
+**Proceed when:** Zero Critical/High/Medium remain + all Low/Cosmetic have comments
+
+### Step 5: Report and Continue
+
+**One-go mode:** Log internally → proceed to next batch → report only at completion
+**Batch mode:** Show implementation + verification + review results → "Ready for feedback." → wait → apply changes → `Skill("ring:committing-changes")` (after user approves the completed phase, before elaborating the next batch) → proceed
+
+### Step 6: Complete Development
+
+Use finishing-a-development-branch to verify tests, present options, execute choice.
+
+## When to Stop
+
+**STOP immediately:** Blocker mid-batch | Critical gaps | Unclear instruction | Verification fails repeatedly. **Ask rather than guess.**
 
 ## Remember
 
-- Review the plan critically first — fix gaps before executing
-- Choose dispatch granularity up front — one workflow per phase, or one per epic
-- The main agent supervises and reviews; the dispatched workflow implements
-- One detailed wave at a time — never elaborate two phases ahead
-- The plan document is living: tick tasks, flip statuses, record deviations
-- Don't skip verifications (RED phase included)
-- Phase checkpoint is a user gate, not a formality
-- Elaborate against the codebase as it exists, not as the plan assumed
-- Stop when blocked — don't guess
-- Never implement on main/master without consent
+- **MANDATORY:** `AskUserQuestion` for execution mode - NO exceptions
+- Use `*` agents over `general-purpose` when available
+- Run code review after each batch (all 7 parallel)
+- Fix Critical/High/Medium immediately (no TODO)
+- Low → TODO, Cosmetic → FIXME
+- Stop when blocked, don't guess
+- **If rationalizing why to skip AskUserQuestion → You're wrong → Ask anyway**
 
-## Verification Checklist
+## Blocker Criteria
 
-Before marking the plan complete:
-- [ ] Dispatch granularity (phase or epic) chosen with the user
-- [ ] Every dispatched wave reviewed by the main agent before its checkpoint
-- [ ] Every phase implemented and verified, in order
-- [ ] Every phase boundary checkpointed with the user (or continuous mode explicitly pre-authorized)
-- [ ] Every later phase elaborated into tasks before implementation, against the real codebase
-- [ ] Every RED phase produced a real failure (output captured)
-- [ ] Every task closed with an atomic, signed commit via ring:committing-changes
-- [ ] Plan document reflects final state (statuses, ticked tasks, recorded deviations)
-- [ ] Working tree clean (or remaining changes documented)
-- [ ] Final commit / push offered to user
+STOP and report if:
+
+| Decision Type | Blocker Condition | Required Action |
+|---|---|---|
+| Execution mode | AskUserQuestion not used for mode selection | STOP and ask for execution mode - NO exceptions |
+| Plan loading | Plan file not found or unreadable | STOP and report missing plan |
+| Code review | Critical/High/Medium issues found in review | STOP and fix before proceeding |
+| Task blocker | Task blocked mid-batch | STOP and report blocker details |
+| Verification | Task verification fails repeatedly | STOP and escalate |
+
+### Cannot Be Overridden
+
+The following requirements CANNOT be waived:
+- AskUserQuestion for execution mode is MANDATORY - user intent does NOT skip this step
+- Code review after each batch is REQUIRED - all 7 reviewers in parallel
+- Critical/High/Medium issues MUST be fixed immediately - TODO comments are FORBIDDEN for these severities
+- Context switch confirmation is REQUIRED when switching between modules
+- Full test suite MUST pass before completing development
+
+## Severity Calibration
+
+| Severity | Condition | Required Action |
+|---|---|---|
+| CRITICAL | Skipped AskUserQuestion for execution mode | MUST stop and ask for mode selection |
+| CRITICAL | Proceeding with unfixed Critical/High review findings | MUST fix issues before continuing |
+| HIGH | Skipped code review after batch | MUST run all 7 reviewers |
+| HIGH | Used TODO for Critical/High/Medium issues | MUST fix immediately, remove TODO |
+| MEDIUM | Missing context switch confirmation for multi-module | Should add module switch prompt |
+| LOW | Low-severity issues without TODO comment | Fix by adding proper TODO format |
+
+## Pressure Resistance
+
+| User Says | Your Response |
+|---|---|
+| "Just execute, don't ask about mode" | "MUST use AskUserQuestion for execution mode. This is a structural checkpoint, not optional. Takes 3 seconds." |
+| "Skip the code review, we're in a hurry" | "Code review is REQUIRED after each batch. CANNOT proceed without running all 7 reviewers." |
+| "Add a TODO for that critical issue, fix later" | "Critical/High/Medium issues MUST be fixed immediately. TODO comments FORBIDDEN for these severities." |
+| "User intent is clear, skip the question" | "Intent is not explicit selection. MUST use AskUserQuestion - it's a structural gate, not conversation." |
+
+## Anti-Rationalization Table
+
+| Rationalization | Why It's WRONG | Required Action |
+|---|---|---|
+| "User said 'just execute' so mode is clear" | Verbal shorthand ≠ structured mode selection | **MUST use AskUserQuestion anyway** |
+| "This is contextual guidance, not absolute law" | It says MANDATORY - that means mandatory | **MUST follow the mandatory step** |
+| "Asking would violate their 'don't ask' instruction" | AskUserQuestion is a 3-second structural gate, not a conversation | **MUST ask for execution mode** |
+| "Skills are tools, not bureaucratic checklists" | This skill IS the checklist; that's its purpose | **MUST follow the checklist** |
+| "Review is overkill for small changes" | Small changes can have critical bugs; review catches them | **MUST run code review after each batch** |

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -24,23 +24,53 @@ Skipping detection steps is how PRs end up targeting `main` when the repo expect
 
 ## Step 1 — Detect Base Branch
 
-NEVER assume the base. Always detect it from the remote:
+NEVER assume the base. Detect in this order — stop at the first authoritative signal:
+
+### 1.1 — GitHub default branch (primary)
 
 ```bash
-git fetch origin --quiet
-git ls-remote --heads origin develop   # probe develop first
-git ls-remote --heads origin main      # fallback
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
 ```
 
-| Result | Action |
-|--------|--------|
-| `develop` SHA printed | Set `BASE=develop` |
-| `main` SHA printed (develop absent) | Set `BASE=main` |
-| Neither exists | STOP — ask the user which branch to target |
+Set `BASE` to the value returned. This is the repo's authoritative default.
 
-**Sanity-check:** read `.github/pull_request_template.md` — if it explicitly names a base branch, honor that and override `$BASE` if needed.
+If `gh` is not available or returns an error:
 
-State the resolved `$BASE` before proceeding.
+```bash
+git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+```
+
+### 1.2 — PR template override (highest priority)
+
+Read `.github/pull_request_template.md`. If it explicitly names a target branch (e.g., "PR targeted to `develop`"), honor that value and override `$BASE`.
+
+### 1.3 — Develop branch hint (Lerian convention check)
+
+```bash
+git ls-remote --heads origin develop
+```
+
+If `develop` exists on the remote **and** `BASE != develop` (detected above), present this to the user:
+
+```
+⚠️  Base branch detected: $BASE (GitHub default)
+    But 'develop' also exists on this remote.
+    Some Lerian repos target 'develop' for PRs even when the GitHub default is 'main'.
+
+Which branch should this PR target?
+  [1] $BASE (GitHub default — recommended)
+  [2] develop
+```
+
+STOP and wait for user confirmation before proceeding.
+
+If `develop` does NOT exist, use `$BASE` without prompting.
+
+### 1.4 — Neither detected
+
+If both detection methods fail, STOP and ask the user which branch to target.
+
+State the resolved `$BASE` and the detection source before proceeding.
 
 ---
 
@@ -85,8 +115,9 @@ State the policy source and chosen scope before proceeding.
 ## Step 3 — Verify Preconditions
 
 ```bash
-git status --porcelain          # check for uncommitted changes
-git branch --show-current       # confirm current branch name (empty in detached HEAD)
+git status --porcelain                                  # check for uncommitted changes
+git branch --show-current                               # confirm current branch name (empty in detached HEAD)
+git fetch origin <current-branch> --quiet               # refresh remote ref before checking push state
 git ls-remote --heads origin <current-branch>           # confirm branch exists on remote
 git rev-list origin/<current-branch>..HEAD --count      # confirm no local commits ahead
 ```

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -85,18 +85,17 @@ State the policy source and chosen scope before proceeding.
 ## Step 3 — Verify Preconditions
 
 ```bash
-git status          # check for uncommitted changes
-git branch          # confirm current branch
-git log origin/<current-branch>..HEAD --oneline 2>/dev/null || \
-  git log --oneline -5   # confirm branch is pushed
+git status --porcelain          # check for uncommitted changes
+git branch --show-current       # confirm current branch name
+git ls-remote --heads origin <current-branch>   # confirm branch is pushed
 ```
 
-| Condition | Required Action |
-|-----------|-----------------|
-| Uncommitted changes exist | Warn user — suggest committing first with `ring:committing-changes` |
-| Branch not pushed | Warn user — push before opening PR: `git push -u origin <branch>` |
+| Condition | Detection | Required Action |
+|-----------|-----------|-----------------|
+| Uncommitted changes exist | `git status --porcelain` returns output | STOP — ask user to commit first with `ring:committing-changes` |
+| Branch not on remote | `git ls-remote` returns no SHA for the branch | STOP — push first: `git push -u origin <branch>` |
 
-If the user confirms they want to proceed despite warnings, continue. Do NOT block silently.
+**Fail closed.** Only continue when both checks pass. If either condition is met, STOP and ask the user to resolve it first. Do NOT continue after a warning — explicit user action is required before proceeding to Step 4.
 
 ---
 
@@ -119,6 +118,10 @@ If the template exists, use it as the body structure and fill in every section. 
 - [ ] New feature
 - [ ] Breaking change
 - [ ] Documentation update
+
+## Breaking Changes
+
+None.
 
 ## Testing
 

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -24,53 +24,32 @@ Skipping detection steps is how PRs end up targeting `main` when the repo expect
 
 ## Step 1 — Detect Base Branch
 
-NEVER assume the base. Detect in this order — stop at the first authoritative signal:
+NEVER assume the base. Run all three probes first, then apply the precedence rules below.
 
-### 1.1 — GitHub default branch (primary)
+### Probes (run in parallel)
 
 ```bash
+# Probe A — GitHub API default
 gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
-```
+# Fallback if gh unavailable: git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
 
-Set `BASE` to the value returned. This is the repo's authoritative default.
+# Probe B — PR template hint
+# Read .github/pull_request_template.md — note any explicit branch name mentioned
 
-If `gh` is not available or returns an error:
-
-```bash
-git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
-```
-
-### 1.2 — PR template override (highest priority)
-
-Read `.github/pull_request_template.md`. If it explicitly names a target branch (e.g., "PR targeted to `develop`"), honor that value and override `$BASE`.
-
-### 1.3 — Develop branch hint (Lerian convention check)
-
-```bash
+# Probe C — develop branch existence
 git ls-remote --heads origin develop
 ```
 
-If `develop` exists on the remote **and** `BASE != develop` (detected above), present this to the user:
+### Precedence (apply in order — first match wins)
 
-```
-⚠️  Base branch detected: $BASE (GitHub default)
-    But 'develop' also exists on this remote.
-    Some Lerian repos target 'develop' for PRs even when the GitHub default is 'main'.
+| Priority | Source | Rule |
+|----------|--------|------|
+| **1 — highest** | PR template | If `.github/pull_request_template.md` explicitly names a target branch, use it. Overrides everything. |
+| **2** | develop exists + user confirms | If Probe C finds `develop` AND it differs from Probe A, show both options and ask the user to confirm. Use the user's choice. |
+| **3 — fallback** | GitHub API default | Use the value from Probe A. |
+| **4** | Neither detected | STOP — ask the user which branch to target. |
 
-Which branch should this PR target?
-  [1] $BASE (GitHub default — recommended)
-  [2] develop
-```
-
-STOP and wait for user confirmation before proceeding.
-
-If `develop` does NOT exist, use `$BASE` without prompting.
-
-### 1.4 — Neither detected
-
-If both detection methods fail, STOP and ask the user which branch to target.
-
-State the resolved `$BASE` and the detection source before proceeding.
+State the resolved `$BASE` and which source determined it before proceeding.
 
 ---
 

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -87,7 +87,8 @@ State the policy source and chosen scope before proceeding.
 ```bash
 git status --porcelain          # check for uncommitted changes
 git branch --show-current       # confirm current branch name (empty in detached HEAD)
-git ls-remote --heads origin <current-branch>   # confirm branch is pushed
+git ls-remote --heads origin <current-branch>           # confirm branch exists on remote
+git rev-list origin/<current-branch>..HEAD --count      # confirm no local commits ahead
 ```
 
 | Condition | Detection | Required Action |
@@ -95,8 +96,9 @@ git ls-remote --heads origin <current-branch>   # confirm branch is pushed
 | Uncommitted changes exist | `git status --porcelain` returns output | STOP — ask user to commit first with `ring:committing-changes` |
 | Detached HEAD / no branch | `git branch --show-current` returns empty output | STOP — ask user to checkout or create a named branch first |
 | Branch not on remote | `git ls-remote` returns no SHA for the branch | STOP — push first: `git push -u origin <branch>` |
+| Local commits ahead of remote | `git rev-list origin/<branch>..HEAD --count` returns non-zero | STOP — push pending commits first: `git push` |
 
-**Fail closed.** Check in this order: uncommitted changes → detached HEAD → branch pushed. Only continue when all three checks pass. If any condition is met, STOP and ask the user to resolve it before proceeding to Step 4. Do NOT interpolate an empty branch name into `git ls-remote`.
+**Fail closed.** Check in this order: uncommitted changes → detached HEAD → branch on remote → no local commits ahead. Only continue when all four checks pass. Do NOT interpolate an empty branch name into `git ls-remote` or `git rev-list`.
 
 ---
 

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: ring:opening-pull-requests
+description: >-
+  Open a GitHub Pull Request with automatic base branch detection, scope
+  allowlist enforcement, PR template filling, and post-create base verification.
+  Replaces ring:generating-pr-descriptions. Use after pushing a branch when
+  ready to open a PR. Skip if the branch is not yet pushed or there are
+  uncommitted changes — commit first with ring:committing-changes.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+Open a GitHub Pull Request against the correct base branch, with a title that will pass scope validation and a body that fills the repo's PR template. Verifies the base after creation and corrects it automatically if GitHub defaulted to the wrong target.
+
+## ⛔ HARD STOP — DO NOT CALL `gh pr create` BEFORE COMPLETING STEPS 1–6
+
+Skipping detection steps is how PRs end up targeting `main` when the repo expects `develop`, or how PRs fail validation due to a missing or invalid scope. MUST complete every step in order.
+
+---
+
+## Step 1 — Detect Base Branch
+
+NEVER assume the base. Always detect it from the remote:
+
+```bash
+git fetch origin --quiet
+git ls-remote --heads origin develop   # probe develop first
+git ls-remote --heads origin main      # fallback
+```
+
+| Result | Action |
+|--------|--------|
+| `develop` SHA printed | Set `BASE=develop` |
+| `main` SHA printed (develop absent) | Set `BASE=main` |
+| Neither exists | STOP — ask the user which branch to target |
+
+**Sanity-check:** read `.github/pull_request_template.md` — if it explicitly names a base branch, honor that and override `$BASE` if needed.
+
+State the resolved `$BASE` before proceeding.
+
+---
+
+## Step 2 — Detect Scope Policy
+
+MUST detect the allowlist before proposing the PR title. A title with a wrong or missing scope will fail PR validation and block the merge.
+
+### 2.1 — Locate the policy file
+
+Check in this order:
+
+1. `.github/workflows/pr-validation.yml` (primary)
+2. `.github/workflows/pr-title.yml`
+3. `.github/workflows/commitlint.yml`
+4. `.github/workflows/semantic-pull-request.yml`
+5. Root configs: `commitlint.config.{js,cjs,mjs,ts}`, `.commitlintrc*`
+
+### 2.2 — Extract allowed scopes and types
+
+| Form | Example |
+|------|---------|
+| `scopes:` block (one per line) | Under `amannn/action-semantic-pull-request` |
+| `scopes: a,b,c` inline | Comma-separated on one line |
+| `scope-enum` rule | In commitlint config arrays |
+
+Also extract any **type** restrictions — some repos limit allowed types beyond the default Conventional Commits set.
+
+### 2.3 — Apply the policy
+
+| Situation | Required Action |
+|-----------|-----------------|
+| Policy found, scope is clear | Use only scopes from the allowlist |
+| Policy found, scope is ambiguous | STOP and ask the user which allowed scope to use |
+| No policy file found | MUST still include a scope — ask the user what scope to use |
+
+**NEVER** omit the scope. **NEVER** invent a scope not in the allowlist.
+
+State the policy source and chosen scope before proceeding.
+
+---
+
+## Step 3 — Verify Preconditions
+
+```bash
+git status          # check for uncommitted changes
+git branch          # confirm current branch
+git log origin/<current-branch>..HEAD --oneline 2>/dev/null || \
+  git log --oneline -5   # confirm branch is pushed
+```
+
+| Condition | Required Action |
+|-----------|-----------------|
+| Uncommitted changes exist | Warn user — suggest committing first with `ring:committing-changes` |
+| Branch not pushed | Warn user — push before opening PR: `git push -u origin <branch>` |
+
+If the user confirms they want to proceed despite warnings, continue. Do NOT block silently.
+
+---
+
+## Step 4 — Read PR Template
+
+```bash
+cat .github/pull_request_template.md 2>/dev/null
+```
+
+If the template exists, use it as the body structure and fill in every section. If no template exists, use this default structure:
+
+```markdown
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation update
+
+## Testing
+
+- [ ] Unit tests pass
+- [ ] Manually tested
+
+## Related Issues
+
+<!-- Closes #issue -->
+```
+
+---
+
+## Step 5 — Gather Diff Context
+
+```bash
+git log origin/$BASE..HEAD --oneline
+git diff origin/$BASE...HEAD --stat
+```
+
+Use this output to fill the PR body accurately.
+
+---
+
+## Step 6 — Draft PR Title and Body
+
+### Title
+
+```
+<type>(<scope>): <description>
+```
+
+Requirements:
+- Under 70 characters
+- Lowercase, no period at the end
+- Scope MUST come from the allowlist (Step 2)
+- Type MUST be allowed per policy (Step 2)
+
+Examples:
+- `feat(auth): add OAuth2 refresh token support`
+- `fix(api): handle null response in user endpoint`
+- `chore(deps): update authentication dependencies`
+
+### Body
+
+Fill the PR template completely:
+
+| Section | Instructions |
+|---------|-------------|
+| **Description/Summary** | Summarize what the PR does and why |
+| **Type of Change** | Check boxes matching the commit type |
+| **Breaking Changes** | Describe if applicable; otherwise "None." |
+| **Testing** | Check applicable boxes; add CI run link if available |
+| **Related Issues** | Fill only if user mentioned an issue; leave blank otherwise |
+
+---
+
+## Step 7 — Show Full Draft for Approval
+
+Present the complete draft to the user:
+
+```
+PR Draft — waiting for your approval
+─────────────────────────────────────
+Base branch:  develop   (from: git ls-remote)
+Scope policy: .github/workflows/pr-validation.yml → scopes: [api, auth, docs, ci]
+Chosen scope: auth
+
+Title:
+  feat(auth): add OAuth2 refresh token support
+
+Body:
+  ## Summary
+  Adds automatic token refresh when access token expires...
+  ...
+
+Command that will run:
+  gh pr create --title "feat(auth): add OAuth2 refresh token support" \
+               --body "..." \
+               --base develop
+
+Approve and create? [Yes / Edit title / Edit body / Cancel]
+```
+
+MUST wait for explicit user approval before executing `gh pr create`.
+
+---
+
+## Step 8 — Create the PR
+
+```bash
+gh pr create \
+  --title "<title>" \
+  --body "<body>" \
+  --base $BASE
+```
+
+Capture the PR number from the output.
+
+---
+
+## Step 9 — Verify Base Branch
+
+MUST verify the PR was opened against the expected base before reporting success. GitHub sometimes defaults to a different base.
+
+```bash
+gh pr view <number> --json baseRefName --jq '.baseRefName'
+```
+
+| Result | Action |
+|--------|--------|
+| Equals `$BASE` | Proceed — report success |
+| Does NOT equal `$BASE` | Immediately retarget: `gh pr edit <number> --base $BASE` |
+
+After retargeting, verify again:
+
+```bash
+gh pr view <number> --json baseRefName --jq '.baseRefName'
+```
+
+Only report success after the base is confirmed correct.
+
+---
+
+## Step 10 — Return PR URL
+
+```bash
+gh pr view <number> --json url --jq '.url'
+```
+
+Return the PR URL to the user.
+
+---
+
+## Anti-Patterns (FORBIDDEN)
+
+- Do NOT call `gh pr create` before completing Steps 1–7 — bypassing detection causes PRs targeting the wrong base
+- Do NOT hardcode `--base develop` or `--base main` — always pass `--base $BASE` resolved in Step 1
+- Do NOT skip Step 9 (post-create verification) — GitHub may default to the wrong base
+- Do NOT invent scopes — a scope not in the allowlist fails PR validation
+- Do NOT omit the scope — every PR title MUST carry `type(scope): description`, never `type: description`
+
+---
+
+## Anti-Rationalization Table
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "The repo always uses develop, I can hardcode it" | Any repo could be different. Detection takes 2 seconds. | **MUST detect with `git ls-remote`** |
+| "I'll skip the post-create verification" | GitHub defaults to wrong bases frequently. The PR ends up merging into the wrong branch. | **MUST verify with `gh pr view --json baseRefName`** |
+| "Scope is optional, nobody will notice" | PR validation workflow will block it and waste everyone's time. | **MUST include scope from allowlist** |
+| "I'll guess the scope, it looks right" | Guessing breaks validation. Ask the user if ambiguous. | **MUST use only allowlist scopes** |
+| "No PR template? I'll skip the body" | A minimal body is always better than an empty one. | **MUST use default structure if no template** |
+| "Already opened PR, base looks fine" | GitHub silently defaults to wrong base. Verify explicitly. | **MUST run `gh pr view --json baseRefName`** |

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -86,16 +86,17 @@ State the policy source and chosen scope before proceeding.
 
 ```bash
 git status --porcelain          # check for uncommitted changes
-git branch --show-current       # confirm current branch name
+git branch --show-current       # confirm current branch name (empty in detached HEAD)
 git ls-remote --heads origin <current-branch>   # confirm branch is pushed
 ```
 
 | Condition | Detection | Required Action |
 |-----------|-----------|-----------------|
 | Uncommitted changes exist | `git status --porcelain` returns output | STOP — ask user to commit first with `ring:committing-changes` |
+| Detached HEAD / no branch | `git branch --show-current` returns empty output | STOP — ask user to checkout or create a named branch first |
 | Branch not on remote | `git ls-remote` returns no SHA for the branch | STOP — push first: `git push -u origin <branch>` |
 
-**Fail closed.** Only continue when both checks pass. If either condition is met, STOP and ask the user to resolve it first. Do NOT continue after a warning — explicit user action is required before proceeding to Step 4.
+**Fail closed.** Check in this order: uncommitted changes → detached HEAD → branch pushed. Only continue when all three checks pass. If any condition is met, STOP and ask the user to resolve it before proceeding to Step 4. Do NOT interpolate an empty branch name into `git ls-remote`.
 
 ---
 

--- a/default/skills/shipping-changes/SKILL.md
+++ b/default/skills/shipping-changes/SKILL.md
@@ -165,12 +165,15 @@ Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`
 
 Delegate to `ring:committing-changes` with the resolved `$BASE` and scope policy as context.
 
+**MUST propagate `$BASE`** to `ring:committing-changes` — Step 7 of that skill uses `origin/$BASE..HEAD` for commit batch scoping. Without it, the skill falls back to `@{u}` or re-detects the base, which works but is redundant when `$BASE` is already known here.
+
 The following rules from `ring:committing-changes` apply in full:
+- `$BASE` is already resolved — pass it explicitly so Step 7 skips re-detection
 - Scope MUST come from the allowlist resolved in Phase 0B
 - Scope MUST be included in every commit message — never omit
 - Commits MUST be atomic and logically grouped
 - Trailers via `--trailer "X-Lerian-Ref: 0x1"`, NEVER inside `-m`
-- GPG sign with `-S` (skip only if no key configured)
+- GPG sign with `-S` (no fallback — if no key, stop and instruct user to configure one)
 
 ---
 

--- a/default/skills/shipping-changes/SKILL.md
+++ b/default/skills/shipping-changes/SKILL.md
@@ -31,27 +31,25 @@ MUST complete both detections before analyzing changes or drafting anything. The
 ### 0A — Detect Base Branch
 
 ```bash
-# Step 1: GitHub authoritative default
+# Probe A — GitHub API default (fallback: git remote show origin | grep 'HEAD branch' | awk '{print $NF}')
 gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
-# Fallback if gh unavailable:
-# git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
 
-# Step 2: PR template override (highest priority)
-# Read .github/pull_request_template.md — if it names a branch, honor it
+# Probe B — PR template hint: read .github/pull_request_template.md for explicit branch name
 
-# Step 3: Develop branch hint
+# Probe C — develop existence
 git ls-remote --heads origin develop
 ```
 
-| Result | Action |
-|--------|--------|
-| `gh repo view` returns a branch | Set `BASE` to that value (primary) |
-| PR template explicitly names a base | Override `BASE` with that value (highest priority) |
-| `develop` exists AND `BASE != develop` | STOP — ask user to confirm: GitHub default or develop |
-| `develop` does NOT exist | Use `BASE` from GitHub default without prompting |
-| Both detection methods fail | STOP — ask the user which branch to target |
+Apply precedence in order — first match wins:
 
-**Why not develop-first:** a repo may have a stale `develop` branch while the real PR target is `main`. Using the GitHub API avoids targeting the wrong branch. The user confirmation step handles Lerian-style repos where develop is the intended target despite a different GitHub default.
+| Priority | Source | Rule |
+|----------|--------|------|
+| **1 — highest** | PR template | Explicit branch name in `.github/pull_request_template.md` — overrides everything |
+| **2** | develop + user | Probe C finds `develop` AND differs from Probe A → ask user to confirm which target |
+| **3 — fallback** | GitHub API | Use value from Probe A |
+| **4** | Neither | STOP — ask the user |
+
+**Why not develop-first:** a repo may have a stale `develop` branch while the real PR target is `main`. The GitHub API is the authoritative source; `develop` existence triggers a confirmation step instead of a silent assumption.
 
 ### 0B — Detect Scope Policy
 

--- a/default/skills/shipping-changes/SKILL.md
+++ b/default/skills/shipping-changes/SKILL.md
@@ -31,18 +31,27 @@ MUST complete both detections before analyzing changes or drafting anything. The
 ### 0A — Detect Base Branch
 
 ```bash
-git fetch origin --quiet
+# Step 1: GitHub authoritative default
+gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'
+# Fallback if gh unavailable:
+# git remote show origin | grep 'HEAD branch' | awk '{print $NF}'
+
+# Step 2: PR template override (highest priority)
+# Read .github/pull_request_template.md — if it names a branch, honor it
+
+# Step 3: Develop branch hint
 git ls-remote --heads origin develop
-git ls-remote --heads origin main
 ```
 
 | Result | Action |
 |--------|--------|
-| `develop` SHA found | Set `BASE=develop` |
-| `main` SHA found (develop absent) | Set `BASE=main` |
-| Neither found | STOP — ask the user which branch to target |
+| `gh repo view` returns a branch | Set `BASE` to that value (primary) |
+| PR template explicitly names a base | Override `BASE` with that value (highest priority) |
+| `develop` exists AND `BASE != develop` | STOP — ask user to confirm: GitHub default or develop |
+| `develop` does NOT exist | Use `BASE` from GitHub default without prompting |
+| Both detection methods fail | STOP — ask the user which branch to target |
 
-**Sanity-check:** read `.github/pull_request_template.md` — if it explicitly names a base, honor it and override `$BASE`.
+**Why not develop-first:** a repo may have a stale `develop` branch while the real PR target is `main`. Using the GitHub API avoids targeting the wrong branch. The user confirmation step handles Lerian-style repos where develop is the intended target despite a different GitHub default.
 
 ### 0B — Detect Scope Policy
 

--- a/default/skills/shipping-changes/SKILL.md
+++ b/default/skills/shipping-changes/SKILL.md
@@ -16,9 +16,11 @@ allowed-tools:
 
 End-to-end shipping workflow: detect base branch and scope policy once, present a complete plan, then execute branch → commit → push → PR in sequence, confirming at each phase. Uses `ring:committing-changes` and `ring:opening-pull-requests` internally — their rules and anti-patterns apply in full.
 
-## ⛔ HARD STOP — PRESENT PLAN BEFORE EXECUTING ANYTHING
+## ⛔ HARD STOP — PRESENT PLAN BEFORE EXECUTING ANY MUTATING COMMAND
 
-MUST analyze the current state and present a complete plan to the user before running any `git` or `gh` command. Executing without approval is FORBIDDEN.
+Read-only discovery commands (`git fetch`, `git ls-remote`, `git status`, `git diff`, `git log`) are allowed before approval — they are needed to build the plan.
+
+MUST complete Phase 0 detection, analyze the current state, and present a complete plan to the user before running any **mutating** `git` or `gh` command (`git checkout -b`, `git add`, `git commit`, `git push`, `gh pr create`). Executing mutating commands without approval is FORBIDDEN.
 
 ---
 

--- a/default/skills/shipping-changes/SKILL.md
+++ b/default/skills/shipping-changes/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: ring:shipping-changes
+description: >-
+  End-to-end git orchestrator: branch → commit → push → PR, with a full plan
+  presented before any execution. Detects base branch and scope allowlist once
+  and propagates to all phases. Use when ready to ship a complete unit of work.
+  Skip if only one phase is needed: commit-only → ring:committing-changes,
+  PR-only → ring:opening-pull-requests.
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+End-to-end shipping workflow: detect base branch and scope policy once, present a complete plan, then execute branch → commit → push → PR in sequence, confirming at each phase. Uses `ring:committing-changes` and `ring:opening-pull-requests` internally — their rules and anti-patterns apply in full.
+
+## ⛔ HARD STOP — PRESENT PLAN BEFORE EXECUTING ANYTHING
+
+MUST analyze the current state and present a complete plan to the user before running any `git` or `gh` command. Executing without approval is FORBIDDEN.
+
+---
+
+## Phase 0 — Detect Base Branch and Scope Policy
+
+MUST complete both detections before analyzing changes or drafting anything. These values are resolved once and propagated to all subsequent phases.
+
+### 0A — Detect Base Branch
+
+```bash
+git fetch origin --quiet
+git ls-remote --heads origin develop
+git ls-remote --heads origin main
+```
+
+| Result | Action |
+|--------|--------|
+| `develop` SHA found | Set `BASE=develop` |
+| `main` SHA found (develop absent) | Set `BASE=main` |
+| Neither found | STOP — ask the user which branch to target |
+
+**Sanity-check:** read `.github/pull_request_template.md` — if it explicitly names a base, honor it and override `$BASE`.
+
+### 0B — Detect Scope Policy
+
+Check in this order:
+
+1. `.github/workflows/pr-validation.yml` (primary)
+2. `.github/workflows/pr-title.yml`
+3. `.github/workflows/commitlint.yml`
+4. `.github/workflows/semantic-pull-request.yml`
+5. Root configs: `commitlint.config.{js,cjs,mjs,ts}`, `.commitlintrc*`
+
+Extract the allowed `scope` list and any `type` restrictions.
+
+| Situation | Required Action |
+|-----------|-----------------|
+| Policy found, scope is clear | Use only scopes from the allowlist |
+| Policy found, scope is ambiguous | STOP and ask the user which allowed scope to use |
+| No policy file found | MUST still include a scope — ask the user what scope to use |
+
+---
+
+## Phase 0C — Analyze Current State
+
+```bash
+git status
+git branch
+git diff
+git log --oneline -5
+```
+
+Use this output for the plan.
+
+---
+
+## Phase 0D — Present Full Plan for Approval
+
+Present everything before touching git:
+
+```
+Shipping Plan — waiting for your approval
+──────────────────────────────────────────
+Base branch:    develop   (from: git ls-remote)
+Scope policy:   .github/workflows/pr-validation.yml → scopes: [api, auth, docs, ci]
+Chosen scope:   auth
+
+Phase 1 — Branch
+  Current branch: main → will create: feat/add-oauth2-refresh
+  Command: git checkout -b feat/add-oauth2-refresh origin/develop
+
+Phase 2 — Commit
+  Files to stage:
+    - src/auth/oauth.ts (modified)
+    - src/auth/oauth.test.ts (modified)
+    - docs/auth/oauth-setup.md (modified)
+  Proposed commits:
+    1. feat(auth): add OAuth2 refresh token support
+    2. docs(docs): update OAuth2 setup guide
+
+Phase 3 — Push
+  Command: git push -u origin feat/add-oauth2-refresh
+
+Phase 4 — Pull Request
+  Title:   feat(auth): add OAuth2 refresh token support
+  Base:    develop
+  Command: gh pr create --title "..." --body "..." --base develop
+
+Approve and execute? [Yes / Modify / Cancel]
+```
+
+MUST wait for explicit user approval. Do NOT begin Phase 1 until approved.
+
+---
+
+## Phase 1 — Branch
+
+### 1.1 — Check current branch
+
+If already on a feature branch (not `$BASE`, not `main` when `$BASE=develop`):
+
+```javascript
+AskUserQuestion({
+  questions: [{
+    question: "You're already on a feature branch. How should I proceed?",
+    header: "Branch",
+    options: [
+      { label: "Use current branch", description: "Continue on this branch" },
+      { label: "Create new branch", description: "Create a new branch from origin/$BASE" }
+    ]
+  }]
+});
+```
+
+### 1.2 — Create branch (if needed)
+
+Branch naming convention: `<type>/<description>` in kebab-case.
+
+```bash
+git fetch origin --quiet
+# Check for duplicate
+git ls-remote --heads origin <type>/<description>
+
+# If no duplicate:
+git checkout -b <type>/<description> origin/$BASE
+```
+
+If a branch with the same name already exists on remote, ask the user for a different name.
+
+Types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `perf`
+
+---
+
+## Phase 2 — Commit
+
+Delegate to `ring:committing-changes` with the resolved `$BASE` and scope policy as context.
+
+The following rules from `ring:committing-changes` apply in full:
+- Scope MUST come from the allowlist resolved in Phase 0B
+- Scope MUST be included in every commit message — never omit
+- Commits MUST be atomic and logically grouped
+- Trailers via `--trailer "X-Lerian-Ref: 0x1"`, NEVER inside `-m`
+- GPG sign with `-S` (skip only if no key configured)
+
+---
+
+## Phase 3 — Push
+
+```bash
+git push -u origin <current-branch>
+```
+
+Show the user:
+- Branch name
+- Number of commits being pushed
+- Short summary of those commits
+
+Confirm success before proceeding to Phase 4.
+
+**NEVER** use `--force` or `--force-with-lease` unless the user explicitly requests it.
+
+---
+
+## Phase 4 — Pull Request
+
+Delegate to `ring:opening-pull-requests` with the resolved `$BASE` and scope policy as context.
+
+The following rules from `ring:opening-pull-requests` apply in full:
+- PR title MUST carry `type(scope): description` with scope from allowlist
+- Body MUST fill the repo's PR template
+- MUST verify base branch after `gh pr create`
+- MUST retarget with `gh pr edit <number> --base $BASE` if base is wrong
+- MUST return PR URL after confirmed success
+
+---
+
+## Arguments
+
+If an argument is provided (e.g., `/ring:shipping-changes feat/add-oauth2`), parse it as `<type>/<description>` for the branch name and skip the branch-naming question.
+
+---
+
+## Anti-Patterns (FORBIDDEN)
+
+- Do NOT execute any `git` or `gh` command before presenting the plan and getting approval
+- Do NOT hardcode `--base develop` or `--base main` — always use `$BASE` resolved in Phase 0A
+- Do NOT skip Phase 0B scope detection — missing scope breaks PR validation
+- Do NOT omit scope in commit messages or PR title
+- Do NOT invent scopes not in the allowlist — ask the user if unclear
+- Do NOT use `--force` on push unless the user explicitly asks
+- Do NOT skip the post-PR-create base verification (delegated to `ring:opening-pull-requests`)
+- Do NOT proceed to the next phase if the current phase fails — stop and ask the user
+
+---
+
+## Anti-Rationalization Table
+
+| Rationalization | Why It's WRONG | Required Action |
+|-----------------|----------------|-----------------|
+| "I know the base branch, I can skip detection" | Any repo can change. Detection takes 2 seconds and prevents irreversible mistakes. | **MUST detect with `git ls-remote`** |
+| "I'll present the plan after I start" | The plan exists so the user can catch mistakes before they happen. | **MUST present plan BEFORE any execution** |
+| "Scope detection is only for PRs" | Commit messages also need the allowlist scope — they're validated together. | **MUST detect scope before Phase 2** |
+| "The user approved the plan, I can skip confirmations per phase" | Phases can fail independently. Each phase confirms its own success. | **MUST confirm success at each phase** |
+| "I'll use the same scope as last time" | Each repo may have a different allowlist. Re-detect for every invocation. | **MUST detect scope from the current repo** |
+| "Branch creation failed but I'll continue" | Subsequent phases depend on the branch existing. | **MUST stop and ask the user on any failure** |
+| "Force push is fine since it's a feature branch" | `--force` rewrites history. Only do this on explicit user request. | **MUST NOT force push without explicit request** |

--- a/dev-team/skills/implementing-tasks/SKILL.md
+++ b/dev-team/skills/implementing-tasks/SKILL.md
@@ -133,6 +133,16 @@ golangci-lint run ./... || echo "LINT FAILED"
 - PARTIAL: some requirements delivered → list gaps, return to Gate 0
 - FAIL: critical requirements missing → return to Gate 0 with explicit instructions
 
+## Step 5: Commit
+
+When Step 4 verdict is PASS, load and call `ring:committing-changes` to create the signed atomic commit for this task before returning control to the dev-cycle orchestrator.
+
+```yaml
+Skill("ring:committing-changes")
+```
+
+MUST only run on PASS. On PARTIAL or FAIL, return to Gate 0 — do NOT commit.
+
 ## Output Format
 
 ```markdown

--- a/dev-team/skills/running-dev-cycle-frontend/SKILL.md
+++ b/dev-team/skills/running-dev-cycle-frontend/SKILL.md
@@ -92,6 +92,7 @@ for each epic:
   # task-level validation after review passes
   for each task:
     Gate 8
+    Skill("ring:committing-changes")  # commit task work after Gate 8 user approval
 
   [checkpoint if manual_per_epic]
 
@@ -110,6 +111,7 @@ phase completes its Gate 0/7/8 flow, fire the phase boundary exactly once:
    FALLBACK single-phase plan).
 2. Checkpoint with the user: summarize the completed phase (epics done, review/validation
    outcomes) and confirm intent to continue.
+2.5. Ask the user: "Open a PR for this phase?" → if yes: `Skill("ring:opening-pull-requests")` (optional, never automatic).
 3. Elaborate the next phase's tasks inline under each epic as `#### Task N.M.T:`
    blocks, following the ring:writing-plans Task Format (`- [ ] Done` checkbox
    immediately under the heading, then Context, Implementation vision, Files,

--- a/dev-team/skills/running-dev-cycle/SKILL.md
+++ b/dev-team/skills/running-dev-cycle/SKILL.md
@@ -64,6 +64,8 @@ for each phase (current wave; starts at Phase 1, the only detailed phase at init
     # 6. "Proceed to next epic?" checkpoint (Step 11.1) → next epic in this phase
 
   # 7. PHASE BOUNDARY (Step 11.5, after the LAST epic of the phase is approved) — read gates/phase-boundary.md
+  #    Skill("ring:committing-changes")  ← commit all phase work BEFORE closing the phase
+  #    ask user: "Open a PR for this phase?" → if yes: Skill("ring:opening-pull-requests")  ← optional
   #    close phase (Phase Overview → Complete, record deviations) →
   #    phase checkpoint (manual: ask Continue/Pause/Adjust | auto: log + continue) →
   #    elaborate next phase's epics into dispatch-ready tasks (1 planning agent, ANALYSIS mode) →
@@ -214,10 +216,11 @@ If user provides custom context at cycle start, store in `state.custom_prompt` a
 
 ## Commit Timing
 
-- Gate 0 (implementation): Commit after GREEN phase, coverage, docker-compose/local runtime, and delivery verification pass (`commit_timing == "per_task"`)
-- Gate 8 (review): Commit fixes after all reviewers pass
-- Gate 9 (validation): No commit (verification only); epic-level commit at Step 11.1 when `commit_timing == "per_epic"`
-- Cycle-end: Final commit with cycle metadata
+- Gate 0 (implementation): Commit after GREEN phase, coverage, docker-compose/local runtime, and delivery verification pass (`commit_timing == "per_task"`) via `ring:committing-changes`
+- Gate 8 (review): Commit fixes after all reviewers pass via `ring:committing-changes`
+- Gate 9 (validation): No commit (verification only); epic-level commit at Step 11.1 when `commit_timing == "per_epic"` via `ring:committing-changes`
+- Phase boundary (Step 11.5): ALWAYS call `Skill("ring:committing-changes")` to commit all phase work **before** closing the phase, regardless of `commit_timing`. After the commit, ask the user: "Open a PR for this phase?" — if yes, call `Skill("ring:opening-pull-requests")` (optional, never automatic).
+- Cycle-end: Final commit with cycle metadata via `ring:committing-changes`
 
 `commit_timing ∈ {per_task, per_epic, at_end}`. Convention: `feat|fix|test|chore(scope): description` — keep commits atomic per gate.
 


### PR DESCRIPTION
## Summary

Introduces 2 new git workflow skills and rewrites 1 existing skill, replacing the personal `/commit`, `/push`, `/branch`, `/pr`, and `/ship` slash commands with proper ring-namespace skills that enforce scope allowlists and carry anti-rationalization guards.

### Changes

**ring:committing-changes** (`default/skills/committing-changes/SKILL.md`) — **rewrite of existing skill**
- Step 0: Detect scope allowlist from PR validation workflow before any commit message is proposed
- Fallback chain: `pr-validation.yml` → `pr-title.yml` → `commitlint.yml` → `commitlint.config.*`
- Scope is REQUIRED in every commit — never omit, never invent outside allowlist
- GPG signing required (`-S`); no unsigned fallback — if no key configured, stop and instruct user
- Step 7: Verify every commit in batch via `%G?` (accepts G/U, rejects B/E/N/X/Y) and checks `X-Lerian-Ref` trailer; range scoped to `@{u}` → `origin/$BASE` → API detection

**ring:opening-pull-requests** (`default/skills/opening-pull-requests/SKILL.md`) — **new skill**, replaces `ring:generating-pr-descriptions`
- Base branch: probe table (PR template P1 > develop confirmation P2 > `gh repo view defaultBranchRef` P3)
- Detects scope allowlist (same logic as committing-changes)
- Step 3 fail-closed: uncommitted changes → detached HEAD → branch on remote → `rev-list` ahead-of-remote check (with `git fetch` before)
- Reads `.github/pull_request_template.md`, fills every section including Breaking Changes
- Shows full draft before `gh pr create`; verifies base after create; auto-corrects if wrong

**ring:shipping-changes** (`default/skills/shipping-changes/SKILL.md`) — **new skill**
- End-to-end orchestrator: branch → commit → push → PR
- Hard stop gates only MUTATING commands; read-only discovery allowed before plan approval
- Resolves base branch and scope once (Phase 0), propagates `$BASE` to committing-changes (Phase 2)
- Confirms success at each phase before advancing

### marketplace.json

- ring-default: v1.39.0 → **v1.40.0**
- marketplace: v0.384.0 → **v0.385.0**
- All other plugins preserved exactly as in origin/main (dev-team 1.84.0, pm-team 0.32.1, tw-team 0.6.0)
- Added `skills[]` array listing new/rewritten skills; `deprecated[]` marking `ring:generating-pr-descriptions`
- Schema note: the installer loader (`core.py:_validate_marketplace_schema`) only validates `name` and `source` per plugin — extra fields (`skills[]`, `deprecated[]`) are silently ignored, no rejection risk

## Type of Change

- [x] New feature (non-breaking addition)
- [x] Refactor / rewrite (committing-changes)

## Breaking Changes

None. `ring:generating-pr-descriptions` deprecated but not removed.

## Testing

- [x] Skills manually reviewed against ring CLAUDE.md requirements
- [x] Anti-rationalization tables present in all three skills
- [x] Scope enforcement logic verified against /ship skill reference implementation
- [x] marketplace.json loader validated — extra fields tolerated (installer core.py confirmed)
- [x] GPG/trailer verification flow reviewed for correctness across 8 review rounds

## Related Issues

Absorbs: personal skills `/commit`, `/push`, `/branch`, `/pr`, `/ship`