### PR TITLE
fix(marketplace): remove invalid skills field from ring-default (real update-failure cause)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,14 +32,6 @@
         "parallel-review",
         "git",
         "pull-requests"
-      ],
-      "skills": [
-        "ring:committing-changes",
-        "ring:opening-pull-requests",
-        "ring:shipping-changes"
-      ],
-      "deprecated": [
-        "ring:generating-pr-descriptions"
       ]
     },
     {


### PR DESCRIPTION
## Root cause of the Ring plugin update/install failures

`ring-default` could not be installed or updated — every attempt failed with:

```
✘ This plugin uses a source type your Claude Code version does not support.
```

The message is misleading. The real trigger is the `ring-default` marketplace entry carrying a **`skills`** field in the wrong shape:

```json
"skills": [
  "ring:committing-changes",
  "ring:opening-pull-requests",
  "ring:shipping-changes"
]
```

The marketplace schema expects `skills` to be **relative path strings** (the official marketplace uses `["./skills/box", ...]`), not namespaced skill IDs. So the entry fails schema validation — `claude plugin validate` reports `plugins.0.skills: Invalid input` — and a malformed entry leaves the plugin's source descriptor unresolvable, which surfaces as the bogus "source type not supported" error in the install/update download path.

This is why **only `ring-default` failed**: it was the sole entry with a `skills` (and `deprecated`) field. `ring-dev-team`, `ring-pm-team`, and `ring-tw-team` have neither and install/update fine.

## Fix

Remove the invalid `skills` field and the unknown `deprecated` field from the `ring-default` entry. The field is optional advertising (240/243 official plugins omit it); the plugin's skills are discovered from `default/skills/` regardless.

## Validation (live CLI 2.1.195)

Isolated, same source (`git-subdir`), only the field varied:

| Entry | `claude plugin install` |
|---|---|
| with `skills` field (array of skill IDs) | ✘ "source type … not supported" |
| with `deprecated` only | ✔ installs |
| with `skills` only | ✘ fails |
| clean entry (no `skills`/`deprecated`) | ✔ installs |
| **exact post-fix `ring-default` entry** | ✔ installs |

- `claude plugin validate .` now **passes** (previously failed on `plugins.0.skills`).

## Relationship to #423

#423 switched plugin sources to `git-subdir` objects. That format is valid and works (the official marketplace uses it for subdirectory plugins), but it was **not** the cause of the failures — this `skills` field was. #423 is harmless to keep; this PR is the actual fix. Both are needed only in the sense that the cleaned entry was validated on top of the `git-subdir` source already on `main`.

https://claude.ai/code/session_01QF6nfqkBt9HGMQnJ7Bikem
