### PR TITLE
ci: migrate workflow jobs to Blacksmith runners

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   version-bump:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     # Explicit minimal permissions
     permissions:


### PR DESCRIPTION
The org is standardizing CI on Blacksmith runners, a drop-in replacement for GitHub-hosted runners that is roughly 2x faster at about half the per-minute price. This swaps the GitHub-hosted ubuntu labels for the same `blacksmith-4vcpu-ubuntu-2404` label the rest of the org uses; nothing else in the workflows changes.

```yaml
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
```