### PR TITLE
docs(declaring-plugin-permissions): namespace RI env contract under IDP_ (#4232)

### DIFF
--- a/dev-team/skills/declaring-plugin-permissions/SKILL.md
+++ b/dev-team/skills/declaring-plugin-permissions/SKILL.md
@@ -172,9 +172,22 @@ stop, err := authdecl.WireFromEnv(ctx, authdecl.WireInput{
     Logger:   logger,
 })
 ```
-Deployment sets the FIXED, un-prefixed env contract (default OFF, fail-open):
-`DECLARATION_ENABLED`, `PLUGIN_IDENTITY_HOST`, `M2M_CLIENT_ID`, `M2M_CLIENT_SECRET`,
-`PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_HOST`.
+Deployment sets the FIXED env contract (default OFF, fail-open). A NEW adopter
+creates these vars with the canonical `IDP_` names from the start. The four
+RI/D7-declaration vars carry the product-wide `IDP_` prefix (identity provider,
+lib-auth #4232 — shared across every plugin, NOT a per-plugin prefix):
+`IDP_DECLARATION_ENABLED`, `IDP_HOST`, `IDP_M2M_CLIENT_ID`, `IDP_M2M_CLIENT_SECRET`,
+plus the token-minter vars `PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_HOST` (out of scope
+for #4232, unchanged).
+
+The `IDP_` names require **lib-auth ≥ the #4232 release** — the next `v3.4.0-beta.x`
+(exact tag TBD, semantic-release-driven: pin it once the beta is tagged). This is a
+LATER threshold than the `>= v3.4.0-beta.1` manifest-schema pin above. For ONE
+release after #4232 the old names (`DECLARATION_ENABLED`, `PLUGIN_IDENTITY_HOST`,
+`M2M_CLIENT_ID`, `M2M_CLIENT_SECRET`) still work as deprecated aliases (canonical
+`IDP_` wins; `WireFromEnv` WARNs when only the alias is set), so a plugin pinned to
+an older lib-auth keeps booting — migrate to the `IDP_` names before the following
+release drops the aliases.
 
 ### Step 7 — Validate
 Run structural checks against every rule below, and if a Go toolchain + lib-auth

--- a/dev-team/skills/declaring-plugin-permissions/SKILL.md
+++ b/dev-team/skills/declaring-plugin-permissions/SKILL.md
@@ -180,9 +180,8 @@ lib-auth #4232 — shared across every plugin, NOT a per-plugin prefix):
 plus the token-minter vars `PLUGIN_AUTH_ENABLED`, `PLUGIN_AUTH_HOST` (out of scope
 for #4232, unchanged).
 
-The `IDP_` names require **lib-auth ≥ the #4232 release** — the next `v3.4.0-beta.x`
-(exact tag TBD, semantic-release-driven: pin it once the beta is tagged). This is a
-LATER threshold than the `>= v3.4.0-beta.1` manifest-schema pin above. For ONE
+The `IDP_` names require **lib-auth ≥ `v3.4.0-beta.6`** (the release that carries #4232).
+This is a LATER threshold than the `>= v3.4.0-beta.1` manifest-schema pin above. For ONE
 release after #4232 the old names (`DECLARATION_ENABLED`, `PLUGIN_IDENTITY_HOST`,
 `M2M_CLIENT_ID`, `M2M_CLIENT_SECRET`) still work as deprecated aliases (canonical
 `IDP_` wins; `WireFromEnv` WARNs when only the alias is set), so a plugin pinned to


### PR DESCRIPTION
## What
Namespace the RI/D7 permission-declaration env contract under the product-wide
`IDP_` prefix in the `declaring-plugin-permissions` skill, per lib-auth #4232 / PR #149.

## Changes
- WireFromEnv env contract (Step 6) now uses the canonical names:
  `IDP_DECLARATION_ENABLED`, `IDP_HOST`, `IDP_M2M_CLIENT_ID`, `IDP_M2M_CLIENT_SECRET`.
- New adopters are told to create the `IDP_` vars from the start.
- Documents the lib-auth version requirement: the `IDP_` contract needs
  **lib-auth ≥ the #4232 release** (next `v3.4.0-beta.x`; exact tag TBD, semantic-release
  driven — pin once tagged). Called out as a later threshold than the existing
  `>= v3.4.0-beta.1` manifest-schema pin.
- Documents the one-release deprecated-alias window (canonical wins; `WireFromEnv`
  WARNs on alias-only use) so plugins on older lib-auth keep booting.
- `PLUGIN_AUTH_ENABLED` / `PLUGIN_AUTH_HOST` are out of scope and unchanged.

## Notes
- Docs-only. The exact `v3.4.0-beta.x` tag should be pinned once the lib-auth beta
  carrying #4232 is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
