### PR TITLE
feat(helm): Enhance Helm chart standards and deployment processes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "ring-dev-team",
-      "description": "24 specialized developer agents + 35 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
+      "description": "25 specialized developer agents + 37 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
       "version": "2.0.0",
       "source": {
         "source": "git-subdir",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,11 +87,11 @@ When adding/removing a code review agent in `ring:reviewing-code` pool:
 | Plugin           | Path           | Skills | Agents |
 | ---------------- | -------------- | ------ | ------ |
 | ring-default     | `default/`     | 23     | 2      |
-| ring-dev-team    | `dev-team/`    | 35     | 24     |
+| ring-dev-team    | `dev-team/`    | 37     | 25     |
 | ring-pm-team     | `pm-team/`     | 14     | 4      |
 | ring-tw-team     | `tw-team/`     | 4      | 3      |
 
-**Total: 76 skills, 33 agents across 4 plugins.** Plugin versions in `.claude-plugin/marketplace.json`.
+**Total: 78 skills, 34 agents across 4 plugins.** Plugin versions in `.claude-plugin/marketplace.json`.
 
 Each plugin contains: `skills/`, `agents/`, `hooks/`, plus per-harness install manifests `.codex-plugin/`, `.cursor-plugin/`, and `.opencode/` (alongside the marketplace-wide `.claude-plugin/marketplace.json` at repo root). See [README.md](README.md#architecture) for full directory structure.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Proven engineering practices, enforced through skills.**
 
-Ring is a comprehensive skills library and workflow system for AI agents that transforms how AI assistants approach software development. Currently implemented as a **Claude Code plugin marketplace** with **4 active plugins**, **76 skills**, and **33 agents** (see `.claude-plugin/marketplace.json` for current versions), the skills themselves are agent-agnostic and can be used with any AI agent system. Ring provides battle-tested patterns, mandatory workflows, and systematic approaches across the entire software delivery value chain.
+Ring is a comprehensive skills library and workflow system for AI agents that transforms how AI assistants approach software development. Currently implemented as a **Claude Code plugin marketplace** with **4 active plugins**, **78 skills**, and **34 agents** (see `.claude-plugin/marketplace.json` for current versions), the skills themselves are agent-agnostic and can be used with any AI agent system. Ring provides battle-tested patterns, mandatory workflows, and systematic approaches across the entire software delivery value chain.
 
 ## ✨ Why Ring?
 
@@ -21,8 +21,8 @@ Without Ring, AI assistants often:
 Ring solves this by:
 
 - **Enforcing proven workflows** - Test-driven development, systematic debugging, proper planning
-- **Providing 76 specialized skills** (23 core + 35 dev-team + 14 product planning + 4 technical writing)
-- **33 specialized agents** - 2 planning/analysis + 24 developer/reviewer + 4 product research + 3 technical writing
+- **Providing 78 specialized skills** (23 core + 37 dev-team + 14 product planning + 4 technical writing)
+- **34 specialized agents** - 2 planning/analysis + 25 developer/reviewer + 4 product research + 3 technical writing
 - **Automating skill discovery** - Skills load automatically at session start
 - **Preventing common failures** - Built-in anti-patterns and mandatory checklists
 
@@ -290,7 +290,7 @@ REFACTOR → Clean up → Stay green
 
 - `ring:auditing-production-readiness` - 44-dimension production readiness audit; runs explorers in batches of up to 10, appends incrementally to a single report; output: scored report (0-430, max 440 with multi-tenant) with severity ratings. See [default/skills/auditing-production-readiness/SKILL.md](default/skills/auditing-production-readiness/SKILL.md) for invocation and implementation details.
 
-### Developer Skills (ring-dev-team plugin - 35 skills)
+### Developer Skills (ring-dev-team plugin - 37 skills)
 
 **Orchestration & Refactoring (7):**
 
@@ -476,7 +476,7 @@ ring/                                  # Monorepo root
 │   │   ├── review-slicer.md             # Review slicing for large PRs (`ring:review-slicer`)
 │   │   └── codebase-explorer.md         # Deep architecture analysis (`ring:codebase-explorer`)
 │   └── docs/                       # Documentation
-├── dev-team/                      # Developer Agents plugin (ring-dev-team) - 35 skills, 24 agents
+├── dev-team/                      # Developer Agents plugin (ring-dev-team) - 37 skills, 25 agents
 │   └── agents/                      # 24 specialized developer/reviewer agents
 │       ├── backend-go.md       # Go backend specialist (`ring:backend-go`)
 │       ├── backend-ts.md   # TypeScript/Node.js backend specialist (`ring:backend-ts`)

--- a/dev-team/agents/helm-deploy.md
+++ b/dev-team/agents/helm-deploy.md
@@ -1,0 +1,149 @@
+---
+name: ring:helm-deploy
+description: Specialist Helm delivery engineer for Lerian. Takes an existing Lerian Helm chart, validates it locally (helm lint/template and best-effort minikube install), and wires it into a Lerian GitOps environment via helmfile + ArgoCD (helmfile.yaml + values.yaml + app-of-apps Application). Does NOT author chart internals — that is ring:helm.
+---
+
+# Helm Delivery Engineer (Lerian GitOps)
+
+You take a chart that `ring:helm` produced and get it running: first locally, then
+wired into a Lerian GitOps environment. You do NOT write chart templates — if the
+chart is missing or non-compliant, STOP and report "chart not ready — use ring:helm".
+
+## Core Responsibilities
+
+- Local validation ladder: `helm lint`, `helm template` (all variants/overlays)
+- Best-effort minikube install + runtime health verification, then cleanup
+- GitOps wiring: `helmfile.yaml` + per-env `values.yaml` + ArgoCD `Application`
+- Per-environment correctness (ingress, storageClass, domain, TLS, project)
+- Offline-render safety for the ArgoCD helmfile CMP
+
+## HARD GATE: Verify Inputs Before Wiring
+
+**MUST confirm all of these before producing GitOps files:**
+
+1. The chart exists and `helm lint .` passes (else STOP → "use ring:helm").
+2. **Classify: addon (third-party infra) or first-party service (Lerian OCI chart)?**
+   They differ in plugin, release count, project, destination, syncPolicy, secrets.
+3. **Repo + env (+ tier)** named: `lerian-aws-gitops` (AWS envs) vs
+   `lerian-internal-gitops` (on-prem envs + tiers `<env>-st`/`<env>-mt`/`cross`/…).
+   Remember one internal env is **AWS/EKS**, not on-prem — check the sibling.
+4. **Secrets model** known: aws → **ESO** (org ClusterSecretStore); internal service →
+   **Vault via `avp-helmfile`** plugin. Never mix.
+5. A **sibling of the SAME class in the SAME env/tier** exists to copy
+   (`project`, `destination` style, plugin, ingress class). If none → report and ask.
+
+**If any is missing → STOP. Report the blocker. Do NOT guess env conventions.**
+
+## Standards Loading
+
+**Before any implementation:**
+
+1. WebFetch `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/index.md`
+2. Selectively load:
+   - `local-testing.md` — lint/template/minikube ladder (best-effort contract)
+   - `gitops-helmfile.md` — file trio, per-env matrix, offline-render caveats
+   - `aws-rolesanywhere.md` — `iam-cert` release when the service uses RolesAnywhere
+   - `conventions.md` — chart naming/ports (cross-check)
+3. **Check PROJECT_RULES.md** if it exists.
+
+**If you cannot produce a Standards Verification section → you have not loaded standards. STOP.**
+
+## How You Work
+
+### 1. Standards Verification (FIRST SECTION)
+
+```markdown
+## Standards Verification
+| Check | Status | Details |
+|-------|--------|---------|
+| Chart present + lint | Pass | charts/<svc>-helm, 0 failures |
+| Target repo/env | Confirmed | lerian-internal-gitops · <env> |
+| Sibling addon molde | Found | seaweedfs (project cross, server URL, nginx) |
+| Minikube reachable | Yes / No (render-only) | context: minikube |
+```
+
+### 2. Non-Negotiable Requirements
+
+| Requirement | Reason |
+|-------------|--------|
+| Pinned OCI version (`oci://ghcr.io/lerianstudio/<svc>-helm`) | Reproducible offline render |
+| First-party = **3-release template** (secrets → app → ingress via `needs:`) | One release ≠ a Lerian service |
+| Right plugin (`avp-helmfile` for internal services; `helmfile` for addons) | Wrong plugin = no Vault / broken secrets |
+| syncPolicy by class (addon `true/true`; service `false/false`) | Wrong policy = Argo fights ESO/HPA |
+| `ignoreDifferences` Secret `/data` (+ Deployment `/replicas`) on services | Else Argo drifts on Vault/ESO/HPA |
+| No `.Capabilities`/`lookup`; PDB `apiVersions` pin only when chart needs it | Breaks ArgoCD CMP offline render |
+| Env column matched (ingress/storageClass/domain/TLS/secrets) | Wrong infra = broken deploy |
+| `project`/`destination`/plugin copied from same-class sibling | Guessing = ArgoCD sync failure |
+| Minikube install only on minikube context | Never touch a real cluster |
+
+### 3. Pre-Submission Checklist
+
+**Local:**
+- [ ] `helm lint .` 0 failures
+- [ ] `helm template test .` (+ overlays, + `keda.enabled=false` if worker) render clean
+- [ ] minikube: installed & pods Running/Ready **OR** explicitly `SKIPPED (render-only)`
+- [ ] minikube resources cleaned up (uninstall + ns delete)
+
+**GitOps:**
+- [ ] File trio created under `environments/<env>/`
+- [ ] `helmfile template` from the addon dir exits 0
+- [ ] Ingress matches env class (alb vs nginx) + domain zone + TLS style
+- [ ] `values.yaml` storageClass/datacenter match env
+- [ ] Application `project`/`repoURL`/`destination`/`ENV_ENV_NAME` match sibling
+
+### 4. Validate Before Completing
+
+```bash
+cd charts/<svc>-helm && helm lint . && helm template test .
+cd environments/<env>/helmfile/addons/<name> && helmfile template   # exit 0
+```
+
+## Output Format
+
+Produce these sections (Implementation archetype):
+
+<example title="GitOps wiring output">
+## Summary
+Wired reporter-helm (first-party service) into lerian-internal-gitops / <env> · <tier>
+(on-prem: nginx, local-path, Vault). Local: lint+template pass; minikube SKIPPED (no cluster).
+
+## Implementation
+- Local validation ladder run (lint, template, overlays).
+- 3-release trio: reporter-secrets (raw, ghcr pull via Vault) → reporter
+  (oci://ghcr.io/lerianstudio/reporter-helm, pinned, needs secrets) → chart-native
+  nginx ingress, host reporter.<env>.<zone>, tls:[].
+- Application: plugin avp-helmfile, project <tier>, syncPolicy prune:false/selfHeal:false,
+  ignoreDifferences Secret/data + Deployment/replicas. No lookup/Capabilities.
+
+## Files Changed
+| File | Action |
+|------|--------|
+| environments/<env>/helmfile/applications/<tier>/reporter/helmfile.yaml | CREATED |
+| environments/<env>/helmfile/applications/<tier>/reporter/values.yaml | CREATED |
+| environments/<env>/apps/applications/reporter-<tier>.yaml | CREATED |
+
+## Testing
+| Rung | Command | Result |
+|------|---------|--------|
+| lint | helm lint . | ✅ 0 failures |
+| template | helm template test . | ✅ 18 resources |
+| minikube | helm install --wait | ⏭️ SKIPPED (no cluster) |
+| gitops render | helmfile template | ✅ exit 0 |
+
+## Next Steps
+- Confirm DNS reporter.<env>.<zone> → ingress LB.
+- Confirm wildcard *.<env>.<zone> covers the host.
+- Merge to main → app-of-apps discovers it; first-party services sync manually.
+</example>
+
+## Standards Compliance
+Optional by default; MANDATORY when the prompt contains `**MODE: ANALYSIS ONLY**`
+(compare the wiring against `gitops-helmfile.md` in a table).
+
+## Scope
+
+**Handles:** local validation (lint/template/minikube best-effort) and GitOps
+wiring (helmfile + values + ArgoCD Application) for an existing Lerian chart.
+**Does NOT handle:** chart authoring/templates (use `ring:helm`), application code
+(`backend-go`/`backend-ts`), Terraform/cluster provisioning (`devops`), cluster
+operations/monitoring (`sre`). Never installs into a non-minikube cluster.

--- a/dev-team/agents/helm.md
+++ b/dev-team/agents/helm.md
@@ -37,7 +37,13 @@ You are a specialist Helm Chart Engineer by Lerian Studio. You create and mainta
    - `templates.md` — Deployment pattern, health checks
    - `dependencies.md` — subchart versions, bootstrap jobs
    - `worker-patterns.md` — dual-mode KEDA/Deployment
+   - `aws-rolesanywhere.md` — AWS credential-helper sidecar (when the app needs AWS)
+   - `conventions.md` → README Version Matrix (NEW chart: create the matrix)
 3. **Check PROJECT_RULES.md** if it exists
+
+**Canonical source of truth = `LerianStudio/helm/docs/helm-chart-standard.md` + its
+CI Go validator.** These ring modules are the digest; when they disagree, the helm
+repo wins.
 
 **If you cannot produce a Standards Verification section → you have not loaded standards. STOP.**
 
@@ -93,6 +99,8 @@ You are a specialist Helm Chart Engineer by Lerian Studio. You create and mainta
 - [ ] `helm lint .` passes with 0 failures
 - [ ] `helm template test .` renders without errors
 - [ ] Chart.yaml name has `-helm` suffix
+- [ ] NEW chart: root README "Application Version Mapping" matrix created (headers
+      `TitleCase(component) + " Version"`; CI `update-readme-matrix` errors if missing)
 
 **Security:**
 - [ ] `runAsNonRoot: true` on all containers

--- a/dev-team/docs/standards/helm/aws-rolesanywhere.md
+++ b/dev-team/docs/standards/helm/aws-rolesanywhere.md
@@ -1,0 +1,109 @@
+# AWS IAM Roles Anywhere Sidecar (Lerian)
+
+How Lerian workloads get **temporary AWS credentials without static keys or IRSA**:
+an `aws-signing-helper` (credential-helper) **sidecar** exchanges an X.509 client
+cert for AWS creds and serves them on a local metadata endpoint the app reads.
+
+Used today by `fetcher`, `matcher`, `plugin-fees`, `reporter` (manager **and**
+worker, incl. the KEDA ScaledJob). Gated everywhere on
+`.Values.aws.rolesAnywhere.enabled` (default `false`) — zero cost when off.
+
+This pattern has **two halves**: the chart ships the sidecar; the GitOps deploy
+provisions the client cert. Both must be present or the app can't get AWS creds.
+
+## Chart side (ring:helm)
+
+`values.yaml` — `aws.rolesAnywhere` block (from reporter):
+
+```yaml
+aws:
+  rolesAnywhere:
+    enabled: false
+    trustAnchorArn: ""
+    profileArn: ""
+    roleArn: ""
+    region: "us-east-2"          # RolesAnywhere trust anchor region
+    sessionDuration: 3600
+    certificateSecretName: "{svc}-iam-tls"   # cert-manager Secret the sidecar mounts
+    sidecar:
+      image:
+        repository: public.ecr.aws/rolesanywhere/credential-helper
+        tag: "latest-amd64"
+        pullPolicy: IfNotPresent
+      port: 9911
+      resources: { ... }
+```
+
+Deployment template — everything gated on `and .Values.aws .Values.aws.rolesAnywhere .Values.aws.rolesAnywhere.enabled`:
+
+- **Pod** `securityContext.fsGroup: 65532` (so the sidecar can read the mounted cert).
+- **App container env**:
+  ```yaml
+  - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+    value: "http://127.0.0.1:{{ .Values.aws.rolesAnywhere.sidecar.port | default 9911 }}"
+  - name: AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE
+    value: "IPv4"
+  ```
+  (the AWS SDK reads creds from this fake IMDS endpoint served by the sidecar).
+- **Sidecar container** `aws-signing-helper`:
+  ```yaml
+  - name: aws-signing-helper
+    image: "{{ .repository }}:{{ .tag }}"
+    args: [ serve, --certificate, <mounted cert>, --private-key, <mounted key>,
+            --trust-anchor-arn, ..., --profile-arn, ..., --role-arn, ..., --port, 9911 ]
+    # mounts the cert-manager Secret certificateSecretName
+  ```
+- MUST be applied to **every** component that needs AWS (manager + worker + ScaledJob),
+  not just the API.
+
+## GitOps side (ring:helm-deploy)
+
+The client cert is a **cert-manager `Certificate`** created as an extra release
+(`iam-cert`, via `incubator/raw`) that the app release `needs:`. From fetcher:
+
+```yaml
+releases:
+  - name: iam-cert
+    namespace: {ns}
+    chart: incubator/raw
+    values:
+      - resources:
+          - apiVersion: cert-manager.io/v1
+            kind: Certificate
+            metadata: { name: {svc}-iam-cert, namespace: {ns} }
+            spec:
+              secretName: {svc}-iam-tls          # == values.aws.rolesAnywhere.certificateSecretName
+              duration: 2160h                     # 90 days
+              renewBefore: 720h                   # 30 days
+              commonName: "{svc}"
+              issuerRef:
+                name: {env}-iam-roles-anywhere-issuer   # ClusterIssuer whose CA is the AWS Trust Anchor
+                kind: ClusterIssuer
+                group: cert-manager.io
+  - name: {svc}
+    chart: oci://ghcr.io/lerianstudio/{svc}-helm
+    needs: [ {ns}/ghcr-credential, {ns}/iam-cert ]   # cert must exist before the pod
+    values: [ values.yaml ]
+```
+
+- The `ClusterIssuer` `{env}-iam-roles-anywhere-issuer` and the AWS **Trust Anchor**
+  (`arn:aws:rolesanywhere:...:trust-anchor/...`) are provisioned by
+  **lerian-infrastructure** (per-env trust-anchor module) — NOT by this chart/deploy.
+  Reference the issuer; do not create the trust anchor here.
+- `values.yaml` must set `aws.rolesAnywhere.enabled: true` + the ARNs +
+  `certificateSecretName` matching the Certificate `secretName`.
+- Requires **cert-manager** installed in the cluster (it is, as an addon).
+
+## Checklist
+- [ ] Sidecar gated on `aws.rolesAnywhere.enabled`; off by default.
+- [ ] Applied to ALL AWS-needing components (manager + worker + ScaledJob).
+- [ ] Pod `fsGroup: 65532`; app env points to `127.0.0.1:<port>`.
+- [ ] Deploy: `iam-cert` Certificate release; app `needs:` it; `secretName` ==
+      `certificateSecretName`.
+- [ ] `issuerRef` → `{env}-iam-roles-anywhere-issuer` (exists via lerian-infrastructure).
+
+## Anti-patterns
+- Static AWS keys / IRSA when the service standard is RolesAnywhere.
+- Sidecar on the API but not the worker (worker then can't reach AWS).
+- Creating the Trust Anchor in the chart/deploy (it's infra-owned).
+- `certificateSecretName` ≠ Certificate `secretName` (sidecar mounts nothing).

--- a/dev-team/docs/standards/helm/conventions.md
+++ b/dev-team/docs/standards/helm/conventions.md
@@ -1,5 +1,17 @@
 # Helm Conventions (Lerian Standard)
 
+## Chart Location
+
+Charts live in the **`LerianStudio/helm` monorepo**, one directory per chart:
+- Public product → `charts/<svc>-helm/` → `oci://ghcr.io/lerianstudio/<svc>-helm`
+- Closed/internal → `oci://ghcr.io/lerianstudio/helm-internal/<svc>-helm`
+
+Do NOT author the chart in the app repo's `deploy/charts/` — that path is legacy.
+The `home:`/`sources:` fields still point at the app's **source** repo (the code),
+which is correct; the chart **files** live in the `helm` monorepo and are published
+to OCI by that repo's `release.yml` (semantic-release). GitOps then references the
+published OCI version.
+
 ## Chart Naming
 
 ```text
@@ -107,3 +119,42 @@ Lerian port ranges:
   15672: RabbitMQ management
   27017: MongoDB
 ```
+
+---
+
+## README Version Matrix (NEW chart — create it)
+
+The `LerianStudio/helm` root `README.md` carries a per-chart **Application Version
+Mapping** table (Chart Version → each app component's image version). On a **new
+chart** this section MUST be **created by hand** — the CI updater only maintains
+existing tables and **errors** if the chart's table is missing
+(`update-readme-matrix` → "Could not find version matrix table for chart 'X'").
+
+Add a section to the root README:
+
+```markdown
+### {Chart Display Name}
+
+For implementation and configuration details, see the [README](https://charts.lerian.studio/charts/{chart}).
+
+#### Application Version Mapping
+
+| Chart Version | {Component} Version |
+| :---: | :---: |
+| `{chart version}` | {component image tag} |
+-----------------
+```
+
+- One `{Component} Version` column per app component (multi-component = one each,
+  e.g. `Manager Version | Worker Version`).
+- **Header format is load-bearing:** `TitleCase(component) + " Version"` — this is
+  what `update-readme-matrix --component <name>` matches. Wrong header = CI can't
+  update it on future bumps.
+- First row: current chart `version` (backticked) + each component's image `tag`.
+
+<cannot_skip>
+Do NOT hand-bump versions after creation. Chart Version is managed by
+semantic-release (`update-chart-version-readme` in release.yml); component versions
+by `update-readme-matrix` on component bump. The chart-creation job only creates the
+initial table STRUCTURE with correct headers + seed row.
+</cannot_skip>

--- a/dev-team/docs/standards/helm/gitops-helmfile.md
+++ b/dev-team/docs/standards/helm/gitops-helmfile.md
@@ -1,0 +1,184 @@
+# GitOps Deploy via Helmfile (Lerian)
+
+How a chart reaches a cluster at Lerian: **ArgoCD + a helmfile CMP plugin**, per
+environment, in one of two GitOps repos. ArgoCD renders **offline**
+(`helmfile template`) — templates MUST NOT use `.Capabilities` or `lookup`.
+
+First decision, always: is this an **addon** (third-party cluster infra) or a
+**first-party service** (a Lerian OCI chart)? They differ in almost every field.
+
+## The two repos + cluster types
+
+| Repo | Clusters | Ingress | storageClass | Domain / TLS | Secrets model |
+|------|----------|---------|--------------|--------------|---------------|
+| `lerian-aws-gitops` | AWS/EKS envs (control-plane + spokes) | **ALB** (kustomize `ingress/`, groups `public`/`private`) | EBS (aws-ebs-csi default) | private `*.<env>.<zone>` / ACM | **ESO** (External Secrets Operator) |
+| `lerian-internal-gitops` | on-prem/eveo envs — **note: one env is actually AWS/EKS** | on-prem **nginx** / AWS-env **ALB** | on-prem `local-path` / AWS-env EBS | on-prem `*.<env>.<zone>` wildcard, `tls:[]` / AWS-env ACM | **Vault** via `avp-helmfile` |
+
+⚠️ In `lerian-internal-gitops` one env is actually **AWS/EKS**, not on-prem — branch
+on cluster **type**, not on repo. Confirm the target env's type from a sibling addon.
+
+## addons vs first-party services
+
+| | `helmfile/addons/<x>/` | `helmfile/applications/[<tier>/]<svc>/` |
+|---|---|---|
+| Content | third-party infra (consul, ingress-nginx, cert-manager, keda, seaweedfs, ESO, karpenter…) | first-party Lerian product charts |
+| CMP plugin (internal repo) | `helmfile` (no Vault) | **`avp-helmfile`** (ArgoCD Vault Plugin) |
+| Chart source | upstream helm repo / OCI | `oci://ghcr.io/lerianstudio/<svc>-helm` |
+| Namespace | shared infra ns | `<svc>[-<tier>]`, hardcoded in helmfile |
+| ArgoCD project | usually `cross` (internal) / env name (aws) | tier-scoped (`<env>-st`,`<env>-mt`,`sandbox`) / env name (aws) |
+| syncPolicy | `prune:true, selfHeal:true` | **`prune:false, selfHeal:false`** (manual) |
+| ignoreDifferences | none | **Secret `/data` + Deployment `/spec/replicas`** |
+
+## First-party chart sources (OCI, pinned)
+
+- Public products: `oci://ghcr.io/lerianstudio/<chart>-helm`
+- Closed/internal: `oci://ghcr.io/lerianstudio/helm-internal/<chart>-helm`
+- Also seen: Docker Hub mirror `oci://registry-1.docker.io/lerianstudio/<chart>-helm`
+  (e.g. plugin-fees) and an `oci://ghcr.io/lerianstudio/alpha/<chart>` channel.
+- `-helm` suffix, **except** `plugin-access-manager` and `otel-collector-lerian`.
+- Charts are published from the `LerianStudio/helm` monorepo (canonical chart
+  standard: `helm/docs/helm-chart-standard.md` + a Go validator). No `repositories:`
+  entry — the OCI URL is inline in the release.
+
+## The three-release template (first-party)
+
+A service is **never one release**. Ordered by `needs:`:
+
+```yaml
+repositories:
+  - name: incubator            # the universal "extra k8s resource" chart
+    url: https://charts.helm.sh/incubator
+
+releases:
+  # 1) pull secret (+ on internal: iam-cert for the RolesAnywhere sidecar)
+  - name: <svc>-secrets        # or ghcr-credential
+    namespace: <ns>
+    chart: incubator/raw
+    values:
+      - resources:
+          # aws (ESO): ExternalSecret(s) from the org ClusterSecretStore, using the
+          #   documented secret-path convention (per-svc creds + shared infra + ghcr) — copy a sibling
+          # internal (Vault): dockerconfigjson pull Secret via a Vault ref
+          #   <path:secret/data/<env>/ghcr-credential#dockerconfigjson>
+          # optionally sync-wave "-100" so it lands before the chart
+  # 2) the app chart
+  - name: <svc>
+    namespace: <ns>
+    chart: oci://ghcr.io/lerianstudio/<svc>-helm
+    version: "<pinned>"        # ALWAYS pin (GA or -beta.N)
+    needs: [<ns>/<svc>-secrets]
+    wait: true
+    timeout: 600
+    values: [values.yaml]
+  # 3) ingress via raw (aws ALB group / internal nginx)
+  - name: <svc>-ingress
+    namespace: <ns>
+    chart: incubator/raw
+    needs: [<ns>/<svc>]
+    values:
+      - resources:
+          - apiVersion: networking.k8s.io/v1
+            kind: Ingress
+            # aws: alb group.name + group.order + target-type ip + backend-protocol HTTP
+            # internal: ingressClassName nginx + backend-protocol + tls:[] (wildcard)
+```
+
+`values.yaml` sets `namespaceOverride: <ns>`, image from ghcr with
+`imagePullSecrets: [ghcr-credential]`, and (internal) Vault refs
+`<path:secret/data/<env>/<svc>/<tier>#KEY>` resolved by AVP at render.
+
+## Secrets: two models, do not mix
+
+- **aws-gitops → ESO.** An `ExternalSecret` (via raw) pulls from the org's
+  `ClusterSecretStore` using the documented secret-path convention (per-service
+  credentials + shared infra secrets + the ghcr pull secret) — **copy a sibling** for
+  the exact store name and paths. The chart consumes the synced K8s Secret (`existingSecret`).
+- **internal-gitops → Vault + AVP.** The `avp-helmfile` plugin resolves
+  `<path:secret/data/<env>/...#KEY>` placeholders at render. Pull secret comes from
+  `secret/data/<env>/ghcr-credential`. Addons use the plain `helmfile` plugin (no Vault).
+
+Both need `ignoreDifferences` on `Secret /data` (managed out-of-band, drifts by design).
+
+## ArgoCD Application matrix
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <env>-<svc>[-<tier>]      # e.g. <env>-<svc>-<tier>
+  namespace: argocd
+  finalizers: [resources-finalizer.argocd.argoproj.io]   # present on services; inconsistent on addons
+spec:
+  project: <see matrix below>
+  source:
+    repoURL: https://github.com/LerianStudio/<repo>.git
+    targetRevision: main
+    path: environments/<env>/helmfile/applications/[<tier>/]<svc>
+    plugin:
+      name: <helmfile | avp-helmfile>          # avp-helmfile for first-party on internal repo
+      env:
+        - { name: APP_NAMESPACE, value: "<ns>" }
+        - { name: ENV_ENV_NAME, value: "<env>" }   # NOTE: vestigial — not consumed by helmfiles; ns is hardcoded
+  destination:
+    # aws first-party: name: <registered spoke cluster>  |  aws control-plane: name: in-cluster
+    # internal: server: https://kubernetes.default.svc
+    namespace: <ns>
+  syncPolicy:
+    automated: { prune: false, selfHeal: false }   # SERVICES manual; ADDONS true/true
+    syncOptions: [ CreateNamespace=true, ServerSideApply=true ]
+  ignoreDifferences:                                # services only
+    - { group: "", kind: Secret, jsonPointers: [/data] }
+    - { group: apps, kind: Deployment, jsonPointers: [/spec/replicas] }   # if HPA
+```
+
+| Field | aws-gitops | internal-gitops |
+|-------|-----------|-----------------|
+| project | env name | tier-scoped (`<env>-st`, `<env>-mt`, `sandbox`, `cross`) |
+| destination | first-party `name: <spoke cluster>`; control-plane `name: in-cluster` | `server: https://kubernetes.default.svc` |
+| plugin | `helmfile` | addons `helmfile`; services `avp-helmfile` |
+| secrets | ESO | Vault (AVP) |
+
+Add CRD-operator flags (`retry`, `RespectIgnoreDifferences`,
+`SkipDryRunOnMissingResource`) only for operator/CRD-heavy addons (ESO, keda, otel).
+
+## Multi-tier fan-out (internal)
+
+One service can exist as up to 6 near-identical copies per env
+(`cross`, `dev-st`, `stg-st`, `prd-st`, `stg-mt`, `sandbox`) — each its own
+`helmfile/applications/<tier>/<svc>/` dir **and** its own `apps/applications/<svc>-<tier>.yaml`.
+There is **no helmfile `environments:`/gotmpl templating** — it is copy-paste. To add
+a service to a new tier, copy a sibling tier dir + Application and adjust ns/tier/project.
+
+## App-of-apps discovery
+
+Directory-based: `apps/app-of-apps.yaml` points at `apps/applications/`; ArgoCD syncs
+every `*.yaml` there as a child. Drop a file → it deploys. You do NOT sync a child
+directly ("Resource not found in cluster" = parent hasn't synced → hard-refresh + sync
+the parent app-of-apps).
+
+## Offline-render caveats (ArgoCD CMP)
+
+- No `.Capabilities`/`lookup` in templates.
+- Pin `apiVersions: [policy/v1/PodDisruptionBudget]` **only** when the chart selects
+  apiVersion via `.Capabilities` (e.g. consul) — not on every helmfile.
+- `APP_NAMESPACE`/`ENV_ENV_NAME` are convention-only in these repos; namespaces are
+  hardcoded in each helmfile. Do not rely on them to template anything.
+
+## Pre-merge gate
+
+```bash
+cd environments/<env>/helmfile/{addons|applications/<tier>}/<svc>
+helmfile template   # exit 0; inspect kinds
+```
+
+Merging to `main` triggers auto-sync (addons) or leaves services for manual sync.
+Runtime deps render cannot prove: **DNS** → ingress LB, and the **cert/wildcard**
+covering the host. Flag both.
+
+## Anti-patterns
+- Treating a first-party service like an addon (wrong plugin, one release, wrong sync).
+- `.Capabilities`/`lookup`; unpinned OCI version.
+- Mixing secret models (ESO on internal, Vault on aws).
+- Guessing `project`/`destination`/plugin — **copy a sibling in the same env/tier**.
+- Assuming all internal envs are on-prem (one is AWS/EKS).
+- Assuming `ENV_ENV_NAME` templates the namespace (it doesn't).

--- a/dev-team/docs/standards/helm/index.md
+++ b/dev-team/docs/standards/helm/index.md
@@ -7,6 +7,12 @@ This directory contains modular Helm chart standards from Lerian Studio. Load on
 
 > **Reference**: Always consult `docs/PROJECT_RULES.md` for common project standards.
 
+> **⛔ CANONICAL SOURCE OF TRUTH:** the authority for chart structure is the
+> `LerianStudio/helm` repo — `docs/helm-chart-standard.md` + its CI Go validator
+> (`.github/scripts/validate-helm-charts`, run `--strict --render-gate`). These ring
+> modules are the **agent-facing digest** of that contract; when they disagree, the
+> helm repo wins. Do not diverge — align the digest to the canonical doc.
+
 ---
 
 ## Table of Contents
@@ -14,7 +20,7 @@ This directory contains modular Helm chart standards from Lerian Studio. Load on
 | # | Section | Description |
 |---|---------|-------------|
 | 1 | [Quick Reference - Which File for What](#quick-reference---which-file-for-what) | Task-based file selection guide |
-| 2 | [Module Index](#module-index) | All 6 modules with descriptions |
+| 2 | [Module Index](#module-index) | All 9 modules with descriptions |
 | 3 | [WebFetch URLs](#webfetch-urls) | Raw GitHub URLs for agent loading |
 
 ---
@@ -29,6 +35,9 @@ This directory contains modular Helm chart standards from Lerian Studio. Load on
 | **Add dependency** | dependencies.md |
 | **ConfigMap/Secrets review** | values.md |
 | **Security context review** | templates.md |
+| **Test chart locally (lint/template/minikube)** | local-testing.md |
+| **Deploy chart to a GitOps env** | gitops-helmfile.md → local-testing.md |
+| **Chart/service needs AWS creds (no static keys)** | aws-rolesanywhere.md |
 
 ---
 
@@ -42,6 +51,9 @@ This directory contains modular Helm chart standards from Lerian Studio. Load on
 | 4 | [dependencies.md](dependencies.md) | Subchart versions (PostgreSQL, MongoDB, RabbitMQ, Valkey, KEDA), bootstrap jobs |
 | 5 | [worker-patterns.md](worker-patterns.md) | Dual-mode KEDA ScaledJob + Deployment fallback, trigger authentication |
 | 6 | [compliance.md](compliance.md) | Standards Compliance output format for ring:helm |
+| 7 | [local-testing.md](local-testing.md) | Local validation ladder: helm lint/template + best-effort minikube install/verify (used by ring:helm-deploy) |
+| 8 | [gitops-helmfile.md](gitops-helmfile.md) | GitOps wiring via helmfile + ArgoCD app-of-apps; per-env matrix (ALB/nginx, gp2/local-path, domain/TLS); offline-render caveats (used by ring:helm-deploy) |
+| 9 | [aws-rolesanywhere.md](aws-rolesanywhere.md) | AWS IAM Roles Anywhere credential-helper sidecar (chart side) + `iam-cert` cert-manager Certificate (deploy side); used by fetcher/matcher/plugin-fees/reporter |
 
 ---
 
@@ -58,3 +70,6 @@ For agents loading standards via WebFetch:
 | dependencies.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/dependencies.md` |
 | worker-patterns.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/worker-patterns.md` |
 | compliance.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/compliance.md` |
+| local-testing.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/local-testing.md` |
+| gitops-helmfile.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/gitops-helmfile.md` |
+| aws-rolesanywhere.md | `https://raw.githubusercontent.com/LerianStudio/ring/main/dev-team/docs/standards/helm/aws-rolesanywhere.md` |

--- a/dev-team/docs/standards/helm/local-testing.md
+++ b/dev-team/docs/standards/helm/local-testing.md
@@ -1,0 +1,85 @@
+# Helm Local Testing (lint → template → minikube)
+
+Validation ladder for a Lerian chart **before** it is wired into GitOps. Runs
+entirely on the engineer's machine. Minikube install is **best-effort**: attempt
+it when a local cluster is reachable; otherwise stop at render validation and
+report the skip explicitly. Never claim a cluster install that did not run.
+
+---
+
+## Rung 1 — Static render (ALWAYS required)
+
+```bash
+cd charts/<service>-helm
+
+helm lint .                                   # 0 failures required
+helm template test . > /tmp/render.yaml       # must render without errors
+helm template test . --set keda.enabled=false # if a worker exists (both modes)
+```
+
+Gate: `helm lint` = 0 failures AND every `helm template` variant exits 0.
+Inspect `/tmp/render.yaml` for the resources you expect (Deployment/StatefulSet,
+Service, ConfigMap, Secret, probes, HPA/PDB). A resource silently missing =
+values mis-wired.
+
+## Rung 2 — Dependency + values sanity
+
+```bash
+helm dependency build .          # resolves Chart.yaml deps into charts/
+helm template test . -f values.yaml -f values-<env>.yaml   # each env overlay
+```
+
+Gate: every env overlay renders clean. Diff the rendered env vars against the
+app's `.env.example` — `env_vars_missing` MUST be 0 (missing = CrashLoopBackOff).
+
+## Rung 3 — Minikube install (BEST-EFFORT)
+
+```bash
+# Detect a usable local cluster first; skip gracefully if absent.
+minikube status >/dev/null 2>&1 || { echo "SKIP: no minikube — render-only"; exit 0; }
+kubectl config current-context   # confirm it is minikube, NOT a real cluster
+
+NS=<service>-test
+helm install <service> . -n "$NS" --create-namespace \
+  --set <secrets/creds as needed> --wait --timeout 300s
+```
+
+Then verify actual runtime health (this is what render cannot prove):
+
+```bash
+kubectl get pods -n "$NS"                       # all Running/Ready
+kubectl rollout status deploy/<service> -n "$NS" --timeout=120s
+kubectl describe pod -n "$NS" -l app.kubernetes.io/name=<service> | grep -A3 -iE "liveness|readiness"
+kubectl logs -n "$NS" -l app.kubernetes.io/name=<service> --tail=50   # no panics/CrashLoop
+```
+
+Cleanup after verifying:
+
+```bash
+helm uninstall <service> -n "$NS" && kubectl delete ns "$NS"
+```
+
+### Best-effort contract
+- No minikube / not reachable → **report `minikube: SKIPPED (render-only)`**, do
+  not fail the task.
+- Context is a **real cluster** (not minikube) → **STOP**, never install.
+- Install ran → report pod status, probe results, and that cleanup happened.
+
+## Output — Local Testing block
+
+```markdown
+## Testing
+| Rung | Command | Result |
+|------|---------|--------|
+| lint | helm lint . | ✅ 0 failures |
+| template | helm template test . | ✅ 18 resources |
+| template (keda off) | --set keda.enabled=false | ✅ 16 resources |
+| env overlays | -f values-<env>.yaml | ✅ all render |
+| minikube | helm install --wait | ✅ Running/Ready · ⏭️ SKIPPED (no cluster) |
+```
+
+## Anti-patterns
+- Reporting "installed OK" without pod/probe evidence.
+- Installing into a non-minikube context.
+- Skipping the `--set keda.enabled=false` render when a worker exists.
+- Treating a render pass as proof the app boots — only Rung 3 proves that.

--- a/dev-team/skills/creating-helm-charts/SKILL.md
+++ b/dev-team/skills/creating-helm-charts/SKILL.md
@@ -96,6 +96,12 @@ Task:
 
     8. Service type: ALWAYS ClusterIP (never NodePort or LoadBalancer)
 
+    9. NEW chart only — create the README "Application Version Mapping" matrix in the
+       helm repo root README.md (see conventions.md → README Version Matrix). Table
+       headers: `Chart Version` + one `TitleCase(component) + " Version"` per component;
+       seed row = chart version (backticked) + each component image tag. The CI updater
+       ERRORS if this table is missing. Do NOT hand-bump afterward — CI owns versions.
+
     ## Required Output
     - Env Var Coverage table (100% of .env.example covered)
     - helm lint result: MUST PASS
@@ -138,4 +144,5 @@ Additional dispatch for worker component:
 | Service type = ClusterIP | ✅/❌ | service.yaml:{line} |
 | Health probes match endpoints | ✅/❌ | deployment.yaml:{line} |
 | No real secrets in values | ✅/❌ | |
+| README version matrix (NEW chart) | ✅/❌/N/A | root README.md section + table, correct headers |
 ```

--- a/dev-team/skills/deploying-helm-charts/SKILL.md
+++ b/dev-team/skills/deploying-helm-charts/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: ring:deploying-helm-charts
+description: "Deploying an existing Lerian Helm chart via ring:helm-deploy: local validation (helm lint/template + best-effort minikube install with health verification) and GitOps wiring into a Lerian environment (helmfile.yaml + per-env values.yaml + ArgoCD app-of-apps Application), env-correct (ALB vs nginx, gp2 vs local-path, domain/TLS) and offline-render safe. Use after a chart exists (ring:creating-helm-charts) to test it locally and/or ship it to a GitOps env. Skip for authoring chart templates (use ring:creating-helm-charts) or non-Helm deploys."
+---
+
+# Helm Chart Deployment (local test + GitOps wiring)
+
+## When to use
+- Validating an existing Lerian chart locally (lint/template/minikube)
+- Wiring a chart into a GitOps env (`lerian-aws-gitops` or `lerian-internal-gitops`)
+- Adding a new addon/application to an environment via helmfile + ArgoCD
+
+## Skip when
+- Authoring chart templates/values → use `ring:creating-helm-charts` (agent `ring:helm`)
+- Non-Helm deployment (raw manifests / docker-compose)
+
+## Sequence
+Standalone/on-demand. Runs **after** a chart exists. Complements `ring:creating-helm-charts`.
+
+## Related
+**Complementary:** ring:creating-helm-charts (authoring), ring:committing-changes (commit)
+
+**Standards reference:** `dev-team/docs/standards/helm/local-testing.md`, `gitops-helmfile.md`
+**Executor agent:** `ring:helm-deploy`
+
+You orchestrate. `ring:helm-deploy` validates locally and writes the GitOps files.
+
+## Step 1: Validate Input
+
+Required: `chart_path` (existing `-helm` chart), `mode` (`local` | `gitops` | `both`),
+`app_class` (`addon` | `service`).
+For `gitops`/`both`: `repo` (`lerian-aws-gitops` | `lerian-internal-gitops`), `env`
+(the target env name), `namespace`. For first-party services also:
+`tier` (`stg-mt`/`dev-st`/`prd-st`/`cross`/`sandbox` on internal), `secrets_model`
+(aws→`eso`, internal service→`vault`).
+Optional: `minikube` (best-effort default true), `dependencies-toggles`.
+
+## Step 2: Confirm Env Conventions (gitops modes)
+
+Identify a **sibling of the same `app_class` in the same env/tier** to copy from:
+- `project` (env-name on aws / tier-scoped `<env>-st`/`-mt`/`cross` on internal)
+- `destination` (`name: <spoke cluster>` / `name: in-cluster` / `server:`)
+- `plugin` (`avp-helmfile` for internal services, else `helmfile`)
+- ingress class (nginx internal / alb aws), domain zone, storageClass, secrets model
+
+If no same-class sibling exists → the agent reports and asks; do NOT guess.
+Note: one internal env is AWS/EKS, not on-prem.
+
+## Step 3: Dispatch Agent
+
+```yaml
+Task:
+  subagent_type: "ring:helm-deploy"
+  description: "Deploy {chart} → {repo}/{env}"
+  prompt: |
+    ## Helm Deployment
+
+    chart_path: {chart_path}
+    mode: {mode}            # local | gitops | both
+    repo: {repo}
+    env: {env}
+    namespace: {namespace}
+    minikube: {best-effort}
+
+    Standards: load dev-team/docs/standards/helm/{index,local-testing,gitops-helmfile}.md
+
+    ## Required Steps
+    1. HARD GATE: chart exists + `helm lint .` passes (else STOP → ring:helm).
+    2. Local ladder: helm lint; helm template (+ overlays, + keda.enabled=false if worker).
+    3. Minikube (best-effort): if `minikube status` OK AND context is minikube →
+       helm install --wait, verify pods Running/Ready + probes, then uninstall + delete ns.
+       Else report `minikube: SKIPPED (render-only)`.
+    4. GitOps wiring (if mode includes gitops):
+       ADDON → file trio under environments/{env}/helmfile/addons/{name}/ +
+         apps/applications/{name}.yaml (plugin helmfile; syncPolicy prune/selfHeal true).
+       SERVICE → environments/{env}/helmfile/applications/[{tier}/]{name}/ with the
+         **3-release template** (secrets→app→ingress via `needs:`): app chart from
+         oci://ghcr.io/lerianstudio/{name}-helm (pinned); secrets via ESO (aws) or
+         Vault refs (internal); ingress via incubator/raw; values.yaml with
+         namespaceOverride + imagePullSecrets ghcr-credential. Application:
+         plugin `avp-helmfile` (internal service) else `helmfile`; project/destination
+         copied from same-class sibling; syncPolicy prune:false/selfHeal:false;
+         ignoreDifferences Secret/data (+ Deployment/replicas if HPA).
+       Both: env column (ingress/storageClass/domain/TLS); NO .Capabilities/lookup;
+       PDB apiVersions pin only if the chart needs it.
+    5. Pre-merge gate: `helmfile template` from the addon/service dir exits 0.
+
+## Step 4: Verify Output
+
+- Local: lint 0 failures; every template variant renders; minikube result reported
+  (installed+verified OR explicitly SKIPPED).
+- GitOps: file trio present; `helmfile template` exits 0; ingress/storageClass/domain
+  match the env; Application `project`/`destination`/`ENV_ENV_NAME` match the sibling.
+- Report the two runtime deps to confirm out-of-band: DNS record + host cert/wildcard.
+
+## Step 5: Commit
+
+Use `ring:committing-changes` (MUST NOT commit manually). Do NOT sync ArgoCD from
+here — merging to `main` triggers the app-of-apps auto-sync.

--- a/dev-team/skills/shipping-helm-chart/SKILL.md
+++ b/dev-team/skills/shipping-helm-chart/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: ring:shipping-helm-chart
+description: "End-to-end Helm delivery for a Lerian service: create the chart from the app project (ring:creating-helm-charts), validate it (helm lint/template + best-effort minikube), gate on publish (merge to LerianStudio/helm → CI publishes the OCI chart to ghcr), then wire it into a GitOps env (ring:deploying-helm-charts). Use to take a new/updated Lerian chart from app source all the way to a running cluster. Skip for chart-authoring only (use ring:creating-helm-charts) or deploying an already-published chart (use ring:deploying-helm-charts)."
+---
+
+# Ship a Helm Chart (app source → GitOps)
+
+The full Lerian Helm lifecycle, in order. This skill **orchestrates two existing
+skills** and makes the **publish gate** and **ordering** explicit — it does not
+re-implement their logic.
+
+## When to use
+- Taking a Lerian service from app repo to a deployed chart, first time or a rev
+- You need the whole path (create → validate → publish → gitops), not one slice
+
+## Skip when
+- Only authoring/fixing chart templates → `ring:creating-helm-charts`
+- Only deploying a chart that is **already published** to OCI → `ring:deploying-helm-charts`
+
+## Related
+**Delegates to:** `ring:creating-helm-charts` (author), `ring:deploying-helm-charts` (wire)
+**Standards:** `dev-team/docs/standards/helm/` (index → load per phase)
+**Commit:** `ring:committing-changes`
+
+## Chart location (decide first)
+Charts live in the **`LerianStudio/helm` monorepo**, one per dir:
+- Public product → `charts/<svc>-helm/` → `oci://ghcr.io/lerianstudio/<svc>-helm`
+- Closed/internal → published to `oci://ghcr.io/lerianstudio/helm-internal/<svc>-helm`
+NOT in the app repo's `deploy/charts/`. (See conventions.md → Chart Location.)
+
+## The flow (ordered — the gate is real)
+
+### Phase 1 — Create (in the helm monorepo)
+Invoke **`ring:creating-helm-charts`**. It reads the app's `.env.example`/config,
+scaffolds `charts/<svc>-helm/`, wires dependencies, security, probes, and — for a
+NEW chart — the README **Application Version Mapping** matrix. If the service needs
+AWS creds, apply the RolesAnywhere sidecar (`aws-rolesanywhere.md`).
+
+### Phase 2 — Validate (local)
+Invoke **`ring:deploying-helm-charts`** in `mode: local`: `helm lint`, `helm template`
+(+ overlays, + `keda.enabled=false` if worker), and best-effort minikube install.
+Gate: lint 0 failures, all templates render, minikube installed-and-healthy OR
+explicitly `SKIPPED (render-only)`.
+
+### Phase 3 — PUBLISH GATE (CI-owned — do not skip)
+Commit + merge the chart to `LerianStudio/helm` (`ring:committing-changes`, `feat:`
+so semantic-release bumps it). On merge, **`release.yml` publishes the OCI chart**
+to `ghcr.io/lerianstudio[/helm-internal]/<svc>-helm` and updates the README matrix
+version. **The chart version is CI-owned — never hand-pin it.**
+
+⛔ GitOps wiring (Phase 4) **cannot render** until the OCI version exists: a brand-new
+chart's `helmfile template` fails to pull until Phase 3 completes. Wait for the
+published version (e.g. `oras` / `helm show chart oci://.../<svc>-helm --version X`).
+
+### Phase 4 — Wire GitOps (deploy)
+Invoke **`ring:deploying-helm-charts`** in `mode: gitops` with `app_class: service`,
+the target `repo`/`env`/`tier`/`namespace`, `secrets_model` (aws→`eso`,
+internal→`vault`), pinned to the **published** OCI version. It emits the file trio
+(secrets[+iam-cert] → app → ingress), the ArgoCD Application, and gates on
+`helmfile template`. Merge → app-of-apps picks it up (services sync manually).
+
+## Verify (end to end)
+- Phase 1: env coverage 100%, chart lint clean, matrix present (new chart).
+- Phase 3: published OCI version resolvable.
+- Phase 4: `helmfile template` exit 0 against the published version; Application
+  project/destination/plugin/syncPolicy match a same-class sibling.
+- Runtime deps to confirm out-of-band: DNS → ingress LB, host cert/wildcard.
+
+## Anti-patterns
+- Wiring GitOps before the chart is published (Phase 4 before Phase 3) → render fails.
+- Hand-pinning the chart version (CI owns it).
+- Authoring the chart in the app repo instead of the `helm` monorepo.
+- Running it as one monolithic step — each phase is a checkpoint; stop on failure.


### PR DESCRIPTION
- Added new documentation for AWS IAM Roles Anywhere sidecar pattern.
- Updated conventions for chart location and README version matrix creation.
- Introduced local testing guidelines for Helm charts, including linting and minikube installation.
- Created GitOps deployment documentation via Helmfile for Lerian environments.
- Established a comprehensive skill for deploying Helm charts, including validation and GitOps wiring.
- Added a skill for shipping Helm charts, detailing the end-to-end process from creation to deployment.
- Updated existing skills to include new requirements for README version matrix and local testing.