### PR TITLE
feat(skills): infer PR scope from recent PRs when no policy file

### DIFF
--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -83,7 +83,7 @@ Also extract any **type** restrictions — some repos limit allowed types beyond
 |-----------|-----------------|
 | Policy found, scope is clear | Use only scopes from the allowlist |
 | Policy found, scope is ambiguous | STOP and ask the user which allowed scope to use |
-| No policy file found | Infer the convention from recent merged PRs first: `gh pr list --state merged --limit 15 --json title --jq '.[].title'`. Use the dominant `type(scope)` pattern (e.g. scope = chart name, sub-env, or cluster depending on the repo). Ask the user only if no clear pattern emerges. |
+| No policy file found | Infer a candidate scope from recent merged PRs first: `gh pr list --state merged --limit 15 --json title --jq '.[].title'`. Present the inferred scope to the user for confirmation; if no clear pattern emerges, ask the user for a scope. |
 
 **NEVER** omit the scope. **NEVER** invent a scope not in the allowlist.
 

--- a/default/skills/opening-pull-requests/SKILL.md
+++ b/default/skills/opening-pull-requests/SKILL.md
@@ -83,7 +83,7 @@ Also extract any **type** restrictions — some repos limit allowed types beyond
 |-----------|-----------------|
 | Policy found, scope is clear | Use only scopes from the allowlist |
 | Policy found, scope is ambiguous | STOP and ask the user which allowed scope to use |
-| No policy file found | MUST still include a scope — ask the user what scope to use |
+| No policy file found | Infer the convention from recent merged PRs first: `gh pr list --state merged --limit 15 --json title --jq '.[].title'`. Use the dominant `type(scope)` pattern (e.g. scope = chart name, sub-env, or cluster depending on the repo). Ask the user only if no clear pattern emerges. |
 
 **NEVER** omit the scope. **NEVER** invent a scope not in the allowlist.
 


### PR DESCRIPTION
## Summary

`ring:opening-pull-requests` Step 2.3 ("Apply the policy") treated **no policy file found** as *ask the user for the scope*. But repos without a `pr-validation.yml` (e.g. `helm`, `lerian-internal-gitops`) still carry a clear, consistent convention in their merged PR history — asking the user is a needless interruption when the answer is one `gh` call away.

This change makes the fallback **infer the convention from recent merged PRs first**:

> `gh pr list --state merged --limit 15 --json title --jq '.[].title'` → use the dominant `type(scope)` pattern (e.g. scope = chart name, sub-env, or cluster depending on the repo). Ask the user only if no clear pattern emerges.

## Type of Change

- [x] Skill behavior improvement (fallback path)

## Breaking Changes

None. Only the "no policy file found" branch changes; the authoritative `pr-validation.yml` detection path is untouched.

## Testing

- [x] Dogfooded: this PR's own title/scope (`feat(skills)`) was chosen by applying the new fallback against ring's own merged-PR history (ring has no `pr-validation.yml`).

https://claude.ai/code/session_016Bv8y35GWdpgNdhGVs28JZ