### PR TITLE
feat(dev-team): add reviewing-operational-risk skill

### DIFF
--- a/dev-team/skills/reviewing-operational-risk/SKILL.md
+++ b/dev-team/skills/reviewing-operational-risk/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: ring:reviewing-operational-risk
+description: "Reviewing a Go/TS service's operational risk by mapping integration failure points (external HTTP calls, queue consumers, outbound webhooks), simulating stuck intermediate states for each entity in a flow, and classifying each scenario into tiers — then emitting operational runbooks (Tier 2) or gap specs (Tier 3). Two entry modes: explore an existing codebase, or read a dev-cycle plan.md and epic artifacts. Use before production hardening, incident retros, or at dev-cycle end. Skip for prototypes, pure libraries, or when no integration boundaries exist."
+---
+
+# Operational Risk Review
+
+## When to use
+- Preparing a service for production and want to know what breaks when a flow gets stuck
+- After a dev-cycle: pressure-test the newly built flows for recovery gaps
+- Incident retro: formalize which failure modes have a rescue path and which do not
+- You need operational runbooks or a backlog of "missing rescue mechanism" gap specs
+
+## Skip when
+- Prototype / throwaway PoC not heading to production
+- Pure library or SDK with no integration boundaries (no external calls, queues, or webhooks)
+- Single-question check (use a targeted read instead of the full review)
+
+## Related
+**Complementary:** ring:auditing-production-readiness (broad readiness scoring), ring:mapping-service-resources (resource inventory), ring:running-dev-cycle (optional end-of-cycle hook)
+
+## What this produces
+For every failure scenario, a **tier** and an actionable artifact:
+
+| Tier | Meaning | Output |
+|------|---------|--------|
+| **Tier 1** | The app resolves it itself — automatic retry, compensation, TTL/expiry, DLQ replay | Note only (documented as self-healing) |
+| **Tier 2** | An **external trigger exists** that unblocks it — an API call, an endpoint, a Console/UI action | **Operational runbook** with concrete steps |
+| **Tier 3** | **Gap** — no rescue path exists short of direct DB intervention | **Gap spec** (what's missing, who can act today, what should exist) |
+
+## Audience
+The output is always written **for the developer running the skill** (tech lead or engineer). Runbooks assume operator access; gap specs assume backlog ownership.
+
+---
+
+## Step 0: Determine entry mode
+
+Ask the developer (or infer from context):
+
+- **Mode A — Codebase explore:** review an existing service by scanning its integration boundaries.
+- **Mode B — Plan context:** review flows just built in a dev-cycle by reading `plan.md` and the current cycle's epic artifacts, without exploring the whole repo.
+
+If a `plan.md` (ring:writing-plans format) with an active cycle is present and the developer wants to review *what was just built*, prefer **Mode B**. Otherwise use **Mode A**.
+
+---
+
+## Step 1 (Mode A): Map integration boundaries
+
+Scan the repo for the points where the service **talks to the outside world**. The focus is on what the service **expects to receive and how it reacts when it does not** — do NOT leave the repo to inspect dependencies.
+
+```bash
+# Outbound HTTP calls (clients this service makes)
+grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx" internal/ components/ 2>/dev/null
+grep -rn "axios\|fetch(\|got(\|undici" src/ 2>/dev/null      # TS
+
+# Queue consumers (things this service waits to receive)
+grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ src/ 2>/dev/null
+
+# Outbound webhooks / event publishes
+grep -rn "Publish(\|Produce(\|webhook\|NotifyURL\|callback" internal/ components/ src/ 2>/dev/null
+```
+
+For **each** integration point, record the resilience posture:
+
+| Attribute | What to check |
+|-----------|---------------|
+| Retry | Is there a retry policy (count, backoff)? |
+| Rollback / compensation | On failure, is there a compensating action or saga step? |
+| DLQ | Dead-letter queue or parking for un-processable messages? |
+| Timeout handling | Explicit context timeout + handling of the timeout path? |
+| Idempotency | Safe to reprocess without duplicate side effects? |
+
+Produce a **boundary map**: `{integration_point, direction, entities_touched, resilience: {retry, rollback, dlq, timeout, idempotency}}`.
+
+---
+
+## Step 1 (Mode B): Extract the flow from the plan
+
+Read the cycle's `plan.md` and the epic artifacts of the **current cycle** only:
+
+- `## Phase Overview` + the active phase's `### Epic N.M:` sections → the flows built this cycle
+- Each epic's task blocks → the entities created/mutated and the transitions between them
+- Any linked design docs (data model, API contracts) referenced by the epics
+
+Produce, per flow: `{flow_name, entry_point, entities[], state_transitions[], terminal_state}`. Do not scan the whole repo — the plan is the source.
+
+---
+
+## Step 2: Confirmation dialogue with the developer
+
+Before analysing failures, confirm the model out loud and get agreement:
+
+```
+For flow "<flow_name>":
+  Entry point:      <e.g. POST /transfers>
+  Terminal state:   <e.g. transfer.status = SETTLED>
+  Entities & states: <entity: [state1 → state2 → state3]>
+  Dependencies:     <external calls / queues / webhooks identified>
+
+Is this correct? Anything missing or misidentified?
+```
+
+Incorporate corrections before proceeding. This gate prevents analysing a wrong model.
+
+---
+
+## Step 3: Simulate stuck intermediate states
+
+For **each intermediate state** of **each entity** in the flow, simulate a failure of progression and trace downstream impact:
+
+```
+For entity E, transition Sn → Sn+1:
+  1. Assume E is stuck in Sn (the transition never completes).
+  2. What triggers Sn → Sn+1? (a consumer, an HTTP response, a scheduled job, a user action)
+  3. If that trigger never fires or fails:
+     - What downstream entities/flows are blocked or left inconsistent?
+     - Is there money / data / a user commitment left in limbo?
+  4. What, if anything, moves E forward or unwinds it?
+```
+
+Record one **scenario** per stuck state.
+
+---
+
+## Step 4: Classify each scenario into a tier
+
+| Tier | Test | Example |
+|------|------|---------|
+| **Tier 1** | A mechanism inside the app recovers it with no human trigger | automatic retry with backoff, saga compensation, message TTL + DLQ replay, expiry job |
+| **Tier 2** | A rescue path exists but needs an **external trigger** | re-drive endpoint, admin API, "retry" button in Console, replay CLI |
+| **Tier 3** | No rescue path exists without touching the database directly | stuck row with no re-drive, orphaned record no API can fix |
+
+Downgrade honestly: if the "retry" only works when the DB is hand-edited first, it's **Tier 3**, not Tier 2.
+
+---
+
+## Step 5: Emit outputs
+
+Write to `docs/ops-risk/<flow-or-service>-<YYYY-MM-DD>.md`.
+
+### Tier 2 → Operational runbook
+```
+### Runbook: <scenario>
+Symptom:        <how an operator recognises the stuck state>
+Detection:      <query / metric / log to confirm>
+Trigger:        <the exact API call / endpoint / Console action that unblocks it>
+Steps:          1. ... 2. ... 3. ...
+Verification:   <how to confirm the entity reached terminal state>
+Blast radius:   <what else is affected while stuck>
+```
+
+### Tier 3 → Gap spec
+```
+### Gap: <scenario>
+What's missing:     <the rescue mechanism that does not exist>
+Impact if hit:      <blast radius, data/money at risk, frequency estimate>
+Who can act today:  <e.g. only a DBA with prod write access>
+What should exist:   <new API / endpoint / Console UI action / automated job>
+Suggested owner:    <team / epic to carry it>
+```
+
+### Summary table (top of file)
+```
+| Flow | Entity | Stuck state | Tier | Artifact |
+|------|--------|-------------|------|----------|
+```
+
+---
+
+## Step 6: Present to the developer
+
+Summarize: mode used, flows reviewed, scenario count per tier, the count of Tier 3 gaps (the important number), and the path to the generated file. Offer to open issues for Tier 3 gaps if the developer wants a backlog.
+
+## Red Flags — STOP
+- Classifying a scenario Tier 2 when the "trigger" only works after a manual DB edit → it is **Tier 3**.
+- Leaving the repo in Mode A to audit a dependency's internals → out of scope; review only how THIS service reacts.
+- Skipping the Step 2 confirmation dialogue → you may be analysing the wrong flow model.
+- Reporting only Tier 3 counts without the concrete "what should exist" → a gap without a spec is not actionable.
+
+## Common Mistakes
+- **Analysing happy path only.** The whole point is the stuck intermediate states, not the terminal success.
+- **Treating a DLQ as Tier 1 automatically.** A DLQ with no replay path is really a Tier 2 (needs a re-drive) or Tier 3 (nothing drains it).
+- **Mode B scope creep.** In plan-context mode, read the plan and epic artifacts — do not fall back into full-repo exploration.

--- a/dev-team/skills/reviewing-operational-risk/SKILL.md
+++ b/dev-team/skills/reviewing-operational-risk/SKILL.md
@@ -143,15 +143,16 @@ on what the service **expects to receive and how it reacts when it does not** �
 do NOT leave the repo to inspect dependencies.
 
 If the script cannot be run (no Node.js, restricted env), fall back to manual
-greps for the same boundaries — **run these from the repo root and include
-`pkg/`**, not just the service subdir:
+greps for the same boundaries — **run these from the repo root and cover the
+same root set as the scanner** (`internal/ components/ pkg/ src/ apps/ cmd/
+services/ plugins/`), not just the service subdir:
 
 ```bash
-grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx\|httpclient.\|DoWithRetry\|New.*Client(" internal/ components/ pkg/ 2>/dev/null
-grep -rn "axios\|fetch(\|got(\|undici" src/ 2>/dev/null      # TS
-grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ pkg/ src/ 2>/dev/null
-grep -rn "Publish(\|Produce(\|NotifyURL\|callbackURL\|webhookURL" internal/ components/ pkg/ src/ 2>/dev/null
-grep -rln "ports/out\|port.[A-Z].*Port" internal/ components/ apps/ 2>/dev/null   # find hexagonal outbound ports, then read their adapters in pkg/
+grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx\|httpclient.\|DoWithRetry\|New.*Client(" internal/ components/ pkg/ apps/ cmd/ services/ plugins/ 2>/dev/null
+grep -rn "axios\|fetch(\|got(\|undici" src/ apps/ services/ plugins/ 2>/dev/null      # TS
+grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ pkg/ src/ apps/ cmd/ services/ plugins/ 2>/dev/null
+grep -rn "Publish(\|Produce(\|NotifyURL\|callbackURL\|webhookURL" internal/ components/ pkg/ src/ apps/ cmd/ services/ plugins/ 2>/dev/null
+grep -rln "ports/out\|port.[A-Z].*Port" internal/ components/ apps/ cmd/ services/ plugins/ 2>/dev/null   # find hexagonal outbound ports, then read their adapters in pkg/
 ```
 
 For **each** integration point, confirm the resilience posture (the script

--- a/dev-team/skills/reviewing-operational-risk/SKILL.md
+++ b/dev-team/skills/reviewing-operational-risk/SKILL.md
@@ -33,6 +33,30 @@ The output is always written **for the developer running the skill** (tech lead 
 
 ---
 
+## How this skill runs: a hybrid (mechanical + judgement) flow
+
+The review is split into two phases so the deterministic work is not left to the LLM:
+
+**Phase 1 — mechanical (`scan-integration-points.mjs`, run by the dev):**
+A zero-dependency Node.js script traverses the target repo and finds integration
+boundaries (external HTTP calls, queue consumers, event publishers, outbound
+webhooks). For each point it heuristically records whether retry, DLQ, timeout,
+rollback/compensation, and idempotency patterns appear nearby. It emits a
+structured JSON report. It is generic: it runs on any Go or TypeScript/Node.js
+Lerian repo. This phase is repeatable and produces the same map every time.
+
+**Phase 2 — judgement (this agent, from here on):**
+The agent takes the JSON as structured context, runs the confirmation dialogue,
+simulates stuck states, classifies Tier 1/2/3, and writes runbooks (T2) and gap
+specs (T3). This is the analysis that needs a human-in-the-loop and cannot be
+reduced to regex.
+
+> **The developer runs the `.mjs` first and pastes/attaches its JSON output to
+> the agent before the dialogue begins.** In Mode A the agent uses that JSON as
+> the boundary map instead of re-deriving it by hand. See **Step 1 (Mode A)**.
+
+---
+
 ## Step 0: Determine entry mode
 
 Ask the developer (or infer from context):
@@ -44,23 +68,50 @@ If a `plan.md` (ring:writing-plans format) with an active cycle is present and t
 
 ---
 
-## Step 1 (Mode A): Map integration boundaries
+## Step 1 (Mode A): Map integration boundaries — run the scanner first
 
-Scan the repo for the points where the service **talks to the outside world**. The focus is on what the service **expects to receive and how it reacts when it does not** — do NOT leave the repo to inspect dependencies.
+The boundary map is produced **mechanically** by the script, not by hand. The
+developer runs it against the target repo and gives the JSON to the agent:
 
 ```bash
-# Outbound HTTP calls (clients this service makes)
+# From the target repo root (any Go or TS/Node.js Lerian service):
+node /path/to/reviewing-operational-risk/scan-integration-points.mjs . --out ops-risk-scan.json
+# then paste/attach ops-risk-scan.json to the agent before the dialogue.
+```
+
+The script emits `ring.ops-risk.integration-scan.v1` JSON:
+
+```jsonc
+{
+  "summary": { "files_scanned": 210, "integration_points": 102, "by_category": {...} },
+  "integration_points": [
+    { "category": "http_outbound", "direction": "outbound", "language": "go",
+      "file": "internal/x.go", "line": 156, "snippet": "...",
+      "resilience": { "retry": false, "dlq": false, "timeout": true,
+                      "rollback": false, "idempotency": false } }
+  ],
+  "resilience_gaps": [ { "file": "...", "line": 156, "category": "...", "missing": ["retry","dlq"] } ]
+}
+```
+
+The agent consumes this JSON as the starting boundary map. **Treat every hit as
+a candidate and every `false` resilience flag as a prompt to verify, not a
+confirmed gap** — the regex scan is deterministic but heuristic. The focus stays
+on what the service **expects to receive and how it reacts when it does not** —
+do NOT leave the repo to inspect dependencies.
+
+If the script cannot be run (no Node.js, restricted env), fall back to manual
+greps for the same boundaries:
+
+```bash
 grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx" internal/ components/ 2>/dev/null
 grep -rn "axios\|fetch(\|got(\|undici" src/ 2>/dev/null      # TS
-
-# Queue consumers (things this service waits to receive)
 grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ src/ 2>/dev/null
-
-# Outbound webhooks / event publishes
 grep -rn "Publish(\|Produce(\|webhook\|NotifyURL\|callback" internal/ components/ src/ 2>/dev/null
 ```
 
-For **each** integration point, record the resilience posture:
+For **each** integration point, confirm the resilience posture (the script
+pre-fills these flags; verify them against the code):
 
 | Attribute | What to check |
 |-----------|---------------|
@@ -88,7 +139,10 @@ Produce, per flow: `{flow_name, entry_point, entities[], state_transitions[], te
 
 ## Step 2: Confirmation dialogue with the developer
 
-Before analysing failures, confirm the model out loud and get agreement:
+Before analysing failures, confirm the model out loud and get agreement. In
+Mode A, drive this dialogue **from the scanner JSON** — walk the developer
+through the `integration_points` and the `resilience_gaps` the script surfaced,
+and let them correct false positives/negatives before you classify anything:
 
 ```
 For flow "<flow_name>":
@@ -175,6 +229,8 @@ Summarize: mode used, flows reviewed, scenario count per tier, the count of Tier
 - Classifying a scenario Tier 2 when the "trigger" only works after a manual DB edit → it is **Tier 3**.
 - Leaving the repo in Mode A to audit a dependency's internals → out of scope; review only how THIS service reacts.
 - Skipping the Step 2 confirmation dialogue → you may be analysing the wrong flow model.
+- Trusting the scanner's `resilience` flags as ground truth → they are heuristic; a `true` is a hint and a `false` is a prompt to verify, never a final verdict.
+- Starting the analysis in Mode A without the `scan-integration-points.mjs` JSON when Node.js is available → run the mechanical phase first, then reason over its output.
 - Reporting only Tier 3 counts without the concrete "what should exist" → a gap without a spec is not actionable.
 
 ## Common Mistakes

--- a/dev-team/skills/reviewing-operational-risk/SKILL.md
+++ b/dev-team/skills/reviewing-operational-risk/SKILL.md
@@ -149,7 +149,7 @@ services/ plugins/`), not just the service subdir:
 
 ```bash
 grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx\|httpclient.\|DoWithRetry\|New.*Client(" internal/ components/ pkg/ apps/ cmd/ services/ plugins/ 2>/dev/null
-grep -rn "axios\|fetch(\|got(\|undici" src/ apps/ services/ plugins/ 2>/dev/null      # TS
+grep -rn "axios\|fetch(\|got(\|undici" internal/ components/ pkg/ src/ apps/ cmd/ services/ plugins/ 2>/dev/null      # TS
 grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ pkg/ src/ apps/ cmd/ services/ plugins/ 2>/dev/null
 grep -rn "Publish(\|Produce(\|NotifyURL\|callbackURL\|webhookURL" internal/ components/ pkg/ src/ apps/ cmd/ services/ plugins/ 2>/dev/null
 grep -rln "ports/out\|port.[A-Z].*Port" internal/ components/ apps/ cmd/ services/ plugins/ 2>/dev/null   # find hexagonal outbound ports, then read their adapters in pkg/

--- a/dev-team/skills/reviewing-operational-risk/SKILL.md
+++ b/dev-team/skills/reviewing-operational-risk/SKILL.md
@@ -79,20 +79,62 @@ node /path/to/reviewing-operational-risk/scan-integration-points.mjs . --out ops
 # then paste/attach ops-risk-scan.json to the agent before the dialogue.
 ```
 
+> **Monorepo / hexagonal Go — do NOT scan only the service subdir.** In a
+> hexagonal layout the outbound boundaries live in the imported `pkg/*` (or
+> shared adapter) packages, **not** under `apps/<svc>`. Scanning only
+> `apps/<svc>` returns a **false 0**. The scanner defends against this: given a
+> subdir it walks up to the repo/module root, scans the whole tree, and
+> attributes each boundary to its service via top-level dir. **Always run from
+> the repo root (or let the scanner expand to it) so `pkg/*` adapters and
+> `ports/out` methods are included.** If you must scan a single subdir, pass
+> `--no-repo-root` and expect the map to miss shared adapters. Whenever
+> `integration_points == 0` for a service that imports `ports/out`, the scanner
+> emits an explicit `warnings[]` entry — treat it as a scope error, not a clean
+> bill of health.
+
+The scanner is **port-aware and adapter-aware**: each method of a `ports/out`
+interface is treated as a boundary candidate (`category: "outbound_port"`), and
+its resilience is inferred over the whole concrete **adapter file** — so an SDK
+adapter (e.g. `midazsdk.WithTimeout`, `DoWithRetry`) that never calls `net/http`
+directly is still detected. Resilience for Go line-matches is inferred over the
+**enclosing function**, not a fixed ±N-line window, so a retry/timeout wrapper
+elsewhere in the function still counts.
+
+**Optional per-repo config (`.ops-risk.json`)** at the repo root tunes
+detection: `shared_adapter_dirs`, `http_wrapper_packages`, `outbound_port_globs`,
+and `exclude_handler_globs`. The scanner **auto-generates a default on first run**
+if none exists (pass `--no-gen-config` to skip). Edit it to match the repo's
+layout before a serious review.
+
 The script emits `ring.ops-risk.integration-scan.v1` JSON:
 
 ```jsonc
 {
-  "summary": { "files_scanned": 210, "integration_points": 102, "by_category": {...} },
+  "scan_root": "/repo", "requested_target": "/repo/apps/svc",
+  "warnings": [ { "level": "warn", "code": "zero_boundaries_in_port_service",
+                 "service": "apps/svc", "message": "0 fronteiras num serviço que importa ports/out ..." } ],
+  "summary": {
+    "files_scanned": 210, "integration_points": 102,
+    "by_category": {...}, "by_service": {...}, "files_by_top_dir": {...},
+    "services_importing_ports_out": ["apps/svc"], "http_wrapper_packages_detected": ["httpclient"]
+  },
   "integration_points": [
     { "category": "http_outbound", "direction": "outbound", "language": "go",
-      "file": "internal/x.go", "line": 156, "snippet": "...",
+      "service": "apps/svc", "file": "internal/x.go", "line": 156, "snippet": "...",
       "resilience": { "retry": false, "dlq": false, "timeout": true,
-                      "rollback": false, "idempotency": false } }
+                      "rollback": false, "idempotency": false } },
+    { "category": "outbound_port", "direction": "outbound", "language": "go",
+      "service": "pkg", "file": "pkg/midazadapter/adapter.go", "line": 42,
+      "port": { "interface": "PaymentPort", "method": "Charge", "declared_in": "apps/svc/ports/out/gateway.go" },
+      "resilience": { "retry": true, "timeout": true, "dlq": false, "rollback": false, "idempotency": false } }
   ],
-  "resilience_gaps": [ { "file": "...", "line": 156, "category": "...", "missing": ["retry","dlq"] } ]
+  "resilience_gaps": [ { "file": "...", "line": 156, "category": "...", "service": "...", "missing": ["retry","dlq"] } ]
 }
 ```
+
+Always read `warnings[]` first: a `zero_integration_points` or
+`zero_boundaries_in_port_service` warning means the map is probably incomplete
+(scope error) and must not be treated as "no boundaries exist".
 
 The agent consumes this JSON as the starting boundary map. **Treat every hit as
 a candidate and every `false` resilience flag as a prompt to verify, not a
@@ -101,13 +143,15 @@ on what the service **expects to receive and how it reacts when it does not** �
 do NOT leave the repo to inspect dependencies.
 
 If the script cannot be run (no Node.js, restricted env), fall back to manual
-greps for the same boundaries:
+greps for the same boundaries — **run these from the repo root and include
+`pkg/`**, not just the service subdir:
 
 ```bash
-grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx" internal/ components/ 2>/dev/null
+grep -rn "http.NewRequest\|http.Client\|resty\|req.Get\|req.Post\|Do(ctx\|httpclient.\|DoWithRetry\|New.*Client(" internal/ components/ pkg/ 2>/dev/null
 grep -rn "axios\|fetch(\|got(\|undici" src/ 2>/dev/null      # TS
-grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ src/ 2>/dev/null
-grep -rn "Publish(\|Produce(\|webhook\|NotifyURL\|callback" internal/ components/ src/ 2>/dev/null
+grep -rn "Consume(\|Subscribe(\|HandleDelivery\|amqp\|rabbitmq\|sqs\|kafka" internal/ components/ pkg/ src/ 2>/dev/null
+grep -rn "Publish(\|Produce(\|NotifyURL\|callbackURL\|webhookURL" internal/ components/ pkg/ src/ 2>/dev/null
+grep -rln "ports/out\|port.[A-Z].*Port" internal/ components/ apps/ 2>/dev/null   # find hexagonal outbound ports, then read their adapters in pkg/
 ```
 
 For **each** integration point, confirm the resilience posture (the script
@@ -231,6 +275,7 @@ Summarize: mode used, flows reviewed, scenario count per tier, the count of Tier
 - Skipping the Step 2 confirmation dialogue → you may be analysing the wrong flow model.
 - Trusting the scanner's `resilience` flags as ground truth → they are heuristic; a `true` is a hint and a `false` is a prompt to verify, never a final verdict.
 - Starting the analysis in Mode A without the `scan-integration-points.mjs` JSON when Node.js is available → run the mechanical phase first, then reason over its output.
+- **Scanning only `apps/<svc>` in a hexagonal monorepo and trusting a `0` result** → the boundaries live in imported `pkg/*` adapters; a subdir-only scan is a false 0. Run from the repo root (the scanner auto-expands) and never treat a `warnings[]` scope alert as "no boundaries exist".
 - Reporting only Tier 3 counts without the concrete "what should exist" → a gap without a spec is not actionable.
 
 ## Common Mistakes

--- a/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
+++ b/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
@@ -173,11 +173,20 @@ function enclosingGoFunc(lines, idx) {
   let start = idx;
   for (; start >= 0; start--) if (/^func\b/.test(lines[start])) break;
   if (start < 0) return null;
-  let end = lines.length;
-  for (let j = start + 1; j < lines.length; j++) {
-    if (/^\}/.test(lines[j])) { end = j + 1; break; }
+  // Track brace depth from the function's opening `{` so nested if/for/switch
+  // blocks don't truncate the body at the first indented-or-not `}`.
+  let depth = 0;
+  let sawOpen = false;
+  for (let j = start; j < lines.length; j++) {
+    for (const ch of lines[j]) {
+      if (ch === '{') { depth++; sawOpen = true; }
+      else if (ch === '}' && sawOpen) {
+        depth--;
+        if (depth === 0) return [start, j + 1];
+      }
+    }
   }
-  return [start, end];
+  return [start, lines.length];
 }
 
 // Go resilience: prefer the enclosing function body (so retry/timeout wrappers
@@ -417,7 +426,7 @@ async function main() {
     // (or returning an interface-like *Client) counts. Timeout/retry configured
     // once here is inherited by every call site through the wrapper pkg.
     if (lang === 'go' && pkgName && pkgName !== 'http' && pkgName !== 'main') {
-      const ctorRe = /func\s+(?:\([^)]*\)\s+)?(New\w*Client)\s*\(([^)]*)\)\s*(?:\*[\w.]+|[\w.]+)?\s*\{/g;
+      const ctorRe = /func\s+(?:\([^)]*\)\s+)?(New\w*Client)\s*\(([^)]*)\)\s*(?:\([^)]*\)|\*?[\w.]+)?\s*\{/g;
       let cm;
       while ((cm = ctorRe.exec(content))) {
         const params = cm[2] || '';
@@ -458,11 +467,15 @@ async function main() {
     // Collect Go func/method declarations (for port->adapter mapping).
     if (lang === 'go') {
       for (let i = 0; i < lines.length; i++) {
-        const fm = lines[i].match(/^func\s+(?:\([^)]*\)\s+)?([A-Z]\w*)\s*\(/);
+        // Capture the receiver type (group 1) so port->adapter matching can
+        // require the full interface method set on one concrete type instead
+        // of matching by bare method name.
+        const fm = lines[i].match(/^func\s+(?:\((?:\w+\s+)?\*?([\w.]+)\)\s+)?([A-Z]\w*)\s*\(/);
         if (fm) {
-          const name = fm[1];
+          const recv = fm[1] || null;
+          const name = fm[2];
           if (!funcDecls.has(name)) funcDecls.set(name, []);
-          funcDecls.get(name).push({ rel, line: i + 1, entry });
+          funcDecls.get(name).push({ rel, line: i + 1, entry, recv });
         }
       }
       if (isPort) {
@@ -604,24 +617,56 @@ async function main() {
   // FILE that implements it (catches SDK adapters like midazsdk.WithTimeout
   // that never touch net/http on the call line).
   // ------------------------------------------------------------------------
+  //
+  // Matching is receiver-type aware, NOT name-only: a concrete type is treated
+  // as an adapter for an interface only when it implements the FULL method set
+  // of that interface. This prevents common method names (Close, Send, Publish)
+  // on unrelated receivers from being misclassified as port implementations and
+  // inflating outbound_port points / bogus resilience gaps.
+
+  // Group interface method names by their declaring (file, interface).
+  const ifaceSets = new Map(); // `${rel}::${iface}` -> { rel, iface, methods:Set }
   for (const pm of portMethods) {
-    const impls = (funcDecls.get(pm.method) || []).filter((d) => !d.entry.isPort);
-    for (const impl of impls) {
-      const e = impl.entry;
-      // whole adapter file: client ctor + retry wrapper may live elsewhere
-      const resilience = resilienceOver(e.content);
-      points.push({
-        category: 'outbound_port',
-        matcher: `port ${pm.iface}.${pm.method} -> adapter`,
-        direction: 'outbound',
-        language: 'go',
-        service: serviceOf(impl.rel),
-        file: impl.rel,
-        line: impl.line,
-        snippet: `${pm.iface}.${pm.method}() implemented here`.slice(0, 200),
-        resilience,
-        port: { interface: pm.iface, method: pm.method, declared_in: pm.rel },
-      });
+    const key = `${pm.rel}::${pm.iface}`;
+    if (!ifaceSets.has(key)) ifaceSets.set(key, { rel: pm.rel, iface: pm.iface, methods: new Set() });
+    ifaceSets.get(key).methods.add(pm.method);
+  }
+
+  // Map each concrete (non-port) receiver type to the methods it defines.
+  const receiverMethods = new Map(); // recv -> Map(method -> decl)
+  for (const [name, decls] of funcDecls) {
+    for (const d of decls) {
+      if (d.entry.isPort || !d.recv) continue;
+      if (!receiverMethods.has(d.recv)) receiverMethods.set(d.recv, new Map());
+      const mmap = receiverMethods.get(d.recv);
+      if (!mmap.has(name)) mmap.set(name, d);
+    }
+  }
+
+  for (const { rel, iface, methods } of ifaceSets.values()) {
+    const methodList = [...methods];
+    if (!methodList.length) continue;
+    for (const [recv, mmap] of receiverMethods) {
+      // Require the receiver to implement EVERY method of the interface.
+      if (!methodList.every((m) => mmap.has(m))) continue;
+      for (const m of methodList) {
+        const impl = mmap.get(m);
+        const e = impl.entry;
+        // whole adapter file: client ctor + retry wrapper may live elsewhere
+        const resilience = resilienceOver(e.content);
+        points.push({
+          category: 'outbound_port',
+          matcher: `port ${iface}.${m} -> adapter (${recv})`,
+          direction: 'outbound',
+          language: 'go',
+          service: serviceOf(impl.rel),
+          file: impl.rel,
+          line: impl.line,
+          snippet: `${iface}.${m}() implemented by ${recv}`.slice(0, 200),
+          resilience,
+          port: { interface: iface, method: m, declared_in: rel, adapter_type: recv },
+        });
+      }
     }
   }
 
@@ -638,8 +683,15 @@ async function main() {
 
   // Aggregate resilience gaps.
   const gaps = [];
+  // Inbound entry points don't own outbound-recovery concerns (retry, dlq,
+  // timeout, rollback); flagging those would flood resilience_gaps with inbound
+  // noise. For inbound points only idempotency is a meaningful gap.
+  const INBOUND_RELEVANT = new Set(['idempotency']);
   for (const p of deduped) {
-    const missing = Object.entries(p.resilience).filter(([, v]) => !v).map(([k]) => k);
+    const inbound = p.entry_point === true || p.direction === 'inbound';
+    const missing = Object.entries(p.resilience)
+      .filter(([k, v]) => !v && (!inbound || INBOUND_RELEVANT.has(k)))
+      .map(([k]) => k);
     if (missing.length) gaps.push({ file: p.file, line: p.line, category: p.category, service: p.service, missing });
   }
 

--- a/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
+++ b/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * scan-integration-points.mjs — Step 1 (mechanical) of ring:reviewing-operational-risk.
+ *
+ * Deterministically walks a Go or TypeScript/Node.js repo and finds the points
+ * where the service talks to the outside world:
+ *   - outbound external HTTP calls
+ *   - queue consumers (RabbitMQ, SQS, Kafka, NATS, ...)
+ *   - event publishers / producers
+ *   - outbound webhooks / callbacks
+ *
+ * For each integration point it records, from a window around the match, whether
+ * the following resilience mechanisms appear to be present:
+ *   retry, dlq, timeout, rollback/compensation, idempotency
+ *
+ * Output: a structured JSON report on stdout. Feed that JSON to the LLM (Step 2)
+ * as structured context BEFORE starting the confirmation dialogue.
+ *
+ * Zero dependencies — Node.js built-ins only. Detection is heuristic (regex over
+ * source, not full AST): treat every hit as a candidate to confirm, and expect
+ * false positives/negatives. The LLM step exercises judgement over this data.
+ *
+ * Usage:
+ *   node scan-integration-points.mjs [targetDir] [--json] [--out FILE] [--context N]
+ *
+ *   targetDir     Repo root to scan (default: current working directory)
+ *   --out FILE    Also write the JSON report to FILE
+ *   --context N   Lines of context each side of a match for resilience detection (default 12)
+ *   --json        (default) emit JSON to stdout
+ */
+
+import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { join, relative, extname, basename } from 'node:path';
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+let targetDir = process.cwd();
+let outFile = null;
+let contextLines = 12;
+for (let i = 0; i < args.length; i++) {
+  const a = args[i];
+  if (a === '--out') outFile = args[++i];
+  else if (a === '--context') contextLines = parseInt(args[++i], 10) || 12;
+  else if (a === '--json') { /* default */ }
+  else if (!a.startsWith('--')) targetDir = a;
+}
+
+// ---------------------------------------------------------------------------
+// Walk config
+// ---------------------------------------------------------------------------
+const SKIP_DIRS = new Set([
+  '.git', 'node_modules', 'vendor', 'dist', 'build', 'out', '.next',
+  'coverage', 'testdata', 'mocks', '.idea', '.vscode', 'bin', 'gen',
+]);
+const CODE_EXT = new Set(['.go', '.ts', '.tsx', '.js', '.mjs', '.cjs', '.jsx']);
+const TEST_RE = /(_test\.go|\.test\.[tj]sx?|\.spec\.[tj]sx?)$/;
+
+// ---------------------------------------------------------------------------
+// Detection patterns. category -> [ {label, re} ]
+// ---------------------------------------------------------------------------
+const PATTERNS = {
+  http_outbound: [
+    { label: 'go net/http', re: /http\.(NewRequest(WithContext)?|Get|Post|Do)\s*\(/ },
+    { label: 'go http.Client', re: /\bhttp\.Client\b|\(&?http\.Client\{|\.Do\(ctx/ },
+    { label: 'go resty', re: /resty\.|\.R\(\)\.(Get|Post|Put|Delete|Patch)\(/ },
+    { label: 'go grpc client', re: /grpc\.Dial\(|grpc\.NewClient\(/ },
+    { label: 'ts axios', re: /\baxios\b|axios\.(get|post|put|delete|patch|request)\(/ },
+    { label: 'ts fetch', re: /(?<![.\w])fetch\s*\(/ },
+    { label: 'ts got/undici/superagent', re: /\bgot\s*\(|\bundici\b|superagent\.|node-fetch/ },
+  ],
+  queue_consumer: [
+    { label: 'amqp consume', re: /\.Consume\s*\(|HandleDelivery|amqp\.|rabbitmq/i },
+    { label: 'sqs receive', re: /ReceiveMessage|sqs\.|SQSClient/ },
+    { label: 'kafka consume', re: /\bConsume(r)?\b.*(kafka|sarama|segmentio)|kafka\.|sarama\.|Reader\.ReadMessage/i },
+    { label: 'nats subscribe', re: /nats\.|\.Subscribe\s*\(|QueueSubscribe/ },
+    { label: 'ts amqplib/bull', re: /amqplib|\.consume\s*\(|new Worker\(|bull(mq)?|@nestjs\/microservices/i },
+  ],
+  event_publisher: [
+    { label: 'go publish/produce', re: /\.Publish\s*\(|\.Produce\s*\(|PublishWithContext|SendMessage\s*\(/ },
+    { label: 'kafka producer', re: /\.WriteMessages\s*\(|Producer\b.*(kafka|sarama)/i },
+    { label: 'ts emit/publish', re: /\.publish\s*\(|\.emit\s*\(|producer\.send\(/ },
+  ],
+  outbound_webhook: [
+    { label: 'webhook/callback', re: /webhook|callbackURL|CallbackURL|NotifyURL|notifyUrl|callback_url/i },
+  ],
+};
+
+// Resilience detection over the surrounding window.
+const RESILIENCE = {
+  retry: /\bretry\b|retryCount|RetryCount|maxRetries|MaxRetries|WithRetry|backoff|Backoff|retryable|Retryable|\.Retry\(|attempts?\b/i,
+  dlq: /\bdlq\b|dead[-_ ]?letter|DeadLetter|parkingLot|x-dead-letter|deadLetterQueue/i,
+  timeout: /context\.WithTimeout|context\.WithDeadline|WithTimeout|SetTimeout|\btimeout\b|Timeout:|deadline/i,
+  rollback: /rollback|Rollback|compensat|Compensat|\bsaga\b|Saga|revert|Revert|undo\b|unwind/i,
+  idempotency: /idempoten|Idempoten|idempotency[-_ ]?key|dedup|deduplicat|exactly[-_ ]?once/i,
+};
+
+// ---------------------------------------------------------------------------
+// Walk the tree
+// ---------------------------------------------------------------------------
+async function* walk(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+      yield* walk(full);
+    } else if (e.isFile()) {
+      if (CODE_EXT.has(extname(e.name)) && !TEST_RE.test(e.name)) yield full;
+    }
+  }
+}
+
+function detectResilience(lines, idx, span) {
+  const from = Math.max(0, idx - span);
+  const to = Math.min(lines.length, idx + span + 1);
+  const window = lines.slice(from, to).join('\n');
+  const found = {};
+  for (const [k, re] of Object.entries(RESILIENCE)) found[k] = re.test(window);
+  return found;
+}
+
+function languageOf(file) {
+  const ext = extname(file);
+  if (ext === '.go') return 'go';
+  return 'ts_node';
+}
+
+// ---------------------------------------------------------------------------
+// Main scan
+// ---------------------------------------------------------------------------
+async function main() {
+  try {
+    const s = await stat(targetDir);
+    if (!s.isDirectory()) throw new Error('not a directory');
+  } catch {
+    process.stderr.write(`error: target is not a directory: ${targetDir}\n`);
+    process.exit(1);
+  }
+
+  const points = [];
+  let filesScanned = 0;
+
+  for await (const file of walk(targetDir)) {
+    let content;
+    try {
+      content = await readFile(file, 'utf8');
+    } catch {
+      continue;
+    }
+    filesScanned++;
+    const lines = content.split(/\r?\n/);
+    const rel = relative(targetDir, file);
+    const lang = languageOf(file);
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.trim() || line.trim().startsWith('//') || line.trim().startsWith('*')) continue;
+      for (const [category, defs] of Object.entries(PATTERNS)) {
+        for (const { label, re } of defs) {
+          if (re.test(line)) {
+            const direction =
+              category === 'queue_consumer' ? 'inbound' : 'outbound';
+            points.push({
+              category,
+              matcher: label,
+              direction,
+              language: lang,
+              file: rel,
+              line: i + 1,
+              snippet: line.trim().slice(0, 200),
+              resilience: detectResilience(lines, i, contextLines),
+            });
+            break; // one hit per line per category is enough
+          }
+        }
+      }
+    }
+  }
+
+  // Deduplicate identical (file,line,category) entries.
+  const seen = new Set();
+  const deduped = points.filter((p) => {
+    const key = `${p.file}:${p.line}:${p.category}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  // Aggregate resilience gaps.
+  const gaps = [];
+  for (const p of deduped) {
+    const missing = Object.entries(p.resilience)
+      .filter(([, v]) => !v)
+      .map(([k]) => k);
+    if (missing.length) gaps.push({ file: p.file, line: p.line, category: p.category, missing });
+  }
+
+  const byCategory = {};
+  for (const p of deduped) byCategory[p.category] = (byCategory[p.category] || 0) + 1;
+
+  const report = {
+    schema: 'ring.ops-risk.integration-scan.v1',
+    generated_at: new Date().toISOString(),
+    target: targetDir,
+    note:
+      'Heuristic regex scan (not full AST). Each integration_point is a candidate to CONFIRM in the Step 2 dialogue. resilience flags mean the pattern was FOUND in a window around the match; a true value is a hint, not proof, and a false value is a prompt to verify, not a confirmed gap.',
+    summary: {
+      files_scanned: filesScanned,
+      integration_points: deduped.length,
+      by_category: byCategory,
+    },
+    integration_points: deduped,
+    resilience_gaps: gaps,
+  };
+
+  const json = JSON.stringify(report, null, 2);
+  if (outFile) {
+    await writeFile(outFile, json + '\n', 'utf8');
+    process.stderr.write(`wrote ${outFile}\n`);
+  }
+  process.stdout.write(json + '\n');
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err?.stack || err}\n`);
+  process.exit(1);
+});

--- a/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
+++ b/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
@@ -4,33 +4,49 @@
  *
  * Deterministically walks a Go or TypeScript/Node.js repo and finds the points
  * where the service talks to the outside world:
- *   - outbound external HTTP calls
+ *   - outbound external HTTP calls (incl. local http wrappers and SDK clients)
  *   - queue consumers (RabbitMQ, SQS, Kafka, NATS, ...)
  *   - event publishers / producers
  *   - outbound webhooks / callbacks
+ *   - hexagonal outbound ports (each ports/out interface method + its adapter)
  *
- * For each integration point it records, from a window around the match, whether
- * the following resilience mechanisms appear to be present:
- *   retry, dlq, timeout, rollback/compensation, idempotency
+ * For each integration point it records whether the following resilience
+ * mechanisms appear present: retry, dlq, timeout, rollback/compensation,
+ * idempotency. Resilience is inferred at the ENCLOSING-FUNCTION / ADAPTER-FILE
+ * level for Go (so a `DoWithRetry` wrapper or a `New*Client(timeout)` client
+ * defined elsewhere in the file/adapter still counts), not from a fixed ±N-line
+ * window around the call site.
  *
- * Output: a structured JSON report on stdout. Feed that JSON to the LLM (Step 2)
- * as structured context BEFORE starting the confirmation dialogue.
+ * SCOPE — IMPORTANT: in a hexagonal Go monorepo, scanning only a service subdir
+ * (apps/<svc>) yields a FALSE 0 because the boundaries live in the imported
+ * pkg/* adapters. This scanner therefore walks up to the repo/module root, scans
+ * the whole tree, and attributes each boundary to the consuming service via its
+ * top-level dir. It never returns 0 silently for a service that imports ports/out.
+ *
+ * Output: a structured JSON report on stdout (schema ring.ops-risk.integration-scan.v1).
+ * Feed that JSON to the LLM (Step 2) as structured context BEFORE the dialogue.
  *
  * Zero dependencies — Node.js built-ins only. Detection is heuristic (regex over
  * source, not full AST): treat every hit as a candidate to confirm, and expect
  * false positives/negatives. The LLM step exercises judgement over this data.
  *
  * Usage:
- *   node scan-integration-points.mjs [targetDir] [--json] [--out FILE] [--context N]
+ *   node scan-integration-points.mjs [targetDir] [--json] [--out FILE]
+ *                                    [--context N] [--config FILE] [--no-gen-config]
+ *                                    [--no-repo-root]
  *
- *   targetDir     Repo root to scan (default: current working directory)
- *   --out FILE    Also write the JSON report to FILE
- *   --context N   Lines of context each side of a match for resilience detection (default 12)
- *   --json        (default) emit JSON to stdout
+ *   targetDir        Dir to scan from (default: cwd). Expanded to repo/module root.
+ *   --out FILE       Also write the JSON report to FILE
+ *   --context N      Fallback lines of context each side of a match (default 12)
+ *   --config FILE    Path to a .ops-risk.json config (default: <repoRoot>/.ops-risk.json)
+ *   --no-gen-config  Do not auto-generate a default .ops-risk.json when missing
+ *   --no-repo-root   Do NOT expand to repo root; scan exactly targetDir (legacy)
+ *   --json           (default) emit JSON to stdout
  */
 
-import { readdir, readFile, stat, writeFile } from 'node:fs/promises';
-import { join, relative, extname, basename } from 'node:path';
+import { readdir, readFile, stat, writeFile, access } from 'node:fs/promises';
+import { join, relative, extname, dirname, basename, sep, isAbsolute, resolve } from 'node:path';
+import { homedir } from 'node:os';
 
 // ---------------------------------------------------------------------------
 // CLI args
@@ -39,13 +55,20 @@ const args = process.argv.slice(2);
 let targetDir = process.cwd();
 let outFile = null;
 let contextLines = 12;
+let configPath = null;
+let genConfig = true;
+let expandToRepoRoot = true;
 for (let i = 0; i < args.length; i++) {
   const a = args[i];
   if (a === '--out') outFile = args[++i];
   else if (a === '--context') contextLines = parseInt(args[++i], 10) || 12;
+  else if (a === '--config') configPath = args[++i];
+  else if (a === '--no-gen-config') genConfig = false;
+  else if (a === '--no-repo-root') expandToRepoRoot = false;
   else if (a === '--json') { /* default */ }
   else if (!a.startsWith('--')) targetDir = a;
 }
+targetDir = isAbsolute(targetDir) ? targetDir : resolve(process.cwd(), targetDir);
 
 // ---------------------------------------------------------------------------
 // Walk config
@@ -58,43 +81,146 @@ const CODE_EXT = new Set(['.go', '.ts', '.tsx', '.js', '.mjs', '.cjs', '.jsx']);
 const TEST_RE = /(_test\.go|\.test\.[tj]sx?|\.spec\.[tj]sx?)$/;
 
 // ---------------------------------------------------------------------------
+// Default per-repo config (.ops-risk.json)
+// ---------------------------------------------------------------------------
+const DEFAULT_CONFIG = {
+  $schema: 'ring.ops-risk.config.v1',
+  // Dirs that hold shared adapters / SDK wrappers imported by services.
+  shared_adapter_dirs: ['pkg', 'internal/adapter', 'internal/adapters'],
+  // Local packages that wrap net/http (e.g. "httpclient"). Auto-detection adds
+  // to this list; declaring here forces inclusion.
+  http_wrapper_packages: [],
+  // Globs for hexagonal outbound port interfaces (each method = a boundary).
+  outbound_port_globs: ['**/ports/out/**', '**/port/**', '**/ports/**'],
+  // Inbound handler globs to EXCLUDE from outbound_webhook detection.
+  exclude_handler_globs: [
+    '**/handler/**', '**/handlers/**', '**/inbound/**', '**/in/**',
+    '**/api/**', '**/rest/**', '**/http/in/**', '**/controller/**', '**/controllers/**',
+  ],
+};
+
+// ---------------------------------------------------------------------------
 // Detection patterns. category -> [ {label, re} ]
 // ---------------------------------------------------------------------------
-const PATTERNS = {
+const BASE_PATTERNS = {
   http_outbound: [
     { label: 'go net/http', re: /http\.(NewRequest(WithContext)?|Get|Post|Do)\s*\(/ },
     { label: 'go http.Client', re: /\bhttp\.Client\b|\(&?http\.Client\{|\.Do\(ctx/ },
     { label: 'go resty', re: /resty\.|\.R\(\)\.(Get|Post|Put|Delete|Patch)\(/ },
     { label: 'go grpc client', re: /grpc\.Dial\(|grpc\.NewClient\(/ },
+    // local http wrappers + generic client constructors + retry wrappers
+    { label: 'go http wrapper/client ctor', re: /\bhttpclient\.|\bDoWithRetry\s*\(|\bNew\w+Client\s*\(|\b\w+\.Do\(\s*req\b/ },
+    // SDK clients that talk to the outside without touching net/http directly
+    { label: 'go sdk client', re: /\b\w*sdk\.[A-Z]\w*\s*\(|\bmidazsdk\./ },
     { label: 'ts axios', re: /\baxios\b|axios\.(get|post|put|delete|patch|request)\(/ },
     { label: 'ts fetch', re: /(?<![.\w])fetch\s*\(/ },
     { label: 'ts got/undici/superagent', re: /\bgot\s*\(|\bundici\b|superagent\.|node-fetch/ },
   ],
   queue_consumer: [
-    { label: 'amqp consume', re: /\.Consume\s*\(|HandleDelivery|amqp\.|rabbitmq/i },
-    { label: 'sqs receive', re: /ReceiveMessage|sqs\.|SQSClient/ },
-    { label: 'kafka consume', re: /\bConsume(r)?\b.*(kafka|sarama|segmentio)|kafka\.|sarama\.|Reader\.ReadMessage/i },
-    { label: 'nats subscribe', re: /nats\.|\.Subscribe\s*\(|QueueSubscribe/ },
-    { label: 'ts amqplib/bull', re: /amqplib|\.consume\s*\(|new Worker\(|bull(mq)?|@nestjs\/microservices/i },
+    { label: 'amqp consume', re: /\.Consume\s*\(|HandleDelivery/ },
+    { label: 'sqs receive', re: /ReceiveMessage|SQSClient/ },
+    { label: 'kafka consume', re: /Reader\.ReadMessage|\bConsumer\b/ },
+    { label: 'nats subscribe', re: /\.Subscribe\s*\(|QueueSubscribe/ },
+    { label: 'ts amqplib/bull', re: /\.consume\s*\(|new Worker\(/ },
   ],
   event_publisher: [
     { label: 'go publish/produce', re: /\.Publish\s*\(|\.Produce\s*\(|PublishWithContext|SendMessage\s*\(/ },
-    { label: 'kafka producer', re: /\.WriteMessages\s*\(|Producer\b.*(kafka|sarama)/i },
-    { label: 'ts emit/publish', re: /\.publish\s*\(|\.emit\s*\(|producer\.send\(/ },
+    { label: 'kafka producer', re: /\.WriteMessages\s*\(/ },
+    { label: 'ts emit/publish', re: /\.publish\s*\(|producer\.send\(/ },
   ],
+  // Tightened: require a SEND verb AND an explicit URL var; case-sensitive
+  // (no blanket /i flag); inbound handler files are excluded before matching.
   outbound_webhook: [
-    { label: 'webhook/callback', re: /webhook|callbackURL|CallbackURL|NotifyURL|notifyUrl|callback_url/i },
+    {
+      label: 'webhook send + url',
+      re: /(Post|Send|Notify|Dispatch|Deliver|Trigger|Call|Fire|Emit)[A-Za-z]*\s*\([^)]*\b(webhookURL|webhookUrl|WebhookURL|callbackURL|callbackUrl|CallbackURL|NotifyURL|notifyUrl|callback_url|webhook_url)\b/,
+    },
   ],
 };
 
-// Resilience detection over the surrounding window.
+// Broker imports that must be present for queue_consumer hits to count.
+const BROKER_IMPORT_RE = /(streadway\/amqp|rabbitmq\/amqp091|amqp091|aws-sdk-go[^"]*\/sqs|aws\/aws-sdk[^"]*sqs|segmentio\/kafka-go|Shopify\/sarama|IBM\/sarama|nats-io\/nats|amqplib|bullmq|@nestjs\/microservices|"github\.com\/[^"]*kafka)/i;
+
+// Import path signalling a hexagonal outbound port dependency.
+const PORTS_OUT_IMPORT_RE = /["`][^"`]*(ports\/out|\/port|\/ports)\b[^"`]*["`]|\bport\.[A-Z]\w*Port\b/;
+
+// ---------------------------------------------------------------------------
+// Resilience detection.
+// ---------------------------------------------------------------------------
 const RESILIENCE = {
-  retry: /\bretry\b|retryCount|RetryCount|maxRetries|MaxRetries|WithRetry|backoff|Backoff|retryable|Retryable|\.Retry\(|attempts?\b/i,
+  retry: /\bretry\b|retryCount|RetryCount|maxRetries|MaxRetries|WithRetry|DoWithRetry|backoff|Backoff|retryable|Retryable|\.Retry\(|attempts?\b/i,
   dlq: /\bdlq\b|dead[-_ ]?letter|DeadLetter|parkingLot|x-dead-letter|deadLetterQueue/i,
   timeout: /context\.WithTimeout|context\.WithDeadline|WithTimeout|SetTimeout|\btimeout\b|Timeout:|deadline/i,
   rollback: /rollback|Rollback|compensat|Compensat|\bsaga\b|Saga|revert|Revert|undo\b|unwind/i,
   idempotency: /idempoten|Idempoten|idempotency[-_ ]?key|dedup|deduplicat|exactly[-_ ]?once/i,
 };
+
+function resilienceOver(text) {
+  const found = {};
+  for (const [k, re] of Object.entries(RESILIENCE)) found[k] = re.test(text);
+  return found;
+}
+
+// ±span-line window (used for TS/Node and as a Go fallback).
+function windowResilience(lines, idx, span) {
+  const from = Math.max(0, idx - span);
+  const to = Math.min(lines.length, idx + span + 1);
+  return resilienceOver(lines.slice(from, to).join('\n'));
+}
+
+// Enclosing top-level Go func/method body [start, end).
+function enclosingGoFunc(lines, idx) {
+  let start = idx;
+  for (; start >= 0; start--) if (/^func\b/.test(lines[start])) break;
+  if (start < 0) return null;
+  let end = lines.length;
+  for (let j = start + 1; j < lines.length; j++) {
+    if (/^\}/.test(lines[j])) { end = j + 1; break; }
+  }
+  return [start, end];
+}
+
+// Go resilience: prefer the enclosing function body (so retry/timeout wrappers
+// anywhere in the function count), fall back to the window if no func found.
+function goResilience(lines, idx, span) {
+  const range = enclosingGoFunc(lines, idx);
+  if (!range) return windowResilience(lines, idx, span);
+  return resilienceOver(lines.slice(range[0], range[1]).join('\n'));
+}
+
+function languageOf(file) {
+  return extname(file) === '.go' ? 'go' : 'ts_node';
+}
+
+// ---------------------------------------------------------------------------
+// glob helpers (support ** and *)
+// ---------------------------------------------------------------------------
+function toPosix(p) {
+  return p.split(sep).join('/');
+}
+function globToRe(glob) {
+  const re = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\u0000')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\u0000/g, '.*');
+  return new RegExp('^' + re + '$');
+}
+function anyGlobMatch(globs, relPath) {
+  const p = toPosix(relPath);
+  return globs.some((g) => globToRe(g).test(p));
+}
+
+// Attribute a boundary to its consuming service via top-level dir.
+function serviceOf(relPath) {
+  const parts = toPosix(relPath).split('/');
+  const roots = new Set(['apps', 'components', 'cmd', 'services', 'plugins']);
+  if (parts.length > 1 && roots.has(parts[0])) return `${parts[0]}/${parts[1]}`;
+  return parts[0] || '.';
+}
+function topDirOf(relPath) {
+  return toPosix(relPath).split('/')[0] || '.';
+}
 
 // ---------------------------------------------------------------------------
 // Walk the tree
@@ -109,7 +235,10 @@ async function* walk(dir) {
   for (const e of entries) {
     const full = join(dir, e.name);
     if (e.isDirectory()) {
-      if (SKIP_DIRS.has(e.name) || e.name.startsWith('.')) continue;
+      // 'out' is a common build-output dir, but in hexagonal Go it is also the
+      // outbound-ports dir (ports/out). Never skip it under a 'ports' parent.
+      const isHexOut = e.name === 'out' && basename(dir) === 'ports';
+      if ((SKIP_DIRS.has(e.name) && !isHexOut) || e.name.startsWith('.')) continue;
       yield* walk(full);
     } else if (e.isFile()) {
       if (CODE_EXT.has(extname(e.name)) && !TEST_RE.test(e.name)) yield full;
@@ -117,25 +246,66 @@ async function* walk(dir) {
   }
 }
 
-function detectResilience(lines, idx, span) {
-  const from = Math.max(0, idx - span);
-  const to = Math.min(lines.length, idx + span + 1);
-  const window = lines.slice(from, to).join('\n');
-  const found = {};
-  for (const [k, re] of Object.entries(RESILIENCE)) found[k] = re.test(window);
-  return found;
+async function exists(p) {
+  try { await access(p); return true; } catch { return false; }
 }
 
-function languageOf(file) {
-  const ext = extname(file);
-  if (ext === '.go') return 'go';
-  return 'ts_node';
+// Find the repo/module root. Prefer the INNERMOST enclosing .git (the actual
+// project repo — avoids over-expanding into a parent workspace / monorepo-of-
+// repos that also happens to be a git repo). If there is no .git, fall back to
+// the OUTERMOST go.mod (module root). The upward walk stops at $HOME so a nested
+// target can never escape into unrelated parent directories.
+async function findRepoRoot(startDir) {
+  const home = homedir();
+  let dir = startDir;
+  let innermostGit = null;
+  const goModDirs = [];
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (!innermostGit && (await exists(join(dir, '.git')))) innermostGit = dir;
+    if (await exists(join(dir, 'go.mod'))) goModDirs.push(dir);
+    if (dir === home) break;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  if (innermostGit) return innermostGit;
+  if (goModDirs.length) return goModDirs[goModDirs.length - 1];
+  return startDir;
+}
+
+// Parse Go interface method names out of a source file.
+function goInterfaceMethods(content) {
+  const methods = [];
+  const ifaceRe = /type\s+(\w+)\s+interface\s*\{/g;
+  let m;
+  while ((m = ifaceRe.exec(content))) {
+    const ifaceName = m[1];
+    // scan from the opening brace to its matching close
+    let depth = 1;
+    let i = ifaceRe.lastIndex;
+    let body = '';
+    while (i < content.length && depth > 0) {
+      const ch = content[i];
+      if (ch === '{') depth++;
+      else if (ch === '}') depth--;
+      if (depth > 0) body += ch;
+      i++;
+    }
+    for (const line of body.split(/\r?\n/)) {
+      const mm = line.match(/^\s*([A-Z]\w*)\s*\(/);
+      if (mm) methods.push({ iface: ifaceName, method: mm[1] });
+    }
+  }
+  return methods;
 }
 
 // ---------------------------------------------------------------------------
 // Main scan
 // ---------------------------------------------------------------------------
 async function main() {
+  const warnings = [];
+
   try {
     const s = await stat(targetDir);
     if (!s.isDirectory()) throw new Error('not a directory');
@@ -144,10 +314,60 @@ async function main() {
     process.exit(1);
   }
 
-  const points = [];
-  let filesScanned = 0;
+  // --- scope: expand to repo/module root -----------------------------------
+  const repoRoot = expandToRepoRoot ? await findRepoRoot(targetDir) : targetDir;
+  const scopeExpanded = expandToRepoRoot && repoRoot !== targetDir;
+  const scanRoot = repoRoot;
+  if (scopeExpanded) {
+    warnings.push({
+      level: 'info',
+      code: 'scope_expanded',
+      message:
+        `requested target "${toPosix(relative(repoRoot, targetDir)) || '.'}" is inside repo root; ` +
+        `scanning the full repo root so imported pkg/* adapters and ports/out boundaries are included. ` +
+        `Boundaries are attributed to each service via top-level dir. Pass --no-repo-root to scan only the subdir.`,
+    });
+  }
 
-  for await (const file of walk(targetDir)) {
+  // --- config --------------------------------------------------------------
+  const cfgFile = configPath
+    ? (isAbsolute(configPath) ? configPath : resolve(process.cwd(), configPath))
+    : join(scanRoot, '.ops-risk.json');
+  let config = { ...DEFAULT_CONFIG };
+  let configGenerated = false;
+  if (await exists(cfgFile)) {
+    try {
+      const loaded = JSON.parse(await readFile(cfgFile, 'utf8'));
+      config = { ...DEFAULT_CONFIG, ...loaded };
+    } catch (e) {
+      warnings.push({ level: 'warn', code: 'config_parse_error', message: `could not parse ${cfgFile}: ${e.message}; using defaults` });
+    }
+  } else if (genConfig) {
+    try {
+      await writeFile(cfgFile, JSON.stringify(DEFAULT_CONFIG, null, 2) + '\n', 'utf8');
+      configGenerated = true;
+      warnings.push({
+        level: 'info',
+        code: 'config_generated',
+        message: `no .ops-risk.json found; generated a default at ${toPosix(relative(scanRoot, cfgFile))}. ` +
+          `Edit shared_adapter_dirs / http_wrapper_packages / outbound_port_globs / exclude_handler_globs to tune this repo.`,
+      });
+    } catch {
+      /* non-fatal */
+    }
+  }
+
+  // ------------------------------------------------------------------------
+  // Pass 1: read all files, collect metadata (imports, ports, func decls).
+  // ------------------------------------------------------------------------
+  const files = []; // { rel, lang, lines, content, importsBroker, importsPortsOut, importsNetHttp, pkgName, isPort, isHandler }
+  const funcDecls = new Map(); // methodName -> [{ rel, line, entry }]
+  const portMethods = []; // { rel, iface, method }
+  const httpWrapperPkgs = new Set(config.http_wrapper_packages || []);
+  let filesScanned = 0;
+  const filesByTopDir = {};
+
+  for await (const file of walk(scanRoot)) {
     let content;
     try {
       content = await readFile(file, 'utf8');
@@ -155,27 +375,94 @@ async function main() {
       continue;
     }
     filesScanned++;
-    const lines = content.split(/\r?\n/);
-    const rel = relative(targetDir, file);
+    const rel = relative(scanRoot, file);
     const lang = languageOf(file);
+    const lines = content.split(/\r?\n/);
 
+    const td = topDirOf(rel);
+    filesByTopDir[td] = (filesByTopDir[td] || 0) + 1;
+
+    const importsBroker = BROKER_IMPORT_RE.test(content);
+    const importsPortsOut = PORTS_OUT_IMPORT_RE.test(content);
+    const importsNetHttp = /["`]net\/http["`]/.test(content);
+    const isPort = anyGlobMatch(config.outbound_port_globs || [], rel);
+    const isHandler = anyGlobMatch(config.exclude_handler_globs || [], rel);
+    const pkgMatch = lang === 'go' ? content.match(/^package\s+(\w+)/m) : null;
+    const pkgName = pkgMatch ? pkgMatch[1] : null;
+
+    const entry = { rel, lang, lines, content, importsBroker, importsPortsOut, importsNetHttp, pkgName, isPort, isHandler };
+    files.push(entry);
+
+    // Auto-detect local http wrapper packages: a package that imports net/http
+    // and lives under a shared adapter dir (or is named like a client wrapper).
+    if (lang === 'go' && importsNetHttp && pkgName && pkgName !== 'http' && pkgName !== 'main') {
+      const underShared = (config.shared_adapter_dirs || []).some((d) => {
+        const dp = toPosix(d);
+        return toPosix(rel).startsWith(dp + '/') || toPosix(rel).includes(`/${dp}/`);
+      });
+      if (underShared || /client|httpclient|gateway|rest/i.test(pkgName)) {
+        httpWrapperPkgs.add(pkgName);
+      }
+    }
+
+    // Collect Go func/method declarations (for port->adapter mapping).
+    if (lang === 'go') {
+      for (let i = 0; i < lines.length; i++) {
+        const fm = lines[i].match(/^func\s+(?:\([^)]*\)\s+)?([A-Z]\w*)\s*\(/);
+        if (fm) {
+          const name = fm[1];
+          if (!funcDecls.has(name)) funcDecls.set(name, []);
+          funcDecls.get(name).push({ rel, line: i + 1, entry });
+        }
+      }
+      if (isPort) {
+        for (const pm of goInterfaceMethods(content)) portMethods.push({ rel, ...pm });
+      }
+    }
+  }
+
+  // Build dynamic http_outbound patterns for detected wrapper packages.
+  const patterns = {};
+  for (const [cat, defs] of Object.entries(BASE_PATTERNS)) patterns[cat] = defs.slice();
+  for (const pkg of httpWrapperPkgs) {
+    if (!pkg || pkg === 'http') continue;
+    patterns.http_outbound.push({
+      label: `go http wrapper pkg (${pkg})`,
+      re: new RegExp(`\\b${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.[A-Z]?\\w*\\s*\\(`),
+    });
+  }
+
+  // ------------------------------------------------------------------------
+  // Pass 2: line-level pattern scan.
+  // ------------------------------------------------------------------------
+  const points = [];
+  for (const f of files) {
+    const { rel, lang, lines, importsBroker, isHandler } = f;
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
-      if (!line.trim() || line.trim().startsWith('//') || line.trim().startsWith('*')) continue;
-      for (const [category, defs] of Object.entries(PATTERNS)) {
+      const t = line.trim();
+      if (!t || t.startsWith('//') || t.startsWith('*')) continue;
+      for (const [category, defs] of Object.entries(patterns)) {
+        // queue_consumer only counts in files that also import a broker.
+        if (category === 'queue_consumer' && !importsBroker) continue;
+        // outbound_webhook excludes inbound handler files.
+        if (category === 'outbound_webhook' && isHandler) continue;
         for (const { label, re } of defs) {
           if (re.test(line)) {
-            const direction =
-              category === 'queue_consumer' ? 'inbound' : 'outbound';
+            const direction = category === 'queue_consumer' ? 'inbound' : 'outbound';
+            const resilience = lang === 'go'
+              ? goResilience(lines, i, contextLines)
+              : windowResilience(lines, i, contextLines);
             points.push({
               category,
               matcher: label,
               direction,
               language: lang,
+              service: serviceOf(rel),
               file: rel,
               line: i + 1,
-              snippet: line.trim().slice(0, 200),
-              resilience: detectResilience(lines, i, contextLines),
+              snippet: t.slice(0, 200),
+              resilience,
             });
             break; // one hit per line per category is enough
           }
@@ -184,7 +471,36 @@ async function main() {
     }
   }
 
+  // ------------------------------------------------------------------------
+  // Pass 3: port-aware detection (hexagonal). Each ports/out interface method
+  // is a boundary candidate; resilience is analysed over the concrete adapter
+  // FILE that implements it (catches SDK adapters like midazsdk.WithTimeout
+  // that never touch net/http on the call line).
+  // ------------------------------------------------------------------------
+  for (const pm of portMethods) {
+    const impls = (funcDecls.get(pm.method) || []).filter((d) => !d.entry.isPort);
+    for (const impl of impls) {
+      const e = impl.entry;
+      // whole adapter file: client ctor + retry wrapper may live elsewhere
+      const resilience = resilienceOver(e.content);
+      points.push({
+        category: 'outbound_port',
+        matcher: `port ${pm.iface}.${pm.method} -> adapter`,
+        direction: 'outbound',
+        language: 'go',
+        service: serviceOf(impl.rel),
+        file: impl.rel,
+        line: impl.line,
+        snippet: `${pm.iface}.${pm.method}() implemented here`.slice(0, 200),
+        resilience,
+        port: { interface: pm.iface, method: pm.method, declared_in: pm.rel },
+      });
+    }
+  }
+
+  // ------------------------------------------------------------------------
   // Deduplicate identical (file,line,category) entries.
+  // ------------------------------------------------------------------------
   const seen = new Set();
   const deduped = points.filter((p) => {
     const key = `${p.file}:${p.line}:${p.category}`;
@@ -196,25 +512,88 @@ async function main() {
   // Aggregate resilience gaps.
   const gaps = [];
   for (const p of deduped) {
-    const missing = Object.entries(p.resilience)
-      .filter(([, v]) => !v)
-      .map(([k]) => k);
-    if (missing.length) gaps.push({ file: p.file, line: p.line, category: p.category, missing });
+    const missing = Object.entries(p.resilience).filter(([, v]) => !v).map(([k]) => k);
+    if (missing.length) gaps.push({ file: p.file, line: p.line, category: p.category, service: p.service, missing });
   }
 
   const byCategory = {};
-  for (const p of deduped) byCategory[p.category] = (byCategory[p.category] || 0) + 1;
+  const byService = {};
+  for (const p of deduped) {
+    byCategory[p.category] = (byCategory[p.category] || 0) + 1;
+    byService[p.service] = (byService[p.service] || 0) + 1;
+  }
+
+  // ------------------------------------------------------------------------
+  // Warnings: never report a silent 0 where ports/out is imported.
+  // ------------------------------------------------------------------------
+  const servicesImportingPortsOut = new Set();
+  const portServiceFiles = {}; // service -> [files importing ports/out]
+  for (const f of files) {
+    if (f.importsPortsOut) {
+      const svc = serviceOf(f.rel);
+      servicesImportingPortsOut.add(svc);
+      (portServiceFiles[svc] ||= []).push(f.rel);
+    }
+  }
+  const anySharedAdapterBoundaries = deduped.some((p) =>
+    (config.shared_adapter_dirs || []).some((d) => {
+      const dp = toPosix(d);
+      return toPosix(p.file).startsWith(dp + '/') || toPosix(p.file).includes(`/${dp}/`);
+    }));
+  for (const svc of servicesImportingPortsOut) {
+    if (!byService[svc]) {
+      // If the whole scan found nothing, this is a real scope error (warn).
+      // If boundaries exist in shared adapter dirs (pkg/*), the service's
+      // adapters simply live there — informational, not an error.
+      const isScopeError = deduped.length === 0 || !anySharedAdapterBoundaries;
+      warnings.push({
+        level: isScopeError ? 'warn' : 'info',
+        code: 'zero_boundaries_in_port_service',
+        service: svc,
+        message: isScopeError
+          ? `0 fronteiras num serviço que importa ports/out — provável erro de escopo; ` +
+            `escaneie o repo root ou pkg/. Service "${svc}" imports outbound ports but no boundary was ` +
+            `attributed to it. Files importing ports/out: ${(portServiceFiles[svc] || []).slice(0, 5).join(', ')}` +
+            ((portServiceFiles[svc] || []).length > 5 ? ' …' : '')
+          : `Service "${svc}" imports outbound ports but its boundaries were attributed to shared adapter ` +
+            `dirs (e.g. pkg/*) rather than the service tree — expected for hexagonal layouts. Cross-check ` +
+            `outbound_port entries whose adapter lives under a shared dir when reviewing "${svc}".`,
+      });
+    }
+  }
+  if (deduped.length === 0 && servicesImportingPortsOut.size > 0) {
+    warnings.push({
+      level: 'warn',
+      code: 'zero_integration_points',
+      message:
+        '0 fronteiras num serviço que importa ports/out — provável erro de escopo; escaneie o repo root ou pkg/. ' +
+        'The scan found zero integration points but outbound ports are imported: this is almost certainly a scope error. ' +
+        'Run from the repo root (default) or include pkg/*.',
+    });
+  }
 
   const report = {
     schema: 'ring.ops-risk.integration-scan.v1',
     generated_at: new Date().toISOString(),
-    target: targetDir,
+    requested_target: targetDir,
+    scan_root: scanRoot,
+    config_file: (await exists(cfgFile)) ? cfgFile : null,
     note:
-      'Heuristic regex scan (not full AST). Each integration_point is a candidate to CONFIRM in the Step 2 dialogue. resilience flags mean the pattern was FOUND in a window around the match; a true value is a hint, not proof, and a false value is a prompt to verify, not a confirmed gap.',
+      'Heuristic regex scan (not full AST). Each integration_point is a candidate to CONFIRM in the Step 2 dialogue. ' +
+      'For Go, resilience flags are inferred over the ENCLOSING FUNCTION (line-matched points) or the whole ADAPTER FILE ' +
+      '(outbound_port points), so a DoWithRetry wrapper or a New*Client(timeout) defined elsewhere still counts. ' +
+      'A true flag is a hint, not proof; a false flag is a prompt to verify, not a confirmed gap. ' +
+      'In a hexagonal monorepo the scan runs from the repo root and attributes each boundary to its service via top-level dir.',
+    warnings,
     summary: {
       files_scanned: filesScanned,
       integration_points: deduped.length,
       by_category: byCategory,
+      by_service: byService,
+      files_by_top_dir: filesByTopDir,
+      services_importing_ports_out: [...servicesImportingPortsOut],
+      http_wrapper_packages_detected: [...httpWrapperPkgs],
+      config_generated: configGenerated,
     },
     integration_points: deduped,
     resilience_gaps: gaps,

--- a/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
+++ b/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
@@ -633,12 +633,16 @@ async function main() {
   }
 
   // Map each concrete (non-port) receiver type to the methods it defines.
-  const receiverMethods = new Map(); // recv -> Map(method -> decl)
+  // Key by package-qualified receiver so same-named types in different
+  // packages (Client, Service, Repository, Handler, ...) are not merged into
+  // a single union that could spuriously satisfy an interface's method set.
+  const receiverMethods = new Map(); // `${pkg}::${recv}` -> { recv, methods: Map(method -> decl) }
   for (const [name, decls] of funcDecls) {
     for (const d of decls) {
       if (d.entry.isPort || !d.recv) continue;
-      if (!receiverMethods.has(d.recv)) receiverMethods.set(d.recv, new Map());
-      const mmap = receiverMethods.get(d.recv);
+      const rkey = `${d.entry.pkgName || ''}::${d.recv}`;
+      if (!receiverMethods.has(rkey)) receiverMethods.set(rkey, { recv: d.recv, methods: new Map() });
+      const mmap = receiverMethods.get(rkey).methods;
       if (!mmap.has(name)) mmap.set(name, d);
     }
   }
@@ -646,7 +650,7 @@ async function main() {
   for (const { rel, iface, methods } of ifaceSets.values()) {
     const methodList = [...methods];
     if (!methodList.length) continue;
-    for (const [recv, mmap] of receiverMethods) {
+    for (const { recv, methods: mmap } of receiverMethods.values()) {
       // Require the receiver to implement EVERY method of the interface.
       if (!methodList.every((m) => mmap.has(m))) continue;
       for (const m of methodList) {

--- a/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
+++ b/dev-team/skills/reviewing-operational-risk/scan-integration-points.mjs
@@ -364,6 +364,13 @@ async function main() {
   const funcDecls = new Map(); // methodName -> [{ rel, line, entry }]
   const portMethods = []; // { rel, iface, method }
   const httpWrapperPkgs = new Set(config.http_wrapper_packages || []);
+  // pkg name -> resilience contributed by the client CONSTRUCTION site
+  // (e.g. `func New*Client(timeout ...) *http.Client { ... }`). Merged into
+  // every call-site whose wrapper pkg is detected, eliminating false-negative
+  // `timeout` flags when the deadline is configured once at construction.
+  const wrapperResilienceByPkg = {};
+  // TS wrapper resilience: file -> {timeout, retry}. Applied to points in that file.
+  const tsWrapperResilienceByFile = {};
   let filesScanned = 0;
   const filesByTopDir = {};
 
@@ -405,6 +412,49 @@ async function main() {
       }
     }
 
+    // Auto-detect Go client-constructor sites and harvest resilience from the
+    // construction body. Any `func New*Client(... timeout ...) *http.Client`
+    // (or returning an interface-like *Client) counts. Timeout/retry configured
+    // once here is inherited by every call site through the wrapper pkg.
+    if (lang === 'go' && pkgName && pkgName !== 'http' && pkgName !== 'main') {
+      const ctorRe = /func\s+(?:\([^)]*\)\s+)?(New\w*Client)\s*\(([^)]*)\)\s*(?:\*[\w.]+|[\w.]+)?\s*\{/g;
+      let cm;
+      while ((cm = ctorRe.exec(content))) {
+        const params = cm[2] || '';
+        const decl = cm[0];
+        // Only care about wrappers that either mention http.Client in return
+        // or accept a timeout-shaped parameter; either signals the wrapper.
+        const returnsHttpClient = /\*http\.Client\b/.test(decl) || /http\.Client\b/.test(decl);
+        const timeoutInParams = /\btimeout\b/i.test(params) || /time\.Duration\b/.test(params);
+        if (!returnsHttpClient && !timeoutInParams) continue;
+        httpWrapperPkgs.add(pkgName);
+        // resilience from the constructor body
+        const startLine = content.slice(0, cm.index).split(/\r?\n/).length - 1;
+        const range = enclosingGoFunc(lines, startLine);
+        const body = range ? lines.slice(range[0], range[1]).join('\n') : decl;
+        const res = resilienceOver(params + '\n' + body);
+        const prev = wrapperResilienceByPkg[pkgName] || {};
+        wrapperResilienceByPkg[pkgName] = {
+          timeout: !!(prev.timeout || res.timeout || timeoutInParams),
+          retry: !!(prev.retry || res.retry),
+        };
+      }
+    }
+
+    // TS equivalent: `axios.create({ timeout: ... })` / fetch-wrapper factories
+    // inside a `create*Client` / `new*Client` / `make*Client` function. Any point
+    // in the same file inherits that construction-site resilience.
+    if (lang === 'ts_node') {
+      const tsCtorRe = /(?:function|const|export\s+(?:const|function))\s+(new\w*Client|create\w*Client|make\w*Client|build\w*Client)\b/i;
+      if (tsCtorRe.test(content)) {
+        const res = resilienceOver(content);
+        const looksHttp = /axios\.create\s*\(|got\.extend\s*\(|new\s+Agent\s*\(|\bfetch\b|\bundici\b/i.test(content);
+        if (looksHttp && (res.timeout || res.retry)) {
+          tsWrapperResilienceByFile[rel] = { timeout: !!res.timeout, retry: !!res.retry };
+        }
+      }
+    }
+
     // Collect Go func/method declarations (for port->adapter mapping).
     if (lang === 'go') {
       for (let i = 0; i < lines.length; i++) {
@@ -438,6 +488,52 @@ async function main() {
   const points = [];
   for (const f of files) {
     const { rel, lang, lines, importsBroker, isHandler } = f;
+    // Entry-point handler signatures. Instead of silently dropping files under
+    // exclude_handler_globs, we surface each handler function/route as an
+    // integration_point with entry_point:true so the flow's entry is
+    // discoverable in the JSON map without manual grep.
+    if (isHandler) {
+      const ENTRY_PATTERNS_GO = [
+        { label: 'go net/http handler', re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*\([^)]*http\.ResponseWriter[^)]*\*http\.Request[^)]*\)/ },
+        { label: 'go fiber handler', re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(\s*\w+\s+\*fiber\.Ctx\s*\)/ },
+        { label: 'go gin handler', re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(\s*\w+\s+\*gin\.Context\s*\)/ },
+        { label: 'go echo handler', re: /func\s+(?:\([^)]*\)\s+)?(\w+)\s*\(\s*\w+\s+echo\.Context\s*\)/ },
+        { label: 'go chi/mux route', re: /\b(router|r|mux|app|api)\.(Get|Post|Put|Delete|Patch|Handle|HandleFunc|Method|Route)\s*\(/ },
+      ];
+      const ENTRY_PATTERNS_TS = [
+        { label: 'ts express route', re: /\b(app|router|api)\.(get|post|put|delete|patch|all|use)\s*\(/ },
+        { label: 'ts nest controller', re: /@(Get|Post|Put|Delete|Patch|All|Head|Options)\s*\(/ },
+        { label: 'ts fastify route', re: /\b(fastify|app|server)\.(get|post|put|delete|patch|route)\s*\(/ },
+        { label: 'ts handler arrow', re: /\((?:req|request)\b[^,)]*,\s*(?:res|response)\b[^)]*\)\s*(?::\s*[\w<>[\]]+\s*)?=>/ },
+      ];
+      const entryPats = lang === 'go' ? ENTRY_PATTERNS_GO : ENTRY_PATTERNS_TS;
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const t = line.trim();
+        if (!t || t.startsWith('//') || t.startsWith('*')) continue;
+        for (const { label, re } of entryPats) {
+          if (re.test(line)) {
+            const resilience = lang === 'go'
+              ? goResilience(lines, i, contextLines)
+              : windowResilience(lines, i, contextLines);
+            points.push({
+              category: 'entry_point',
+              matcher: label,
+              direction: 'inbound',
+              language: lang,
+              service: serviceOf(rel),
+              file: rel,
+              line: i + 1,
+              snippet: t.slice(0, 200),
+              resilience,
+              entry_point: true,
+            });
+            break;
+          }
+        }
+      }
+    }
+
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
       const t = line.trim();
@@ -445,7 +541,8 @@ async function main() {
       for (const [category, defs] of Object.entries(patterns)) {
         // queue_consumer only counts in files that also import a broker.
         if (category === 'queue_consumer' && !importsBroker) continue;
-        // outbound_webhook excludes inbound handler files.
+        // outbound_webhook excludes inbound handler files (they're inbound
+        // entry points, surfaced separately with entry_point:true above).
         if (category === 'outbound_webhook' && isHandler) continue;
         for (const { label, re } of defs) {
           if (re.test(line)) {
@@ -453,7 +550,35 @@ async function main() {
             const resilience = lang === 'go'
               ? goResilience(lines, i, contextLines)
               : windowResilience(lines, i, contextLines);
-            points.push({
+            // Merge in wrapper-construction-site resilience so a timeout/retry
+            // configured once in `New*Client(...)` counts for every call site.
+            let wrapperInherited = null;
+            if (category === 'http_outbound') {
+              // Prefer the dynamic per-pkg label; else detect wrapper pkg by
+              // scanning the line for `<pkg>.` since the generic wrapper regex
+              // may have already matched first.
+              const pkgMatch = label.match(/^go http wrapper pkg \((\w+)\)$/);
+              let wrapperPkg = pkgMatch ? pkgMatch[1] : null;
+              if (!wrapperPkg && lang === 'go') {
+                for (const pkg of httpWrapperPkgs) {
+                  if (!pkg || pkg === 'http') continue;
+                  if (new RegExp(`\\b${pkg.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.`).test(line)) {
+                    wrapperPkg = pkg;
+                    break;
+                  }
+                }
+              }
+              if (wrapperPkg && wrapperResilienceByPkg[wrapperPkg]) {
+                wrapperInherited = wrapperResilienceByPkg[wrapperPkg];
+              } else if (lang === 'ts_node' && tsWrapperResilienceByFile[rel]) {
+                wrapperInherited = tsWrapperResilienceByFile[rel];
+              }
+              if (wrapperInherited) {
+                resilience.timeout = resilience.timeout || !!wrapperInherited.timeout;
+                resilience.retry = resilience.retry || !!wrapperInherited.retry;
+              }
+            }
+            const point = {
               category,
               matcher: label,
               direction,
@@ -463,7 +588,9 @@ async function main() {
               line: i + 1,
               snippet: t.slice(0, 200),
               resilience,
-            });
+            };
+            if (wrapperInherited) point.resilience_source = 'wrapper_construction+call_site';
+            points.push(point);
             break; // one hit per line per category is enough
           }
         }

--- a/dev-team/skills/running-dev-cycle/gates/cycle-completion.md
+++ b/dev-team/skills/running-dev-cycle/gates/cycle-completion.md
@@ -178,3 +178,19 @@ state.gate_progress.migration_safety_verification = {
    - **Per-task checklist `done=true` flip:** on the same push-to-develop event, flip EACH completed task's checklist item `done=true` (`task_matches[].done_dispatch`). ⛔ IDEMPOTENCY (MANDATORY): the checklist push MERGES BY `checklist_item_id` — instruct Gandalf to read the card's `checklist` array, set the matching item's `done`, and PATCH; it MUST NEVER replace the whole array (that would drop sibling items). A retried push re-asserts the same item id safely. Skipped tasks (`tasks[j].status == "blocked"`) stay `done=false`. Same terminal trigger as the epic `done` status, NOT Gate 9. Async fire-and-forget.
    - **Deferred reconciliation:** drain the `state.lerian_map_sync.pending` queue (oldest → newest) and do one batched non-blocking verification of outstanding `dispatched` task_ids, flipping any confirmed ones to `synced`; clear `degraded` when nothing is `pending`.
    - **End-of-cycle report:** print outstanding items, e.g. `⚠️ Lerian Map Sync: 2 dispatched (awaiting confirmation), 1 pending (Gandalf was down)`. All Map I/O here is non-blocking — see SKILL.md '## Lerian Map Sync (optional)'.
+
+### Step 12.2: Operational Risk Review (optional, opt-in)
+
+**OPTIONAL and opt-in — never automatic, never blocking.** After the cycle report is printed, offer a review of the flows just built for operational recovery gaps:
+
+```text
+Offer once, after Step 12.1:
+  "This cycle built <N> flow(s). Run ring:reviewing-operational-risk (Mode B) to
+   map stuck-state failure modes and produce runbooks / gap specs? (y/n)"
+
+- y → Skill("ring:reviewing-operational-risk") in plan-context mode (reads this cycle's
+      plan.md + epic artifacts; no full-repo exploration needed).
+- n → done. The cycle is already complete; this offer adds nothing to gate state.
+```
+
+Declining has zero effect on cycle completion — Step 12.1 already finished the cycle. Do NOT gate, block, or re-prompt.


### PR DESCRIPTION
## Summary

Proposta de skill: adiciona `ring:reviewing-operational-risk` ao `dev-team`, uma skill para identificar **riscos operacionais em produção** mapeando pontos de falha em fluxos de integração, classificando cada cenário em tiers e gerando runbooks operacionais ou gap specs.

Skills são auto-descobertas por diretório (`"skills": "./skills/"`), então basta o novo diretório com o `SKILL.md`.

## Propósito

Para cada estado intermediário de cada entidade em um fluxo, simula uma falha de progressão, traça o impacto downstream e classifica o cenário:

- **Tier 1** — a aplicação se resolve sozinha (retry automático, compensação, TTL, DLQ replay) → nota apenas.
- **Tier 2** — existe um trigger externo (API, endpoint, ação no Console/UI) que destrava → **runbook operacional** com passos concretos.
- **Tier 3** — gap: não há resgate sem intervenção direta no banco → **gap spec** (o que falta, quem pode executar hoje, o que precisaria existir).

## Dois modos de entrada

- **Modo A (codebase explore):** varre o repositório por chamadas HTTP externas, consumers de fila (RabbitMQ/SQS/Kafka) e webhooks de saída; para cada ponto de integração registra retry, rollback/compensação, DLQ, timeout e idempotência. **Não sai do repositório** — o foco é no que o serviço espera receber e como reage quando não recebe.
- **Modo B (plan-context):** lê o `plan.md` e os artefatos dos épicos do ciclo atual para extrair entidades e fluxos construídos, sem explorar o repositório inteiro.

## Fluxo

1. Determinar modo (explorer vs plan-context)
2. Mapear fronteiras de integração / extrair fluxo do plan
3. Diálogo de confirmação com o dev (entry point, terminal state, dependências)
4. Simular falha de progressão para cada estado intermediário e traçar impacto downstream
5. Classificar em Tier 1/2/3
6. Output: runbooks (Tier 2) e gap specs (Tier 3) em `docs/ops-risk/`

Público-alvo ao executar: sempre o desenvolvedor (tech lead ou engenheiro).

## Hook opcional

Adiciona um oferecimento **opt-in, não obrigatório e não bloqueante** ao final do `ring:running-dev-cycle` (Step 12.2 em `cycle-completion.md`): pergunta se o dev quer rodar a skill em Modo B sobre os fluxos recém-construídos. Recusar não afeta a conclusão do ciclo.

## Arquivos

- `dev-team/skills/reviewing-operational-risk/SKILL.md` (novo)
- `dev-team/skills/running-dev-cycle/gates/cycle-completion.md` (hook opt-in, Step 12.2)

## Notas

- Nome escolhido segue a convenção verbo-gerúndio do Ring (`auditing-`, `mapping-`, `reviewing-`), preferido sobre `ops-risk-review`.
- Contagem de skills nas descrições dos `plugin.json`/README (\"35 development skills\") não foi alterada para manter o PR focado; pode ser ajustada por quem gerencia releases/versão.

_Contexto de origem: proposta de skill._
