### PR TITLE
fix(marketplace): git-subdir plugin sources to unblock updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,12 @@
       "name": "ring-default",
       "description": "Core skills library for the Lerian Team: TDD, code review, collaboration patterns, and proven techniques. Features parallel code review orchestration with 9 default reviewers plus triggered conditional specialists, and git shipping skills (ring:committing-changes, ring:opening-pull-requests, ring:shipping-changes) with scope allowlist enforcement. 25 essential skills for software engineering excellence, including plan authoring and execution.",
       "version": "1.42.1",
-      "source": "./default",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/lerianstudio/ring.git",
+        "path": "default",
+        "ref": "main"
+      },
       "homepage": "https://github.com/lerianstudio/ring/tree/main/default",
       "repository": "https://github.com/lerianstudio/ring/tree/main/default",
       "license": "MIT",
@@ -41,7 +46,12 @@
       "name": "ring-dev-team",
       "description": "24 specialized developer agents + 35 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
       "version": "1.85.0",
-      "source": "./dev-team",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/lerianstudio/ring.git",
+        "path": "dev-team",
+        "ref": "main"
+      },
       "homepage": "https://github.com/lerianstudio/ring/tree/main/dev-team",
       "repository": "https://github.com/lerianstudio/ring/tree/main/dev-team",
       "license": "MIT",
@@ -74,7 +84,12 @@
       "name": "ring-pm-team",
       "description": "Product team workflow: 14 skills + 4 research agents. Pre-dev planning with 4-gate (small features) and 8-gate (large features) orchestrators producing machine-consumable specs (prd, trd, openapi.yaml, schema, plan.md), plus standalone mapping-streaming-events discovery and UX validation. Includes parallel research agents, specialized code analysis, and Product Designer.",
       "version": "0.32.1",
-      "source": "./pm-team",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/lerianstudio/ring.git",
+        "path": "pm-team",
+        "ref": "main"
+      },
       "homepage": "https://github.com/lerianstudio/ring/tree/main/pm-team",
       "repository": "https://github.com/lerianstudio/ring/tree/main/pm-team",
       "license": "MIT",
@@ -96,7 +111,12 @@
       "name": "ring-tw-team",
       "description": "Technical writing specialists for functional and API documentation. 3 specialized agents (guide-writer, api-writer, docs-reviewer) and 4 documentation skills covering voice/tone, structure, API field descriptions, and quality review. Enforces clear, consistent documentation standards.",
       "version": "0.6.0",
-      "source": "./tw-team",
+      "source": {
+        "source": "git-subdir",
+        "url": "https://github.com/lerianstudio/ring.git",
+        "path": "tw-team",
+        "ref": "main"
+      },
       "homepage": "https://github.com/lerianstudio/ring/tree/main/tw-team",
       "repository": "https://github.com/lerianstudio/ring/tree/main/tw-team",
       "license": "MIT",

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -103,7 +103,10 @@ jobs:
           # For each plugin in marketplace.json
           for ((i=0; i<$PLUGIN_COUNT; i++)); do
             PLUGIN_NAME=$(jq -r ".plugins[$i].name" "$MARKETPLACE_JSON")
-            PLUGIN_SOURCE=$(jq -r ".plugins[$i].source" "$MARKETPLACE_JSON" | sed 's|^\./||')
+            # source is either a relative string ("./default") or a git-subdir
+            # object ({"source":"git-subdir","path":"default",...}); both resolve
+            # to the plugin directory name used for change detection below.
+            PLUGIN_SOURCE=$(jq -r ".plugins[$i].source | if type == \"object\" then .path else . end" "$MARKETPLACE_JSON" | sed 's|^\./||')
 
             echo "Checking plugin: $PLUGIN_NAME (source: $PLUGIN_SOURCE)"
 


### PR DESCRIPTION
## Problem

`claude plugin update <plugin>@ring` fails for **every** Ring plugin:

```
✘ Failed to update plugin "ring-default@ring": This plugin uses a source type
  your Claude Code version does not support. Update Claude Code and try again.
```

The message is misleading — Claude Code is already on the latest release (`2.1.195`); there is nothing newer to update to. The result: installs silently stick at old versions (e.g. `ring-default` pinned at `1.39.0` while `1.42.1` had shipped), and the merged hook fix from #422 never reaches users via the normal update path.

## Root cause

The CLI's plugin download/update switch handles four source types: `npm`, `github`, `url`, `git-subdir`. A Ring plugin is declared with a **relative-string** source pointing to a **subdirectory** of a GitHub-hosted marketplace:

```json
"source": "./default"
```

For a plugin living in a subdirectory, that relative form resolves to a source type the update switch does not handle, so it hits the `default: throw`. (A plugin at the marketplace **root**, e.g. ponytail's `"./"`, resolves to `github` and updates fine — which is why only the subdirectory plugins are affected.)

## Fix

Declare each plugin with an explicit **`git-subdir`** source — the same format the official Anthropic marketplace uses for subdirectory plugins:

```json
"source": {
  "source": "git-subdir",
  "url": "https://github.com/lerianstudio/ring.git",
  "path": "default",
  "ref": "main"
}
```

`ref: main` (no pinned `sha`) keeps updates rolling with `main`, matching how this same-repo marketplace already tracks itself.

`version-bump.yml` read `.source` as a string to locate each plugin's directory for change detection; updated to extract `.path` from the object form, with the legacy string form still handled (so the workflow keeps working regardless of format).

## Validation

Tested against the live Claude Code CLI (`2.1.195`) via an isolated throwaway marketplace:

| Source form | `claude plugin install` result |
|---|---|
| `"./default"` (relative, in github marketplace) | ✘ "source type … not supported" |
| `git-subdir` object, `ref=main`, with `sha` | ✔ installs (clones repo, takes `default/`) |
| `git-subdir` object, `ref=main`, **no `sha`** | ✔ installs |

- `claude plugin validate .` accepts the new `source` objects (no new findings; the pre-existing `plugins.0.skills` / `deprecated` notes are unrelated and present on `main`).
- Workflow `jq` path extraction verified to resolve all four plugins to their correct directories (`default`, `dev-team`, `pm-team`, `tw-team`).

## Blast radius

- Only `.claude-plugin/marketplace.json` carries a `source` field; the per-harness manifests (`.codex-plugin/`, `.cursor-plugin/`, `.opencode/`) do not, so they are unaffected.
- `version-bump.yml:106` is the only consumer of `.source` across all workflows/scripts; it is updated in the same commit.

https://claude.ai/code/session_01QF6nfqkBt9HGMQnJ7Bikem
