### PR TITLE
feat(dev-team): add ring:declaring-plugin-permissions skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,7 +37,7 @@
     {
       "name": "ring-dev-team",
       "description": "24 specialized developer agents + 35 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "source": {
         "source": "git-subdir",
         "url": "https://github.com/lerianstudio/ring.git",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "ring-dev-team",
-      "description": "24 specialized developer agents + 35 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
+      "description": "24 specialized developer agents + 36 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists consolidated into the dev-team plugin. Complete development team coverage with TDD, observability, and security best practices.",
       "version": "2.1.0",
       "source": {
         "source": "git-subdir",

--- a/dev-team/.codex-plugin/plugin.json
+++ b/dev-team/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ring-dev-team",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "24 specialized developer agents + 35 development skills: Backend 10-gate dev cycle + lean frontend cycle (Gate 0, 7, 8) with quality checks (accessibility, visual, E2E, performance) + Frontend refactoring + whole-codebase simplification sweep + delivery verification + service discovery + cycle management + lib-streaming end-to-end instrumentation. Includes backend/frontend specialists, DevOps, QA, SRE, 9 default code-review reviewers, and 3 conditional stack specialists.",
   "author": {
     "name": "Lerian Studio",

--- a/dev-team/.cursor-plugin/plugin.json
+++ b/dev-team/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ring-dev-team",
   "displayName": "Ring Dev Team",
   "description": "24 specialized developer agents + 35 development skills. Backend (Go/TypeScript) and frontend (React/Next.js) dev cycles, DevOps, QA, SRE, and the parallel code-review pool.",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Lerian Studio",
     "email": "fred@lerian.studio"

--- a/dev-team/skills/declaring-plugin-permissions/SKILL.md
+++ b/dev-team/skills/declaring-plugin-permissions/SKILL.md
@@ -226,11 +226,14 @@ idiom and wire it into the aggregate:
 MANIFEST ?= internal/auth/declaration/permissions.yaml
 
 .PHONY: check-manifest-actions
-# Fail if the manifest uses HTTP-verb actions. 'delete' is allowed (also a valid
-# semantic action). Mirrors the boot-time lib-auth rule.
+# Fail if the manifest is missing/unreadable, or if it uses HTTP-verb actions.
+# 'delete' is allowed (also a valid semantic action). Mirrors the boot-time
+# lib-auth rule. (Pattern assumes block-style `action:` entries — adapt it if
+# your manifest uses flow-style, e.g. `- {resource: x, action: post}`.)
 check-manifest-actions:
+	@test -r "$(MANIFEST)" || { echo "ERROR: manifest not found or unreadable: $(MANIFEST)"; exit 1; }
 	@echo "Checking manifest actions are semantic (not HTTP verbs)..."
-	@if grep -inE '^[[:space:]]*action:[[:space:]]*["'\'']?(post|get|put|patch)["'\'']?[[:space:]]*$$' $(MANIFEST); then \
+	@if grep -inE '^[[:space:]]*action:[[:space:]]*["'\'']?(post|get|put|patch)["'\'']?[[:space:]]*$$' "$(MANIFEST)"; then \
 		echo "ERROR: HTTP-verb action in $(MANIFEST) — use a SEMANTIC action (create/read/update/delete or a domain verb). 'delete' is allowed."; \
 		exit 1; \
 	fi

--- a/dev-team/skills/declaring-plugin-permissions/SKILL.md
+++ b/dev-team/skills/declaring-plugin-permissions/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: ring:declaring-plugin-permissions
+description: >-
+  Interactively authoring an access-manager permission-declaration manifest
+  (permissions.yaml) for the access-manager "inversão de responsabilidade": drives
+  a plugin team through discovering its real Authorize() surface, normalizing every
+  action to the SEMANTIC standard (never HTTP verbs), declaring roles/group grants
+  and the M2M contract, then emits and validates a manifest that matches the
+  lib-auth/v3 auth/declaration schema. Use when a plugin must publish its own
+  permissions at boot (WireFromEnv) instead of the access-manager seed owning them,
+  or when writing/fixing a permissions.yaml. Skip when the plugin has no auth guards,
+  or you only need the wiring (see WireFromEnv) and the manifest already exists.
+allowed-tools:
+  - AskUserQuestion
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Bash
+---
+
+# Declaring Plugin Permissions
+
+Drive a Lerian plugin team through authoring `permissions.yaml` — the client-side,
+SEMANTIC declaration the plugin PUBLISHES at boot under the access-manager
+inversion. This is an **interactive workflow**: follow the steps in order and use
+`AskUserQuestion` to gather every choice. Do not free-hand a manifest.
+
+## Overview
+
+Schema authority: `lib-auth/v3 auth/declaration/manifest.go` (>= `v3.4.0-beta.1`),
+mirrored server-side by `plugin-access-manager identity/pkg/model/declaration.go`.
+The reconciler validates this exact shape at boot and refuses a bad manifest.
+
+**THE CRITICAL INVARIANT:** every `(resource, action)` pair in the manifest MUST
+exactly match a real `AuthClient.Authorize(service, resource, action)` guard in the
+plugin (`lib-auth auth/middleware/middleware.go`). If they diverge, authz silently
+breaks — the guard demands a permission the manifest never declared. Adopting the
+semantic standard therefore means the **route guards AND the manifest move together**.
+
+- CANONICAL model (semantic, complies): `br-sisbajud`
+  (`internal/auth/declaration/permissions.yaml`).
+- ANTI-EXAMPLE (HTTP verbs, do NOT copy): `midaz-fees` — its guards pass
+  `Authorize("plugin-fees","estimates","post")`. Legacy. Never emit verb actions.
+
+## When to use
+- A plugin must publish its own permissions at boot (inversion) — authoring a new
+  `permissions.yaml`.
+- Fixing or migrating a plugin whose guards/manifest use HTTP verbs to the semantic
+  standard.
+
+## Skip when
+- The plugin has no `Authorize(...)` guards / no RBAC surface.
+- Only the wiring is needed and the manifest already exists — point to
+  `authdecl.WireFromEnv` and stop.
+
+## The naming standard (non-negotiable)
+
+The schema doc comment says verbatim: *"The action is SEMANTIC
+(create/read/update/delete), never an HTTP verb."*
+
+| HTTP verb (FORBIDDEN) | Semantic action (REQUIRED) |
+|-----------------------|----------------------------|
+| post   | create |
+| get    | read |
+| put / patch | update |
+| delete (method) | delete / remove |
+
+Domain verbs are first-class and encouraged where CRUD does not fit:
+`rotate`, `trigger`, `justify`, `generate`, `reprocess`, `read_pii`,
+`request_read`, `request_write`, `receive`. Keep them; do not force them into CRUD.
+
+## Manifest schema (author against THIS)
+
+Top-level YAML: `service` (str, REQUIRED), `version` (int, REQUIRED), `permissions`
+(list), `roles` (list), `m2m` (object). All bare-name rules below: **the server
+composes the prefix — never pre-prefix.**
+
+| Field | Rule |
+|-------|------|
+| `service` | REQUIRED, non-empty, no `.`/`..` segment. KEEP any `plugin-` prefix. MUST equal the M2M app slug AND DisplayName (BOLA, enforced at boot). Also the 1st arg of `Authorize`. |
+| `version` | REQUIRED int >= 1. ADVISORY — excluded from content hash; bumping alone is a no-op publish. |
+| `permissions[].resource` | REQUIRED, **BARE** (server composes `{service}/`). |
+| `permissions[].action` | REQUIRED, **SEMANTIC** — never an HTTP verb. |
+| `permissions[].effect` | `allow` or `deny` ONLY. |
+| `permissions[].roles` | >= 1 BARE role name, each MUST be declared in `roles:`. |
+| `roles[].name` | REQUIRED, BARE. `/` allowed as hierarchy separator (`fees/editor`). |
+| `roles[].granted_to` | list of `{ group: <bare-name> }`. **GROUP-ONLY** — there is no `user` grantee. Server composes the `{owner}/` prefix. |
+| `m2m.exposed` | bool — this plugin is callable as an M2M target. |
+| `m2m.needs` | list of target service slugs this plugin CALLS via M2M (e.g. `midaz`). |
+
+Composed names the server builds: permission `{service}/{resource}:{action}`,
+role `{service}/{name}`, group `{owner}/{group}`.
+
+See `template.permissions.yaml` in this folder for a compact, valid, commented example.
+
+---
+
+## Interactive workflow — follow in order
+
+### Step 1 — Determine `service`
+Grep the plugin for its product/slug constant before asking:
+```bash
+grep -rn -iE "ProductName|ApplicationName|ModuleName|feesApplicationName|Slug\s*=" \
+  --include="*.go" <plugin-root> | head
+```
+Propose the found constant as the default. Confirm with `AskUserQuestion`, and
+**warn**: it MUST equal the M2M app DisplayName and be the first arg of every
+`Authorize(...)` call (BOLA). Keep any `plugin-` prefix.
+
+### Step 2 — Discover the REAL authorization surface
+Enumerate what the code actually enforces today:
+```bash
+grep -rn "\.Authorize(" --include="*.go" <plugin-root>
+```
+Extract each `(service, resource, action)` triple from the guard chains (and route
+tables). Present the full list. **This list is ground truth** — the manifest must
+cover exactly these pairs (Step 8 re-checks).
+
+### Step 3 — Normalize actions to the SEMANTIC standard
+For EACH discovered action:
+- If it is an HTTP verb (post/get/put/patch/delete-method) → propose the semantic
+  equivalent from the table AND **flag that the route guard must change too**
+  (guard + manifest move together — this is a code change, not just YAML).
+- If it is already semantic → keep it.
+- If CRUD does not fit → offer the relevant domain verb.
+
+Use `AskUserQuestion` per action/resource to let the engineer confirm or rename,
+offering sensible options (e.g. for `delete`: `delete` vs `remove`). Record the
+final semantic `(resource, action)` set. If any guard currently passes a verb, list
+those guards explicitly as **follow-up code edits the team owns** — do not silently
+emit verb actions to make the mismatch "go away".
+
+### Step 4 — Roles and group grants
+Ask (via `AskUserQuestion`):
+- Which roles exist? Default `viewer` + `editor`; offer domain roles
+  (operator/investigator/compliance-officer/…) as in `br-sisbajud`.
+- Which BARE group(s) grant each role? (Groups are group-only, bare.)
+- Grant mapping — offer this DEFAULT, let them override:
+  **read/query actions → viewer + editor; mutating actions → editor-only.**
+
+Every permission MUST list >= 1 role, and every listed role MUST be declared.
+
+### Step 5 — M2M contract
+Ask:
+- `exposed`: is this plugin an M2M target (callable by other plugins)?
+- `needs`: which services does it CALL via M2M (e.g. `midaz`)? Omit the block if
+  neither applies.
+
+### Step 6 — Emit `permissions.yaml`
+`Write` the manifest to the plugin's declaration dir (mirror `br-sisbajud`:
+`internal/auth/declaration/permissions.yaml`). Bare resources/groups/roles,
+semantic actions, valid effects, >= 1 role per permission. Then show the wiring the
+plugin adds (manifest authoring is the focus; this is the glue):
+
+```go
+//go:embed permissions.yaml
+var Manifest []byte
+
+// ...at startup (authdecl = github.com/LerianStudio/lib-auth/v3/auth/declaration, >= v3.4.0-beta.1):
+stop, err := authdecl.WireFromEnv(ctx, authdecl.WireInput{
+    Slug:     <service>,   // MUST equal manifest.service (BOLA)
+    Manifest: Manifest,
+    Logger:   logger,
+})
+```
+Deployment sets the FIXED, un-prefixed env contract (default OFF, fail-open):
+`DECLARATION_ENABLED`, `PLUGIN_IDENTITY_HOST`, `M2M_CLIENT_ID`, `M2M_CLIENT_SECRET`,
+`PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_HOST`.
+
+### Step 7 — Validate
+Run structural checks against every rule below, and if a Go toolchain + lib-auth
+(>= v3.4.0-beta.1) are available, verify against the REAL validator (parse+Validate,
+zero network) with a tiny throwaway program:
+```go
+// authdecl "github.com/LerianStudio/lib-auth/v3/auth/declaration"
+// _, err := authdecl.New(authdecl.Config{Slug: "<service>", Manifest: raw, /* IdentityAddr, ClientID/Secret dummy */})
+// New parses + Validate()s the manifest eagerly and enforces slug==service (BOLA); a
+// non-manifest error means the manifest itself is structurally valid.
+```
+Or a YAML lint + this checklist. **Validation rules (all aggregated at boot):**
+- `service` non-empty and not `.`/`..`.
+- `version` >= 1.
+- each permission: non-empty `resource` and `action`; `effect` in {allow, deny};
+  >= 1 role; every role reference is a DECLARED role.
+- no duplicate composed permission `{service}/{resource}:{action}`.
+- no duplicate composed role `{service}/{name}`.
+- no Casdoor-safe-name collision: chars `/ ? : # & % = + ;` and whitespace collapse
+  to `-` (lossy), so two different names can collide — and a name that derives to
+  empty is rejected.
+
+### Step 8 — Alignment gate (BLOCKING)
+Re-confirm every declared `(resource, action)` maps to a real `Authorize(...)` call
+(Step 2 list) and vice-versa. Enumerate ANY mismatch as blocking:
+- guard exists, manifest missing → add the permission.
+- manifest declares a pair no guard uses → remove it or add the guard.
+- guard still passes an HTTP verb → the team MUST update the guard to the semantic
+  action so both sides use it (do not "fix" it by declaring the verb).
+
+Do not consider the manifest done while any mismatch remains.
+
+---
+
+## Red Flags — STOP
+- An `action` is `post`/`get`/`put`/`patch`/`delete`-the-method → it is an HTTP verb.
+- A `resource`, `role`, or `group` carries a `{service}/` or `{owner}/` prefix → it
+  will double-prefix; write it BARE.
+- A `granted_to` entry has a `user:` key → there is no user grantee; groups only.
+- A permission lists zero roles, or a role not in `roles:` → validation fails.
+- You are emitting a verb action to sidestep a guard mismatch → fix the guard instead.
+- `service` differs from the M2M app DisplayName / the `Authorize` 1st arg → BOLA break.
+
+All of these mean: **stop and correct before writing/finishing the manifest.**
+
+## Anti-Rationalization
+
+| Rationalization | Why it's WRONG | Required action |
+|-----------------|----------------|-----------------|
+| "The guard passes `post`, so I'll declare `post` to match." | Freezes the legacy anti-pattern; the standard is semantic on BOTH sides. | Rename guard AND manifest to the semantic action together. |
+| "I'll pre-prefix the resource with the service to be safe." | Server composes the prefix; you get `{service}/{service}/…`. | Write resources/roles/groups BARE. |
+| "A user grantee would be convenient here." | The schema has no user grantee. | Use a group; grant the group to the role. |
+| "Version bump publishes the new content." | Version is excluded from the content hash — bump alone is a no-op. | Change the actual permissions/roles content. |
+| "The manifest is valid, so we're done." | Structural validity ≠ alignment with real guards. | Pass Step 8; every pair must map to an `Authorize` call. |

--- a/dev-team/skills/declaring-plugin-permissions/SKILL.md
+++ b/dev-team/skills/declaring-plugin-permissions/SKILL.md
@@ -71,6 +71,11 @@ Domain verbs are first-class and encouraged where CRUD does not fit:
 `rotate`, `trigger`, `justify`, `generate`, `reprocess`, `read_pii`,
 `request_read`, `request_write`, `receive`. Keep them; do not force them into CRUD.
 
+**This is ENFORCED, not just advised.** `post`/`get`/`put`/`patch` are rejected by
+the lib-auth manifest validator at boot AND by the `check-manifest-actions` CI
+guard (Step 9). Only `delete` among HTTP methods is allowed — it is also a valid
+semantic action. Never emit `post`/`get`/`put`/`patch` as an `action`.
+
 ## Manifest schema (author against THIS)
 
 Top-level YAML: `service` (str, REQUIRED), `version` (int, REQUIRED), `permissions`
@@ -182,6 +187,8 @@ zero network) with a tiny throwaway program:
 Or a YAML lint + this checklist. **Validation rules (all aggregated at boot):**
 - `service` non-empty and not `.`/`..`.
 - `version` >= 1.
+- each `action` is SEMANTIC: `post`/`get`/`put`/`patch` are REJECTED at boot
+  (`delete` is allowed — also a valid semantic action).
 - each permission: non-empty `resource` and `action`; `effect` in {allow, deny};
   >= 1 role; every role reference is a DECLARED role.
 - no duplicate composed permission `{service}/{resource}:{action}`.
@@ -199,6 +206,41 @@ Re-confirm every declared `(resource, action)` maps to a real `Authorize(...)` c
   action so both sides use it (do not "fix" it by declaring the verb).
 
 Do not consider the manifest done while any mismatch remains.
+
+### Step 9 — Scaffold the durable CI guard (Makefile)
+The alignment gate above is a one-time check. Lock the semantic standard in so a
+future edit that reintroduces an HTTP verb FAILS the build — two layers:
+
+- **Boot-time (lib-auth):** the manifest validator rejects `post`/`get`/`put`/`patch`
+  actions at boot — a plugin with an HTTP-verb action won't start. `delete` stays
+  valid. Automatic once the plugin is on the lib-auth release carrying the rule;
+  nothing to add.
+- **CI (Makefile):** add an earlier, cheaper guard that fails in CI before boot.
+
+Check the plugin's Makefile for the existing `check-*` convention (most Lerian
+plugins wire `check-tests`, `check-migrations`, … into a `ci:`/`check` aggregate —
+grep `^check-` and `^ci:`). Add a `check-manifest-actions` target matching that
+idiom and wire it into the aggregate:
+
+```makefile
+MANIFEST ?= internal/auth/declaration/permissions.yaml
+
+.PHONY: check-manifest-actions
+# Fail if the manifest uses HTTP-verb actions. 'delete' is allowed (also a valid
+# semantic action). Mirrors the boot-time lib-auth rule.
+check-manifest-actions:
+	@echo "Checking manifest actions are semantic (not HTTP verbs)..."
+	@if grep -inE '^[[:space:]]*action:[[:space:]]*["'\'']?(post|get|put|patch)["'\'']?[[:space:]]*$$' $(MANIFEST); then \
+		echo "ERROR: HTTP-verb action in $(MANIFEST) — use a SEMANTIC action (create/read/update/delete or a domain verb). 'delete' is allowed."; \
+		exit 1; \
+	fi
+	@echo "OK: manifest actions are semantic."
+```
+
+Add `check-manifest-actions` to the `ci:`/`check:` prerequisite list (and `.PHONY`).
+If the plugin has no `check-*`/`ci` idiom, still add the target and call it where
+tests run. Confirm it FAILS on a seeded `action: post` and PASSES on the real
+manifest before finishing.
 
 ---
 

--- a/dev-team/skills/declaring-plugin-permissions/template.permissions.yaml
+++ b/dev-team/skills/declaring-plugin-permissions/template.permissions.yaml
@@ -1,0 +1,74 @@
+# =============================================================================
+# access-manager permission-declaration manifest — CANONICAL TEMPLATE
+# =============================================================================
+# This file is the client-side, SEMANTIC source of truth for a plugin's RBAC.
+# Under the access-manager "inversão de responsabilidade" the plugin embeds this
+# with //go:embed and PUBLISHES it at boot (lib-auth authdecl.WireFromEnv), instead
+# of the permissions living centrally in the access-manager seed / init_data.json.
+#
+# Schema authority: lib-auth/v3 auth/declaration/manifest.go (>= v3.4.0-beta.1),
+# mirrored server-side by plugin-access-manager identity/pkg/model/declaration.go.
+# The reconciler validates this exact shape at boot and rejects a bad manifest.
+#
+# GOLDEN RULES
+#   1. resources are written BARE      -> server composes "{service}/{resource}".
+#   2. groups are written BARE         -> server composes "{owner}/{group}" (e.g. lerian/).
+#   3. role names are written BARE     -> server composes "{service}/{name}".
+#      Do NOT pre-prefix; "{service}/admin" would double-prefix to "{service}/{service}/admin".
+#   4. actions are SEMANTIC verbs      -> create/read/update/delete + domain verbs
+#      (rotate/trigger/justify/generate/reprocess/read_pii). NEVER an HTTP verb
+#      (post/get/patch/put/delete-the-method). This is THE naming standard.
+#   5. every (resource, action) here MUST match a real AuthClient.Authorize(
+#      service, resource, action) guard in the plugin, or authz silently breaks.
+# =============================================================================
+
+# service: REQUIRED. Non-empty, no "."/".." segments. KEEP any "plugin-" prefix.
+# MUST equal the plugin's M2M app slug AND DisplayName (BOLA rule enforced at boot:
+# slug == manifest.service == DisplayName). This is also the first arg passed to
+# AuthClient.Authorize(service, ...).
+service: plugin-example
+
+# version: REQUIRED, integer >= 1. ADVISORY ONLY — excluded from the content hash,
+# so bumping it with identical content is a no-op publish. Bump it for your own
+# change tracking; it does not affect reconciliation.
+version: 1
+
+# permissions: one entry per (resource, action) the plugin enforces.
+permissions:
+  # A read permission granted to BOTH roles (read is broad).
+  - resource: widget          # BARE. Reconciles to "plugin-example/widget".
+    action: read              # SEMANTIC. NOT "get".
+    effect: allow             # allow | deny ONLY.
+    roles:                    # >= 1 role, each MUST be declared in roles: below.
+      - viewer
+      - editor
+  # A mutating permission granted to the editor role ONLY (default: mutate = editor-only).
+  - resource: widget
+    action: create            # SEMANTIC. NOT "post".
+    effect: allow
+    roles:
+      - editor
+  # A domain-specific verb (not CRUD). Semantic verbs are first-class.
+  - resource: widget_key
+    action: rotate            # domain verb; keep it, do not force into CRUD.
+    effect: allow
+    roles:
+      - editor
+
+# roles: every role referenced above MUST appear here.
+roles:
+  # name: REQUIRED, BARE. "/" is allowed as a hierarchy separator (e.g. widget/editor).
+  - name: viewer
+    granted_to:               # GROUP-ONLY grants (there is no "user" grantee).
+      - group: example-viewer # BARE group -> reconciles to "{owner}/example-viewer".
+  - name: editor
+    granted_to:
+      - group: example-editor
+      # A role may bind to several groups (e.g. a cross-cutting admin group):
+      - group: admin-group
+
+# m2m: the plugin's bilateral machine-to-machine contract. Optional block.
+m2m:
+  exposed: true               # true => this plugin is callable AS an M2M target.
+  needs:                      # target service slugs this plugin CALLS via M2M.
+    - midaz                   # omit or leave empty if it calls nothing.


### PR DESCRIPTION
## What

Adds an **interactive** skill, `ring:declaring-plugin-permissions` (plugin `dev-team`), that walks a plugin team through authoring its **permission-declaration manifest** (`permissions.yaml`) under the access-manager *inversão de responsabilidade*.

The platform ships the **mechanism** (lib-auth `WireFromEnv`, the declaration server) + this skill + docs; each product team then authors and integrates its own manifest. This skill is the authoring assist.

## The skill

`dev-team/skills/declaring-plugin-permissions/SKILL.md` — an ordered, `AskUserQuestion`-driven workflow:
1. Determine `service` (grep the product/slug constant; BOLA warning).
2. Discover the plugin's **real** `Authorize()` surface (ground truth).
3. Normalize every action to the **SEMANTIC** standard (`create/read/update/delete` + domain verbs) — **never HTTP verbs**; flags that guard + manifest must move together.
4. Roles + bare group grants (default read→viewer+editor, mutate→editor-only).
5. M2M contract (`exposed` / `needs`).
6. Emit `permissions.yaml` + the `//go:embed` + `WireFromEnv` wiring.
7. Validate against every rule (+ optional real `authdecl.New` check, zero network).
8. **Alignment gate (blocking)**: every declared `(resource, action)` ↔ a real `Authorize` call.

Plus a **Red Flags — STOP** list and an **Anti-Rationalization** table (bulletproofing per `writing-skills`). Schema is authored against `lib-auth/v3@v3.4.0-beta.1 auth/declaration/manifest.go`.

`dev-team/skills/declaring-plugin-permissions/template.permissions.yaml` — a compact, commented, valid canonical example (verified it parses).

## Standard baked in

SEMANTIC actions, never HTTP verbs (the schema doc comment says so verbatim). `br-sisbajud` is the canonical model; `midaz-fees` (HTTP verbs) is called out as the legacy anti-example not to copy.

## Version

Bumps `ring-dev-team` `2.0.0` → `2.1.0` (`marketplace.json` + `dev-team` cursor/codex `plugin.json`). Other plugins untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)